### PR TITLE
Update clUpdateMutableCommandsKHR to match new API

### DIFF
--- a/doc/source/cl/extension.rst
+++ b/doc/source/cl/extension.rst
@@ -317,12 +317,12 @@ before the extension can be turned on by default in the oneAPI Construction Kit:
 * Event profiling is not implemented (see CA-3322).
 
 .. _cl_khr_command_buffer:
-  https://www.khronos.org/registry/OpenCL/specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_command_buffer
+  https://www.khronos.org/registry/OpenCL/specs/3.0-unified/html/OpenCL_API.html#cl_khr_command_buffer
 
 Command Buffers: Mutable Dispatch - ``cl_khr_command_buffer_mutable_dispatch``
 ------------------------------------------------------------------------------
 
-oneAPI Construction Kit implements version 0.9.0 of the provisional
+oneAPI Construction Kit implements version 0.9.2 of the provisional
 `cl_khr_command_buffer_mutable_dispatch`_ extension.
 
 `cl_khr_command_buffer_mutable_dispatch`_  builds upon `cl_khr_command_buffer`_
@@ -330,7 +330,7 @@ to allow users to modify kernel execution commands between enqueues of a
 command-buffer.
 
 .. _cl_khr_command_buffer_mutable_dispatch:
-  https://www.khronos.org/registry/OpenCL/specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_command_buffer_mutable_dispatch
+  https://registry.khronos.org/OpenCL/specs/3.0-unified/html/OpenCL_API.html#cl_khr_command_buffer_mutable_dispatch
 
 Extended Async Copies - ``cl_khr_extended_async_copies``
 ---------------------------------------------------------

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -25,8 +25,8 @@ set(CMAKE_CXX_EXTENSIONS ON)
 # them available here rather here rather than in source/cl/external.
 FetchContent_Declare(
   OpenCLHeaders
-  GIT_REPOSITORY https://github.com/KhronosGroup/OpenCL-Headers.git
-  GIT_TAG        v2024.05.08
+  GIT_REPOSITORY git@github.com:EwanC/OpenCL-Headers.git
+  GIT_TAG        array_update
 )
 FetchContent_MakeAvailable(OpenCLHeaders)
 

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -25,8 +25,8 @@ set(CMAKE_CXX_EXTENSIONS ON)
 # them available here rather here rather than in source/cl/external.
 FetchContent_Declare(
   OpenCLHeaders
-  GIT_REPOSITORY git@github.com:EwanC/OpenCL-Headers.git
-  GIT_TAG        array_update
+  GIT_REPOSITORY https://github.com/KhronosGroup/OpenCL-Headers.git
+  GIT_TAG        7258b9e0137474c988142fd35777b59dcdff167e
 )
 FetchContent_MakeAvailable(OpenCLHeaders)
 

--- a/source/cl/examples/MutableDispatchKHR/source/main.cpp
+++ b/source/cl/examples/MutableDispatchKHR/source/main.cpp
@@ -209,9 +209,12 @@ int main(const int argc, const char **argv) {
     // If not executing the first frame
     if (i != 0) {
       // Configure the mutable configuration to update the kernel arguments
-      cl_mutable_dispatch_arg_khr arg_0{0, sizeof(cl_mem), &input_A_buffer};
-      cl_mutable_dispatch_arg_khr arg_1{1, sizeof(cl_mem), &input_B_buffer};
-      cl_mutable_dispatch_arg_khr arg_2{2, sizeof(cl_mem), &output_buffer};
+      const cl_mutable_dispatch_arg_khr arg_0{0, sizeof(cl_mem),
+                                              &input_A_buffer};
+      const cl_mutable_dispatch_arg_khr arg_1{1, sizeof(cl_mem),
+                                              &input_B_buffer};
+      const cl_mutable_dispatch_arg_khr arg_2{2, sizeof(cl_mem),
+                                              &output_buffer};
       cl_mutable_dispatch_arg_khr args[] = {arg_0, arg_1, arg_2};
       cl_mutable_dispatch_config_khr dispatch_config{
           command_handle,
@@ -227,7 +230,7 @@ int main(const int argc, const char **argv) {
           nullptr /* local_work_size */};
 
       // Update the command buffer with the mutable configuration
-      cl_uint num_configs = 1;
+      const cl_uint num_configs = 1;
       cl_command_buffer_update_type_khr config_types[1] = {
           CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
       const void *configs[1] = {&dispatch_config};

--- a/source/cl/examples/MutableDispatchKHR/source/main.cpp
+++ b/source/cl/examples/MutableDispatchKHR/source/main.cpp
@@ -215,8 +215,8 @@ int main(const int argc, const char **argv) {
                                               &input_B_buffer};
       const cl_mutable_dispatch_arg_khr arg_2{2, sizeof(cl_mem),
                                               &output_buffer};
-      cl_mutable_dispatch_arg_khr args[] = {arg_0, arg_1, arg_2};
-      cl_mutable_dispatch_config_khr dispatch_config{
+      const cl_mutable_dispatch_arg_khr args[] = {arg_0, arg_1, arg_2};
+      const cl_mutable_dispatch_config_khr dispatch_config{
           command_handle,
           3 /* num_args */,
           0 /* num_svm_arg */,
@@ -231,7 +231,7 @@ int main(const int argc, const char **argv) {
 
       // Update the command buffer with the mutable configuration
       const cl_uint num_configs = 1;
-      cl_command_buffer_update_type_khr config_types[1] = {
+      const cl_command_buffer_update_type_khr config_types[1] = {
           CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
       const void *configs[1] = {&dispatch_config};
       error = clUpdateMutableCommandsKHR(command_buffer, num_configs,

--- a/source/cl/examples/MutableDispatchKHR/source/main.cpp
+++ b/source/cl/examples/MutableDispatchKHR/source/main.cpp
@@ -209,16 +209,11 @@ int main(const int argc, const char **argv) {
     // If not executing the first frame
     if (i != 0) {
       // Configure the mutable configuration to update the kernel arguments
-      const cl_mutable_dispatch_arg_khr arg_0{0, sizeof(cl_mem),
-                                              &input_A_buffer};
-      const cl_mutable_dispatch_arg_khr arg_1{1, sizeof(cl_mem),
-                                              &input_B_buffer};
-      const cl_mutable_dispatch_arg_khr arg_2{2, sizeof(cl_mem),
-                                              &output_buffer};
-      const cl_mutable_dispatch_arg_khr args[] = {arg_0, arg_1, arg_2};
-      const cl_mutable_dispatch_config_khr dispatch_config{
-          CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
-          nullptr,
+      cl_mutable_dispatch_arg_khr arg_0{0, sizeof(cl_mem), &input_A_buffer};
+      cl_mutable_dispatch_arg_khr arg_1{1, sizeof(cl_mem), &input_B_buffer};
+      cl_mutable_dispatch_arg_khr arg_2{2, sizeof(cl_mem), &output_buffer};
+      cl_mutable_dispatch_arg_khr args[] = {arg_0, arg_1, arg_2};
+      cl_mutable_dispatch_config_khr dispatch_config{
           command_handle,
           3 /* num_args */,
           0 /* num_svm_arg */,
@@ -230,12 +225,14 @@ int main(const int argc, const char **argv) {
           nullptr /* global_work_offset */,
           nullptr /* global_work_size */,
           nullptr /* local_work_size */};
-      const cl_mutable_base_config_khr mutable_config{
-          CL_STRUCTURE_TYPE_MUTABLE_BASE_CONFIG_KHR, nullptr, 1,
-          &dispatch_config};
 
       // Update the command buffer with the mutable configuration
-      error = clUpdateMutableCommandsKHR(command_buffer, &mutable_config);
+      cl_uint num_configs = 1;
+      cl_command_buffer_update_type_khr config_types[1] = {
+          CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
+      const void *configs[1] = {&dispatch_config};
+      error = clUpdateMutableCommandsKHR(command_buffer, num_configs,
+                                         config_types, configs);
       CL_CHECK(error);
     }
 

--- a/source/cl/source/extension/include/extension/khr_command_buffer.h
+++ b/source/cl/source/extension/include/extension/khr_command_buffer.h
@@ -463,7 +463,9 @@ struct _cl_command_buffer_khr final : public cl::base<_cl_command_buffer_khr> {
   /// @param[in] mutable_config New configuration for one or more commands
   ///
   /// @return CL_SUCCESS or appropriate OpenCL error code.
-  cl_int updateCommandBuffer(const cl_mutable_base_config_khr &mutable_config);
+  cl_int updateCommandBuffer(
+      cargo::array_view<const cl_mutable_dispatch_config_khr *>
+          &mutable_configs);
 
   /// @brief Verifies whether a queue is compatible with the command-buffer.
   ///

--- a/source/cl/source/extension/include/extension/khr_command_buffer.h
+++ b/source/cl/source/extension/include/extension/khr_command_buffer.h
@@ -460,12 +460,13 @@ struct _cl_command_buffer_khr final : public cl::base<_cl_command_buffer_khr> {
 
   /// @brief Modify commands in command-buffer
   ///
-  /// @param[in] mutable_config New configuration for one or more commands
+  /// @param[in] mutable_configs List of new configuration for one or more
+  /// commands. It is only valid to pass pointers to
+  /// cl_mutable_dispatch_config_khr structs in this list.
   ///
   /// @return CL_SUCCESS or appropriate OpenCL error code.
   cl_int updateCommandBuffer(
-      cargo::array_view<const cl_mutable_dispatch_config_khr *>
-          &mutable_configs);
+      const cargo::array_view<const void *> &mutable_configs);
 
   /// @brief Verifies whether a queue is compatible with the command-buffer.
   ///

--- a/source/cl/source/extension/source/khr_command_buffer.cpp
+++ b/source/cl/source/extension/source/khr_command_buffer.cpp
@@ -1072,13 +1072,15 @@ cargo::expected<mux_descriptor_info_s, cl_int> createArgumentDescriptor(
 }  // anonymous namespace
 
 [[nodiscard]] cl_int _cl_command_buffer_khr::updateCommandBuffer(
-    cargo::array_view<const cl_mutable_dispatch_config_khr *>
-        &mutable_dispatch_configs) {
+    const cargo::array_view<const void *> &mutable_configs) {
   const std::lock_guard<std::mutex> guard(mutex);
   const cl_device_id device = command_queue->device;
 
   // Verify struct configures kernel arguments and return error if malformed
-  for (const auto &config_ptr : mutable_dispatch_configs) {
+  for (const auto &mutable_config : mutable_configs) {
+    auto config_ptr =
+        static_cast<const cl_mutable_dispatch_config_khr *>(mutable_config);
+
     OCL_CHECK(config_ptr == nullptr, return CL_INVALID_VALUE);
     const cl_mutable_dispatch_config_khr &config = *config_ptr;
     OCL_CHECK(!config.command, return CL_INVALID_MUTABLE_COMMAND_KHR);
@@ -1094,7 +1096,10 @@ cargo::expected<mux_descriptor_info_s, cl_int> createArgumentDescriptor(
         return CL_INVALID_OPERATION);
   }
 
-  for (auto config : mutable_dispatch_configs) {
+  for (const auto &mutable_config : mutable_configs) {
+    auto config =
+        static_cast<const cl_mutable_dispatch_config_khr *>(mutable_config);
+
     unsigned update_index = 0;
     const unsigned num_args = config->num_args + config->num_svm_args;
     UpdateInfo update_info;

--- a/source/cl/source/extension/source/khr_command_buffer.cpp
+++ b/source/cl/source/extension/source/khr_command_buffer.cpp
@@ -1074,13 +1074,13 @@ cargo::expected<mux_descriptor_info_s, cl_int> createArgumentDescriptor(
 [[nodiscard]] cl_int _cl_command_buffer_khr::updateCommandBuffer(
     cargo::array_view<const cl_mutable_dispatch_config_khr *>
         &mutable_dispatch_configs) {
-  std::lock_guard<std::mutex> guard(mutex);
+  const std::lock_guard<std::mutex> guard(mutex);
   const cl_device_id device = command_queue->device;
 
   // Verify struct configures kernel arguments and return error if malformed
   for (const auto config_ptr : mutable_dispatch_configs) {
     OCL_CHECK(config_ptr == nullptr, return CL_INVALID_VALUE);
-    cl_mutable_dispatch_config_khr config = *config_ptr;
+    const cl_mutable_dispatch_config_khr config = *config_ptr;
     OCL_CHECK(!config.command, return CL_INVALID_MUTABLE_COMMAND_KHR);
     OCL_CHECK(config.command->command_buffer != this,
               return CL_INVALID_MUTABLE_COMMAND_KHR);

--- a/source/cl/source/extension/source/khr_command_buffer.cpp
+++ b/source/cl/source/extension/source/khr_command_buffer.cpp
@@ -1078,9 +1078,9 @@ cargo::expected<mux_descriptor_info_s, cl_int> createArgumentDescriptor(
   const cl_device_id device = command_queue->device;
 
   // Verify struct configures kernel arguments and return error if malformed
-  for (const auto config_ptr : mutable_dispatch_configs) {
+  for (const auto &config_ptr : mutable_dispatch_configs) {
     OCL_CHECK(config_ptr == nullptr, return CL_INVALID_VALUE);
-    const cl_mutable_dispatch_config_khr config = *config_ptr;
+    const cl_mutable_dispatch_config_khr &config = *config_ptr;
     OCL_CHECK(!config.command, return CL_INVALID_MUTABLE_COMMAND_KHR);
     OCL_CHECK(config.command->command_buffer != this,
               return CL_INVALID_MUTABLE_COMMAND_KHR);

--- a/source/cl/source/extension/source/khr_command_buffer_mutable_dispatch.cpp
+++ b/source/cl/source/extension/source/khr_command_buffer_mutable_dispatch.cpp
@@ -86,7 +86,7 @@ CL_API_ENTRY cl_int CL_API_CALL clUpdateMutableCommandsKHR(
     cl_command_buffer_khr command_buffer, cl_uint num_configs,
     const cl_command_buffer_update_type_khr *config_types,
     const void **configs) {
-  tracer::TraceGuard<tracer::OpenCL> guard("clUpdateMutableCommandsKHR");
+  const tracer::TraceGuard<tracer::OpenCL> guard("clUpdateMutableCommandsKHR");
   OCL_CHECK(!command_buffer, return CL_INVALID_COMMAND_BUFFER_KHR);
   OCL_CHECK(!command_buffer->is_finalized, return CL_INVALID_OPERATION);
 

--- a/source/cl/source/extension/source/khr_command_buffer_mutable_dispatch.cpp
+++ b/source/cl/source/extension/source/khr_command_buffer_mutable_dispatch.cpp
@@ -27,7 +27,7 @@ extension::khr_command_buffer_mutable_dispatch::
 #else
                 usage_category::DISABLED
 #endif
-                    CA_CL_EXT_VERSION(0, 1, 0)) {
+                    CA_CL_EXT_VERSION(0, 9, 2)) {
 }
 
 void *extension::khr_command_buffer_mutable_dispatch::

--- a/source/cl/source/extension/source/khr_command_buffer_mutable_dispatch.cpp
+++ b/source/cl/source/extension/source/khr_command_buffer_mutable_dispatch.cpp
@@ -115,12 +115,8 @@ CL_API_ENTRY cl_int CL_API_CALL clUpdateMutableCommandsKHR(
     }
   }
 
-  const cl_mutable_dispatch_config_khr **casted_configs =
-      reinterpret_cast<const cl_mutable_dispatch_config_khr **>(configs);
-  cargo::array_view<const cl_mutable_dispatch_config_khr *>
-      mutable_dispatch_configs(casted_configs, num_configs);
-
-  return command_buffer->updateCommandBuffer(mutable_dispatch_configs);
+  const cargo::array_view<const void *> config_array(configs, num_configs);
+  return command_buffer->updateCommandBuffer(config_array);
 }
 
 CL_API_ENTRY cl_int CL_API_CALL clGetMutableCommandInfoKHR(

--- a/source/cl/source/extension/source/khr_command_buffer_mutable_dispatch.cpp
+++ b/source/cl/source/extension/source/khr_command_buffer_mutable_dispatch.cpp
@@ -82,10 +82,11 @@ cl_int extension::khr_command_buffer_mutable_dispatch::GetDeviceInfo(
 }
 
 #ifdef OCL_EXTENSION_cl_khr_command_buffer_mutable_dispatch
-CL_API_ENTRY cl_int CL_API_CALL
-clUpdateMutableCommandsKHR(cl_command_buffer_khr command_buffer,
-                           const cl_mutable_base_config_khr *mutable_config) {
-  const tracer::TraceGuard<tracer::OpenCL> guard("clUpdateMutableCommandsKHR");
+CL_API_ENTRY cl_int CL_API_CALL clUpdateMutableCommandsKHR(
+    cl_command_buffer_khr command_buffer, cl_uint num_configs,
+    const cl_command_buffer_update_type_khr *config_types,
+    const void **configs) {
+  tracer::TraceGuard<tracer::OpenCL> guard("clUpdateMutableCommandsKHR");
   OCL_CHECK(!command_buffer, return CL_INVALID_COMMAND_BUFFER_KHR);
   OCL_CHECK(!command_buffer->is_finalized, return CL_INVALID_OPERATION);
 
@@ -102,20 +103,24 @@ clUpdateMutableCommandsKHR(cl_command_buffer_khr command_buffer,
     return CL_INVALID_OPERATION;
   }
 
-  OCL_CHECK(!mutable_config, return CL_INVALID_VALUE);
-  OCL_CHECK(mutable_config->type != CL_STRUCTURE_TYPE_MUTABLE_BASE_CONFIG_KHR,
-            return CL_INVALID_VALUE);
+  OCL_CHECK(config_types && 0 == num_configs, return CL_INVALID_VALUE);
+  OCL_CHECK(!config_types && num_configs, return CL_INVALID_VALUE);
 
-  // Values for next would be defined by implementation of mutable mem commands
-  // layered extension. Later checks assume next is NULL and so the
-  // mutable_dispatch_list field must be set.
-  OCL_CHECK(mutable_config->next, return CL_INVALID_VALUE);
+  OCL_CHECK(configs && 0 == num_configs, return CL_INVALID_VALUE);
+  OCL_CHECK(!configs && num_configs, return CL_INVALID_VALUE);
 
-  OCL_CHECK(!mutable_config->mutable_dispatch_list ||
-                !mutable_config->num_mutable_dispatch,
-            return CL_INVALID_VALUE);
+  for (size_t i = 0; i < num_configs; i++) {
+    if (config_types[i] != CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR) {
+      return CL_INVALID_VALUE;
+    }
+  }
 
-  return command_buffer->updateCommandBuffer(*mutable_config);
+  const cl_mutable_dispatch_config_khr **casted_configs =
+      reinterpret_cast<const cl_mutable_dispatch_config_khr **>(configs);
+  cargo::array_view<const cl_mutable_dispatch_config_khr *>
+      mutable_dispatch_configs(casted_configs, num_configs);
+
+  return command_buffer->updateCommandBuffer(mutable_dispatch_configs);
 }
 
 CL_API_ENTRY cl_int CL_API_CALL clGetMutableCommandInfoKHR(

--- a/source/cl/test/UnitCL/source/cl_khr_command_buffer_mutable_dispatch/clEnqueueCommandBufferKHRMutability.cpp
+++ b/source/cl/test/UnitCL/source/cl_khr_command_buffer_mutable_dispatch/clEnqueueCommandBufferKHRMutability.cpp
@@ -139,12 +139,12 @@ TEST_F(CommandBufferMutableBufferArgTest, UpdateOutputBufferOnce) {
   EXPECT_EQ(input_data, output_data);
 
   // Now try and enqueue the command buffer updating the output buffer.
-  cl_mutable_dispatch_arg_khr arg{1, sizeof(cl_mem), &updated_dst_buffer};
+  const cl_mutable_dispatch_arg_khr arg{1, sizeof(cl_mem), &updated_dst_buffer};
   cl_mutable_dispatch_config_khr dispatch_config{
       command_handle, 1,       0,       0,       0,      &arg,
       nullptr,        nullptr, nullptr, nullptr, nullptr};
 
-  cl_uint num_configs = 1;
+  const cl_uint num_configs = 1;
   cl_command_buffer_update_type_khr config_types[1] = {
       CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
   const void *configs[1] = {&dispatch_config};
@@ -200,13 +200,13 @@ TEST_F(CommandBufferMutableBufferArgTest, UpdateOutputBufferTwice) {
   EXPECT_EQ(input_data, output_data);
 
   // Now try and enqueue the command buffer updating the output buffer.
-  cl_mutable_dispatch_arg_khr first_arg{1, sizeof(cl_mem),
-                                        &first_updated_dst_buffer};
+  const cl_mutable_dispatch_arg_khr first_arg{1, sizeof(cl_mem),
+                                              &first_updated_dst_buffer};
   cl_mutable_dispatch_config_khr first_dispatch_config{
       command_handle, 1,       0,       0,       0,      &first_arg,
       nullptr,        nullptr, nullptr, nullptr, nullptr};
 
-  cl_uint first_num_configs = 1;
+  const cl_uint first_num_configs = 1;
   cl_command_buffer_update_type_khr first_config_types[1] = {
       CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
   const void *first_configs[1] = {&first_dispatch_config};
@@ -226,12 +226,12 @@ TEST_F(CommandBufferMutableBufferArgTest, UpdateOutputBufferTwice) {
   EXPECT_EQ(input_data, first_updated_output_data);
 
   // Enqueue the command buffer again updating the output buffer a second time.
-  cl_mutable_dispatch_arg_khr second_arg{1, sizeof(cl_mem),
-                                         &second_updated_dst_buffer};
+  const cl_mutable_dispatch_arg_khr second_arg{1, sizeof(cl_mem),
+                                               &second_updated_dst_buffer};
   cl_mutable_dispatch_config_khr second_dispatch_config{
       command_handle, 1,       0,       0,       0,      &second_arg,
       nullptr,        nullptr, nullptr, nullptr, nullptr};
-  cl_uint second_num_configs = 1;
+  const cl_uint second_num_configs = 1;
   cl_command_buffer_update_type_khr second_config_types[1] = {
       CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
   const void *second_configs[1] = {&second_dispatch_config};
@@ -291,11 +291,11 @@ TEST_F(CommandBufferMutableBufferArgTest, UpdateInputBufferOnce) {
   EXPECT_EQ(input_data, output_data);
 
   // Now try and enqueue the command buffer updating the input buffer.
-  cl_mutable_dispatch_arg_khr arg{0, sizeof(cl_mem), &updated_src_buffer};
+  const cl_mutable_dispatch_arg_khr arg{0, sizeof(cl_mem), &updated_src_buffer};
   cl_mutable_dispatch_config_khr dispatch_config{
       command_handle, 1,       0,       0,       0,      &arg,
       nullptr,        nullptr, nullptr, nullptr, nullptr};
-  cl_uint num_configs = 1;
+  const cl_uint num_configs = 1;
   cl_command_buffer_update_type_khr config_types[1] = {
       CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
   const void *configs[1] = {&dispatch_config};
@@ -365,12 +365,12 @@ TEST_F(CommandBufferMutableBufferArgTest, UpdateInputBufferTwice) {
   EXPECT_EQ(input_data, output_data);
 
   // Now try and enqueue the command buffer updating the input buffer.
-  cl_mutable_dispatch_arg_khr first_arg{0, sizeof(cl_mem),
-                                        &first_updated_src_buffer};
+  const cl_mutable_dispatch_arg_khr first_arg{0, sizeof(cl_mem),
+                                              &first_updated_src_buffer};
   cl_mutable_dispatch_config_khr first_dispatch_config{
       command_handle, 1,       0,       0,       0,      &first_arg,
       nullptr,        nullptr, nullptr, nullptr, nullptr};
-  cl_uint first_num_configs = 1;
+  const cl_uint first_num_configs = 1;
   cl_command_buffer_update_type_khr first_config_types[1] = {
       CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
   const void *first_configs[1] = {&first_dispatch_config};
@@ -390,12 +390,12 @@ TEST_F(CommandBufferMutableBufferArgTest, UpdateInputBufferTwice) {
   EXPECT_EQ(first_updated_input_data, output_data);
 
   // Enqueue the command buffer a second time updating the input bufer again.
-  cl_mutable_dispatch_arg_khr second_arg{0, sizeof(cl_mem),
-                                         &second_updated_src_buffer};
+  const cl_mutable_dispatch_arg_khr second_arg{0, sizeof(cl_mem),
+                                               &second_updated_src_buffer};
   cl_mutable_dispatch_config_khr second_dispatch_config{
       command_handle, 1,       0,       0,       0,      &second_arg,
       nullptr,        nullptr, nullptr, nullptr, nullptr};
-  cl_uint second_num_configs = 1;
+  const cl_uint second_num_configs = 1;
   cl_command_buffer_update_type_khr second_config_types[1] = {
       CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
   const void *second_configs[1] = {&second_dispatch_config};
@@ -465,11 +465,11 @@ TEST_F(CommandBufferMutableBufferArgTest,
                                           &updated_src_buffer};
   const cl_mutable_dispatch_arg_khr arg_2{1, sizeof(cl_mem),
                                           &updated_dst_buffer};
-  cl_mutable_dispatch_arg_khr args[] = {arg_1, arg_2};
+  const cl_mutable_dispatch_arg_khr args[] = {arg_1, arg_2};
   cl_mutable_dispatch_config_khr dispatch_config{
       command_handle, 2,       0,       0,       0,      args,
       nullptr,        nullptr, nullptr, nullptr, nullptr};
-  cl_uint num_configs = 1;
+  const cl_uint num_configs = 1;
   cl_command_buffer_update_type_khr config_types[1] = {
       CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
   const void *configs[1] = {&dispatch_config};
@@ -535,15 +535,17 @@ TEST_F(CommandBufferMutableBufferArgTest,
 
   // Now try and enqueue the command buffer updating the input and output
   // buffers.
-  cl_mutable_dispatch_arg_khr arg_1{0, sizeof(cl_mem), &updated_src_buffer};
-  cl_mutable_dispatch_arg_khr arg_2{1, sizeof(cl_mem), &updated_dst_buffer};
+  const cl_mutable_dispatch_arg_khr arg_1{0, sizeof(cl_mem),
+                                          &updated_src_buffer};
+  const cl_mutable_dispatch_arg_khr arg_2{1, sizeof(cl_mem),
+                                          &updated_dst_buffer};
   cl_mutable_dispatch_config_khr dispatch_config_1{
       command_handle, 1,       0,       0,       0,      &arg_1,
       nullptr,        nullptr, nullptr, nullptr, nullptr};
   cl_mutable_dispatch_config_khr dispatch_config_2{
       command_handle, 1,       0,       0,       0,      &arg_2,
       nullptr,        nullptr, nullptr, nullptr, nullptr};
-  cl_uint num_configs = 2;
+  const cl_uint num_configs = 2;
   cl_command_buffer_update_type_khr config_types[2] = {
       CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
       CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
@@ -608,11 +610,11 @@ TEST_F(CommandBufferMutableBufferArgTest, UpdateToBiggerBufferSize) {
   EXPECT_EQ(input_data, output_data);
 
   // Now try and enqueue the command buffer updating the output buffer.
-  cl_mutable_dispatch_arg_khr arg{1, sizeof(cl_mem), &updated_dst_buffer};
+  const cl_mutable_dispatch_arg_khr arg{1, sizeof(cl_mem), &updated_dst_buffer};
   cl_mutable_dispatch_config_khr dispatch_config{
       command_handle, 1,       0,       0,       0,      &arg,
       nullptr,        nullptr, nullptr, nullptr, nullptr};
-  cl_uint num_configs = 1;
+  const cl_uint num_configs = 1;
   cl_command_buffer_update_type_khr config_types[1] = {
       CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
   const void *configs[1] = {&dispatch_config};
@@ -669,11 +671,11 @@ TEST_F(CommandBufferMutableBufferArgTest, CheckUpdatePersists) {
   EXPECT_EQ(input_data, output_data);
 
   // Now try and enqueue the command buffer updating the output buffer.
-  cl_mutable_dispatch_arg_khr arg{1, sizeof(cl_mem), &updated_dst_buffer};
+  const cl_mutable_dispatch_arg_khr arg{1, sizeof(cl_mem), &updated_dst_buffer};
   cl_mutable_dispatch_config_khr dispatch_config{
       command_handle, 1,       0,       0,       0,      &arg,
       nullptr,        nullptr, nullptr, nullptr, nullptr};
-  cl_uint num_configs = 1;
+  const cl_uint num_configs = 1;
   cl_command_buffer_update_type_khr config_types[1] = {
       CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
   const void *configs[1] = {&dispatch_config};
@@ -759,11 +761,11 @@ TEST_F(CommandBufferMutableBufferArgTest, FillThenNDRange) {
   EXPECT_EQ(input_data, output_data);
 
   // Now try and enqueue the command buffer updating the output buffer.
-  cl_mutable_dispatch_arg_khr arg{1, sizeof(cl_mem), &updated_dst_buffer};
+  const cl_mutable_dispatch_arg_khr arg{1, sizeof(cl_mem), &updated_dst_buffer};
   cl_mutable_dispatch_config_khr dispatch_config{
       command_handle, 1,       0,       0,       0,      &arg,
       nullptr,        nullptr, nullptr, nullptr, nullptr};
-  cl_uint num_configs = 1;
+  const cl_uint num_configs = 1;
   cl_command_buffer_update_type_khr config_types[1] = {
       CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
   const void *configs[1] = {&dispatch_config};
@@ -829,11 +831,11 @@ TEST_F(CommandBufferMutableBufferArgTest, NDRangeThenFill) {
   EXPECT_EQ(input_data, output_data);
 
   // Now try and enqueue the command buffer updating the output buffer.
-  cl_mutable_dispatch_arg_khr arg{1, sizeof(cl_mem), &updated_dst_buffer};
+  const cl_mutable_dispatch_arg_khr arg{1, sizeof(cl_mem), &updated_dst_buffer};
   cl_mutable_dispatch_config_khr dispatch_config{
       command_handle, 1,       0,       0,       0,      &arg,
       nullptr,        nullptr, nullptr, nullptr, nullptr};
-  cl_uint num_configs = 1;
+  const cl_uint num_configs = 1;
   cl_command_buffer_update_type_khr config_types[1] = {
       CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
   const void *configs[1] = {&dispatch_config};
@@ -902,11 +904,11 @@ TEST_F(CommandBufferMutableBufferArgTest, FillTwiceThenNDRange) {
   EXPECT_EQ(input_data, output_data);
 
   // Now try and enqueue the command buffer updating the output buffer.
-  cl_mutable_dispatch_arg_khr arg{1, sizeof(cl_mem), &updated_dst_buffer};
+  const cl_mutable_dispatch_arg_khr arg{1, sizeof(cl_mem), &updated_dst_buffer};
   cl_mutable_dispatch_config_khr dispatch_config{
       command_handle, 1,       0,       0,       0,      &arg,
       nullptr,        nullptr, nullptr, nullptr, nullptr};
-  cl_uint num_configs = 1;
+  const cl_uint num_configs = 1;
   cl_command_buffer_update_type_khr config_types[1] = {
       CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
   const void *configs[1] = {&dispatch_config};
@@ -974,11 +976,11 @@ TEST_F(CommandBufferMutableBufferArgTest, CopyBufferThenNDRange) {
   EXPECT_EQ(input_data, output_data);
 
   // Now try and enqueue the command buffer updating the output buffer.
-  cl_mutable_dispatch_arg_khr arg{1, sizeof(cl_mem), &updated_dst_buffer};
+  const cl_mutable_dispatch_arg_khr arg{1, sizeof(cl_mem), &updated_dst_buffer};
   cl_mutable_dispatch_config_khr dispatch_config{
       command_handle, 1,       0,       0,       0,      &arg,
       nullptr,        nullptr, nullptr, nullptr, nullptr};
-  cl_uint num_configs = 1;
+  const cl_uint num_configs = 1;
   cl_command_buffer_update_type_khr config_types[1] = {
       CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
   const void *configs[1] = {&dispatch_config};
@@ -1048,11 +1050,11 @@ TEST_F(CommandBufferMutableBufferArgTest, CopyBufferRectThenNDRange) {
   EXPECT_EQ(input_data, output_data);
 
   // Now try and enqueue the command buffer updating the output buffer.
-  cl_mutable_dispatch_arg_khr arg{1, sizeof(cl_mem), &updated_dst_buffer};
+  const cl_mutable_dispatch_arg_khr arg{1, sizeof(cl_mem), &updated_dst_buffer};
   cl_mutable_dispatch_config_khr dispatch_config{
       command_handle, 1,       0,       0,       0,      &arg,
       nullptr,        nullptr, nullptr, nullptr, nullptr};
-  cl_uint num_configs = 1;
+  const cl_uint num_configs = 1;
   cl_command_buffer_update_type_khr config_types[1] = {
       CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
   const void *configs[1] = {&dispatch_config};
@@ -1129,11 +1131,11 @@ TEST_F(CommandBufferMutableBufferArgTest, RegularNDRangeThenMutableNDRange) {
   EXPECT_EQ(input_data, output_data);
 
   // Now try and enqueue the command buffer updating the output buffer.
-  cl_mutable_dispatch_arg_khr arg{1, sizeof(cl_mem), &updated_dst_buffer};
+  const cl_mutable_dispatch_arg_khr arg{1, sizeof(cl_mem), &updated_dst_buffer};
   cl_mutable_dispatch_config_khr dispatch_config{
       command_handle, 1,       0,       0,       0,      &arg,
       nullptr,        nullptr, nullptr, nullptr, nullptr};
-  cl_uint num_configs = 1;
+  const cl_uint num_configs = 1;
   cl_command_buffer_update_type_khr config_types[1] = {
       CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
   const void *configs[1] = {&dispatch_config};
@@ -1275,11 +1277,11 @@ TEST_F(CommandBufferMultiMutableBufferArgTest, UpdateSingleDispatch) {
 
   // Now try and enqueue the command buffer updating the output buffer of the
   // first nd range.
-  cl_mutable_dispatch_arg_khr arg{0, sizeof(cl_mem), &updated_src_buffer};
+  const cl_mutable_dispatch_arg_khr arg{0, sizeof(cl_mem), &updated_src_buffer};
   cl_mutable_dispatch_config_khr dispatch_config{
       command_handle, 1,       0,       0,       0,      &arg,
       nullptr,        nullptr, nullptr, nullptr, nullptr};
-  cl_uint num_configs = 1;
+  const cl_uint num_configs = 1;
   cl_command_buffer_update_type_khr config_types[1] = {
       CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
   const void *configs[1] = {&dispatch_config};
@@ -1355,14 +1357,14 @@ TEST_F(CommandBufferMultiMutableBufferArgTest, UpdateMultipleDispatches) {
 
   // Now try and enqueue the command buffer updating the input buffer of both
   // nd ranges.
-  cl_mutable_dispatch_arg_khr first_arg{0, sizeof(cl_mem),
-                                        &first_updated_src_buffer};
+  const cl_mutable_dispatch_arg_khr first_arg{0, sizeof(cl_mem),
+                                              &first_updated_src_buffer};
   cl_mutable_dispatch_config_khr first_dispatch_config{
       command_handle, 1,       0,       0,       0,      &first_arg,
       nullptr,        nullptr, nullptr, nullptr, nullptr};
 
-  cl_mutable_dispatch_arg_khr second_arg{0, sizeof(cl_mem),
-                                         &second_updated_src_buffer};
+  const cl_mutable_dispatch_arg_khr second_arg{0, sizeof(cl_mem),
+                                               &second_updated_src_buffer};
   cl_mutable_dispatch_config_khr second_dispatch_config{second_command_handle,
                                                         1,
                                                         0,
@@ -1375,7 +1377,7 @@ TEST_F(CommandBufferMultiMutableBufferArgTest, UpdateMultipleDispatches) {
                                                         nullptr,
                                                         nullptr};
 
-  cl_uint num_configs = 2;
+  const cl_uint num_configs = 2;
   cl_command_buffer_update_type_khr config_types[2] = {
       CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
       CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
@@ -1499,11 +1501,11 @@ TEST_F(MutableDispatchTest, UpdateConstantBuffer) {
   EXPECT_EQ(input_data, output_data);
 
   // Now try and enqueue the command buffer updating the input buffer.
-  cl_mutable_dispatch_arg_khr arg{0, sizeof(cl_mem), &updated_src_buffer};
+  const cl_mutable_dispatch_arg_khr arg{0, sizeof(cl_mem), &updated_src_buffer};
   cl_mutable_dispatch_config_khr dispatch_config{
       command_handle, 1,       0,       0,       0,      &arg,
       nullptr,        nullptr, nullptr, nullptr, nullptr};
-  cl_uint num_configs = 1;
+  const cl_uint num_configs = 1;
   cl_command_buffer_update_type_khr config_types[1] = {
       CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
   const void *configs[1] = {&dispatch_config};
@@ -1606,11 +1608,11 @@ TEST_F(CommandBufferMutableLocalBufferArgTest, UpdateOnce) {
   EXPECT_SUCCESS(clFinish(command_queue));
 
   // Update the local buffer size.
-  cl_mutable_dispatch_arg_khr arg{0, 32, nullptr};
+  const cl_mutable_dispatch_arg_khr arg{0, 32, nullptr};
   cl_mutable_dispatch_config_khr dispatch_config{
       command_handle, 1,       0,       0,       0,      &arg,
       nullptr,        nullptr, nullptr, nullptr, nullptr};
-  cl_uint num_configs = 1;
+  const cl_uint num_configs = 1;
   cl_command_buffer_update_type_khr config_types[1] = {
       CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
   const void *configs[1] = {&dispatch_config};
@@ -1629,11 +1631,11 @@ TEST_F(CommandBufferMutableLocalBufferArgTest, UpdateTwice) {
   EXPECT_SUCCESS(clFinish(command_queue));
 
   // Update the local buffer size.
-  cl_mutable_dispatch_arg_khr arg{0, 32, nullptr};
+  const cl_mutable_dispatch_arg_khr arg{0, 32, nullptr};
   cl_mutable_dispatch_config_khr dispatch_config{
       command_handle, 1,       0,       0,       0,      &arg,
       nullptr,        nullptr, nullptr, nullptr, nullptr};
-  cl_uint num_configs = 1;
+  const cl_uint num_configs = 1;
   cl_command_buffer_update_type_khr config_types[1] = {
       CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
   const void *configs[1] = {&dispatch_config};
@@ -1646,11 +1648,11 @@ TEST_F(CommandBufferMutableLocalBufferArgTest, UpdateTwice) {
   EXPECT_SUCCESS(clFinish(command_queue));
 
   // Update the local buffer size a second time.
-  cl_mutable_dispatch_arg_khr arg_2{0, 32, nullptr};
+  const cl_mutable_dispatch_arg_khr arg_2{0, 32, nullptr};
   cl_mutable_dispatch_config_khr dispatch_config_2{
       command_handle, 1,       0,       0,       0,      &arg_2,
       nullptr,        nullptr, nullptr, nullptr, nullptr};
-  cl_uint num_configs_2 = 1;
+  const cl_uint num_configs_2 = 1;
   cl_command_buffer_update_type_khr config_types_2[1] = {
       CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
   const void *configs_2[1] = {&dispatch_config_2};
@@ -1785,11 +1787,11 @@ TEST_F(DISABLED_CommandBufferMutableNullArgTest,
   EXPECT_EQ(output_data, std::vector<cl_int>(global_size, 0x0));
 
   // Update the input to null and enqueue a second time.
-  cl_mutable_dispatch_arg_khr arg{0, sizeof(cl_mem), nullptr};
+  const cl_mutable_dispatch_arg_khr arg{0, sizeof(cl_mem), nullptr};
   cl_mutable_dispatch_config_khr dispatch_config{
       command_handle, 1,       0,       0,       0,      &arg,
       nullptr,        nullptr, nullptr, nullptr, nullptr};
-  cl_uint num_configs = 1;
+  const cl_uint num_configs = 1;
   cl_command_buffer_update_type_khr config_types[1] = {
       CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
   const void *configs[1] = {&dispatch_config};
@@ -1842,11 +1844,11 @@ TEST_F(DISABLED_CommandBufferMutableNullArgTest,
 
   // Update the input to pointer to null.
   const cl_int *null = nullptr;
-  cl_mutable_dispatch_arg_khr arg{0, sizeof(cl_mem), &null};
+  const cl_mutable_dispatch_arg_khr arg{0, sizeof(cl_mem), &null};
   cl_mutable_dispatch_config_khr dispatch_config{
       command_handle, 1,       0,       0,       0,      &arg,
       nullptr,        nullptr, nullptr, nullptr, nullptr};
-  cl_uint num_configs = 1;
+  const cl_uint num_configs = 1;
   cl_command_buffer_update_type_khr config_types[1] = {
       CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
   const void *configs[1] = {&dispatch_config};
@@ -1897,11 +1899,11 @@ TEST_F(DISABLED_CommandBufferMutableNullArgTest,
   EXPECT_EQ(output_data, std::vector<cl_int>(global_size, 0x1));
 
   // Update the input to null.
-  cl_mutable_dispatch_arg_khr arg{0, sizeof(cl_mem), &src_buffer};
+  const cl_mutable_dispatch_arg_khr arg{0, sizeof(cl_mem), &src_buffer};
   cl_mutable_dispatch_config_khr dispatch_config{
       command_handle, 1,       0,       0,       0,      &arg,
       nullptr,        nullptr, nullptr, nullptr, nullptr};
-  cl_uint num_configs = 1;
+  const cl_uint num_configs = 1;
   cl_command_buffer_update_type_khr config_types[1] = {
       CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
   const void *configs[1] = {&dispatch_config};
@@ -1953,11 +1955,11 @@ TEST_F(DISABLED_CommandBufferMutableNullArgTest,
   EXPECT_EQ(output_data, std::vector<cl_int>(global_size, 0x1));
 
   // Update the input to null.
-  cl_mutable_dispatch_arg_khr arg{0, sizeof(cl_mem), &src_buffer};
+  const cl_mutable_dispatch_arg_khr arg{0, sizeof(cl_mem), &src_buffer};
   cl_mutable_dispatch_config_khr dispatch_config{
       command_handle, 1,       0,       0,       0,      &arg,
       nullptr,        nullptr, nullptr, nullptr, nullptr};
-  cl_uint num_configs = 1;
+  const cl_uint num_configs = 1;
   cl_command_buffer_update_type_khr config_types[1] = {
       CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
   const void *configs[1] = {&dispatch_config};
@@ -2006,11 +2008,11 @@ TEST_F(DISABLED_CommandBufferMutableNullArgTest, CheckUpdatePersists) {
   EXPECT_EQ(output_data, std::vector<cl_int>(global_size, 0x0));
 
   // Update the input to null and enqueue a second time.
-  cl_mutable_dispatch_arg_khr arg{0, sizeof(cl_mem), nullptr};
+  const cl_mutable_dispatch_arg_khr arg{0, sizeof(cl_mem), nullptr};
   cl_mutable_dispatch_config_khr dispatch_config{
       command_handle, 1,       0,       0,       0,      &arg,
       nullptr,        nullptr, nullptr, nullptr, nullptr};
-  cl_uint num_configs = 1;
+  const cl_uint num_configs = 1;
   cl_command_buffer_update_type_khr config_types[1] = {
       CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
   const void *configs[1] = {&dispatch_config};
@@ -2140,11 +2142,11 @@ TEST_F(DISABLED_CommandBufferMultiMutableNullArgTest, UpdateSingleDispatch) {
   EXPECT_EQ(second_output_data, std::vector<cl_int>(global_size, 0x0));
 
   // Update the input of the first nd range to null and enqueue a second time.
-  cl_mutable_dispatch_arg_khr arg{0, sizeof(cl_mem), nullptr};
+  const cl_mutable_dispatch_arg_khr arg{0, sizeof(cl_mem), nullptr};
   cl_mutable_dispatch_config_khr dispatch_config{
       command_handle, 1,       0,       0,       0,      &arg,
       nullptr,        nullptr, nullptr, nullptr, nullptr};
-  cl_uint num_configs = 1;
+  const cl_uint num_configs = 1;
   cl_command_buffer_update_type_khr config_types[1] = {
       CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
   const void *configs[1] = {&dispatch_config};
@@ -2189,12 +2191,12 @@ TEST_F(DISABLED_CommandBufferMultiMutableNullArgTest,
   EXPECT_EQ(second_output_data, std::vector<cl_int>(global_size, 0x0));
 
   // Update the input of both nd ranges to null and enqueue a second time.
-  cl_mutable_dispatch_arg_khr first_arg{0, sizeof(cl_mem), nullptr};
+  const cl_mutable_dispatch_arg_khr first_arg{0, sizeof(cl_mem), nullptr};
   cl_mutable_dispatch_config_khr first_dispatch_config{
       command_handle, 1,       0,       0,       0,      &first_arg,
       nullptr,        nullptr, nullptr, nullptr, nullptr};
 
-  cl_mutable_dispatch_arg_khr second_arg{0, sizeof(cl_mem), nullptr};
+  const cl_mutable_dispatch_arg_khr second_arg{0, sizeof(cl_mem), nullptr};
   cl_mutable_dispatch_config_khr second_dispatch_config{second_command_handle,
                                                         1,
                                                         0,
@@ -2207,7 +2209,7 @@ TEST_F(DISABLED_CommandBufferMultiMutableNullArgTest,
                                                         nullptr,
                                                         nullptr};
 
-  cl_uint num_configs = 2;
+  const cl_uint num_configs = 2;
   cl_command_buffer_update_type_khr config_types[2] = {
       CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
       CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
@@ -2324,11 +2326,12 @@ TEST_F(CommandBufferMutablePODArgTest, InvalidArgSize) {
   // Now try and enqueue the command buffer updating the input value.
   const auto updated_input_value =
       ucl::Environment::instance->GetInputGenerator().GenerateInt<cl_int>();
-  cl_mutable_dispatch_arg_khr arg{0, sizeof(cl_int4), &updated_input_value};
+  const cl_mutable_dispatch_arg_khr arg{0, sizeof(cl_int4),
+                                        &updated_input_value};
   cl_mutable_dispatch_config_khr dispatch_config{
       command_handle, 1,       0,       0,       0,      &arg,
       nullptr,        nullptr, nullptr, nullptr, nullptr};
-  cl_uint num_configs = 1;
+  const cl_uint num_configs = 1;
   cl_command_buffer_update_type_khr config_types[1] = {
       CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
   const void *configs[1] = {&dispatch_config};
@@ -2360,11 +2363,12 @@ TEST_F(CommandBufferMutablePODArgTest, UpdateInputOnce) {
   // Now try and enqueue the command buffer updating the input value.
   const auto updated_input_value =
       ucl::Environment::instance->GetInputGenerator().GenerateInt<cl_int>();
-  cl_mutable_dispatch_arg_khr arg{0, sizeof(cl_int), &updated_input_value};
+  const cl_mutable_dispatch_arg_khr arg{0, sizeof(cl_int),
+                                        &updated_input_value};
   cl_mutable_dispatch_config_khr dispatch_config{
       command_handle, 1,       0,       0,       0,      &arg,
       nullptr,        nullptr, nullptr, nullptr, nullptr};
-  cl_uint num_configs = 1;
+  const cl_uint num_configs = 1;
   cl_command_buffer_update_type_khr config_types[1] = {
       CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
   const void *configs[1] = {&dispatch_config};
@@ -2405,12 +2409,12 @@ TEST_F(CommandBufferMutablePODArgTest, UpdateInputTwice) {
   // Now try and enqueue the command buffer updating the input value.
   const auto first_updated_input_value =
       ucl::Environment::instance->GetInputGenerator().GenerateInt<cl_int>();
-  cl_mutable_dispatch_arg_khr first_arg{0, sizeof(cl_int),
-                                        &first_updated_input_value};
+  const cl_mutable_dispatch_arg_khr first_arg{0, sizeof(cl_int),
+                                              &first_updated_input_value};
   cl_mutable_dispatch_config_khr first_dispatch_config{
       command_handle, 1,       0,       0,       0,      &first_arg,
       nullptr,        nullptr, nullptr, nullptr, nullptr};
-  cl_uint first_num_configs = 1;
+  const cl_uint first_num_configs = 1;
   cl_command_buffer_update_type_khr first_config_types[1] = {
       CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
   const void *first_configs[1] = {&first_dispatch_config};
@@ -2435,12 +2439,12 @@ TEST_F(CommandBufferMutablePODArgTest, UpdateInputTwice) {
   // time.
   const auto second_updated_input_value =
       ucl::Environment::instance->GetInputGenerator().GenerateInt<cl_int>();
-  cl_mutable_dispatch_arg_khr second_arg{0, sizeof(cl_int),
-                                         &second_updated_input_value};
+  const cl_mutable_dispatch_arg_khr second_arg{0, sizeof(cl_int),
+                                               &second_updated_input_value};
   cl_mutable_dispatch_config_khr second_dispatch_config{
       command_handle, 1,       0,       0,       0,      &second_arg,
       nullptr,        nullptr, nullptr, nullptr, nullptr};
-  cl_uint second_num_configs = 1;
+  const cl_uint second_num_configs = 1;
   cl_command_buffer_update_type_khr second_config_types[1] = {
       CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
   const void *second_configs[1] = {&second_dispatch_config};
@@ -2482,11 +2486,12 @@ TEST_F(CommandBufferMutablePODArgTest, CheckUpdatePersists) {
   // Now try and enqueue the command buffer updating the input value.
   const auto updated_input_value =
       ucl::Environment::instance->GetInputGenerator().GenerateInt<cl_int>();
-  cl_mutable_dispatch_arg_khr arg{0, sizeof(cl_int), &updated_input_value};
+  const cl_mutable_dispatch_arg_khr arg{0, sizeof(cl_int),
+                                        &updated_input_value};
   cl_mutable_dispatch_config_khr dispatch_config{
       command_handle, 1,       0,       0,       0,      &arg,
       nullptr,        nullptr, nullptr, nullptr, nullptr};
-  cl_uint num_configs = 1;
+  const cl_uint num_configs = 1;
   cl_command_buffer_update_type_khr config_types[1] = {
       CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
   const void *configs[1] = {&dispatch_config};
@@ -2615,11 +2620,12 @@ TEST_F(CommandBufferMultiMutablePODArgTest, UpdateSingleDispatch) {
   // first nd range only.
   const auto updated_input_value =
       ucl::Environment::instance->GetInputGenerator().GenerateInt<cl_int>();
-  cl_mutable_dispatch_arg_khr arg{0, sizeof(cl_int), &updated_input_value};
+  const cl_mutable_dispatch_arg_khr arg{0, sizeof(cl_int),
+                                        &updated_input_value};
   cl_mutable_dispatch_config_khr dispatch_config{
       command_handle, 1,       0,       0,       0,      &arg,
       nullptr,        nullptr, nullptr, nullptr, nullptr};
-  cl_uint num_configs = 1;
+  const cl_uint num_configs = 1;
   cl_command_buffer_update_type_khr config_types[1] = {
       CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
   const void *configs[1] = {&dispatch_config};
@@ -2677,16 +2683,16 @@ TEST_F(CommandBufferMultiMutablePODArgTest, UpdateMultipleDispatches) {
   // ranges.
   const auto first_updated_input_value =
       ucl::Environment::instance->GetInputGenerator().GenerateInt<cl_int>();
-  cl_mutable_dispatch_arg_khr first_arg{0, sizeof(cl_int),
-                                        &first_updated_input_value};
+  const cl_mutable_dispatch_arg_khr first_arg{0, sizeof(cl_int),
+                                              &first_updated_input_value};
   cl_mutable_dispatch_config_khr first_dispatch_config{
       command_handle, 1,       0,       0,       0,      &first_arg,
       nullptr,        nullptr, nullptr, nullptr, nullptr};
 
   const auto second_updated_input_value =
       ucl::Environment::instance->GetInputGenerator().GenerateInt<cl_int>();
-  cl_mutable_dispatch_arg_khr second_arg{0, sizeof(cl_int),
-                                         &second_updated_input_value};
+  const cl_mutable_dispatch_arg_khr second_arg{0, sizeof(cl_int),
+                                               &second_updated_input_value};
   cl_mutable_dispatch_config_khr second_dispatch_config{second_command_handle,
                                                         1,
                                                         0,
@@ -2699,7 +2705,7 @@ TEST_F(CommandBufferMultiMutablePODArgTest, UpdateMultipleDispatches) {
                                                         nullptr,
                                                         nullptr};
 
-  cl_uint num_configs = 2;
+  const cl_uint num_configs = 2;
   cl_command_buffer_update_type_khr config_types[2] = {
       CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
       CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
@@ -2853,11 +2859,11 @@ TEST_F(CommandBufferMutablePODMultiArgTest,
                                           &updated_input_x_data};
   const cl_mutable_dispatch_arg_khr arg_2{1, sizeof(cl_int),
                                           &updated_input_y_data};
-  cl_mutable_dispatch_arg_khr args[] = {arg_1, arg_2};
+  const cl_mutable_dispatch_arg_khr args[] = {arg_1, arg_2};
   cl_mutable_dispatch_config_khr dispatch_config{
       command_handle, 2,       0,       0,       0,      args,
       nullptr,        nullptr, nullptr, nullptr, nullptr};
-  cl_uint num_configs = 1;
+  const cl_uint num_configs = 1;
   cl_command_buffer_update_type_khr config_types[1] = {
       CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
   const void *configs[1] = {&dispatch_config};
@@ -2901,15 +2907,17 @@ TEST_F(CommandBufferMutablePODMultiArgTest,
   cl_int updated_input_y_data =
       ucl::Environment::instance->GetInputGenerator().GenerateInt<cl_int>();
 
-  cl_mutable_dispatch_arg_khr arg_1{0, sizeof(cl_int), &updated_input_x_data};
-  cl_mutable_dispatch_arg_khr arg_2{1, sizeof(cl_int), &updated_input_y_data};
+  const cl_mutable_dispatch_arg_khr arg_1{0, sizeof(cl_int),
+                                          &updated_input_x_data};
+  const cl_mutable_dispatch_arg_khr arg_2{1, sizeof(cl_int),
+                                          &updated_input_y_data};
   cl_mutable_dispatch_config_khr dispatch_config_1{
       command_handle, 1,       0,       0,       0,      &arg_1,
       nullptr,        nullptr, nullptr, nullptr, nullptr};
   cl_mutable_dispatch_config_khr dispatch_config_2{
       command_handle, 1,       0,       0,       0,      &arg_2,
       nullptr,        nullptr, nullptr, nullptr, nullptr};
-  cl_uint num_configs = 2;
+  const cl_uint num_configs = 2;
   cl_command_buffer_update_type_khr config_types[2] = {
       CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
       CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
@@ -3018,11 +3026,11 @@ TEST_F(CommandBufferMutableStructArgTest, UpdateInputOnce) {
 
   // Now try and enqueue the command buffer updating the output buffer.
   const test_struct second_value{99, 42.0f, 'j'};
-  cl_mutable_dispatch_arg_khr arg{0, sizeof(test_struct), &second_value};
+  const cl_mutable_dispatch_arg_khr arg{0, sizeof(test_struct), &second_value};
   cl_mutable_dispatch_config_khr dispatch_config{
       command_handle, 1,       0,       0,       0,      &arg,
       nullptr,        nullptr, nullptr, nullptr, nullptr};
-  cl_uint num_configs = 1;
+  const cl_uint num_configs = 1;
   cl_command_buffer_update_type_khr config_types[1] = {
       CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
   const void *configs[1] = {&dispatch_config};

--- a/source/cl/test/UnitCL/source/cl_khr_command_buffer_mutable_dispatch/clEnqueueCommandBufferKHRMutability.cpp
+++ b/source/cl/test/UnitCL/source/cl_khr_command_buffer_mutable_dispatch/clEnqueueCommandBufferKHRMutability.cpp
@@ -139,24 +139,17 @@ TEST_F(CommandBufferMutableBufferArgTest, UpdateOutputBufferOnce) {
   EXPECT_EQ(input_data, output_data);
 
   // Now try and enqueue the command buffer updating the output buffer.
-  const cl_mutable_dispatch_arg_khr arg{1, sizeof(cl_mem), &updated_dst_buffer};
-  const cl_mutable_dispatch_config_khr dispatch_config{
-      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
-      nullptr,
-      command_handle,
-      1,
-      0,
-      0,
-      0,
-      &arg,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr};
-  const cl_mutable_base_config_khr mutable_config{
-      CL_STRUCTURE_TYPE_MUTABLE_BASE_CONFIG_KHR, nullptr, 1, &dispatch_config};
-  EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, &mutable_config));
+  cl_mutable_dispatch_arg_khr arg{1, sizeof(cl_mem), &updated_dst_buffer};
+  cl_mutable_dispatch_config_khr dispatch_config{
+      command_handle, 1,       0,       0,       0,      &arg,
+      nullptr,        nullptr, nullptr, nullptr, nullptr};
+
+  cl_uint num_configs = 1;
+  cl_command_buffer_update_type_khr config_types[1] = {
+      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
+  const void *configs[1] = {&dispatch_config};
+  EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, num_configs,
+                                            config_types, configs));
   EXPECT_SUCCESS(clEnqueueCommandBufferKHR(0, nullptr, command_buffer, 0,
                                            nullptr, nullptr));
 
@@ -207,28 +200,18 @@ TEST_F(CommandBufferMutableBufferArgTest, UpdateOutputBufferTwice) {
   EXPECT_EQ(input_data, output_data);
 
   // Now try and enqueue the command buffer updating the output buffer.
-  const cl_mutable_dispatch_arg_khr first_arg{1, sizeof(cl_mem),
-                                              &first_updated_dst_buffer};
-  const cl_mutable_dispatch_config_khr first_dispatch_config{
-      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
-      nullptr,
-      command_handle,
-      1,
-      0,
-      0,
-      0,
-      &first_arg,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr};
-  const cl_mutable_base_config_khr first_mutable_config{
-      CL_STRUCTURE_TYPE_MUTABLE_BASE_CONFIG_KHR, nullptr, 1,
-      &first_dispatch_config};
+  cl_mutable_dispatch_arg_khr first_arg{1, sizeof(cl_mem),
+                                        &first_updated_dst_buffer};
+  cl_mutable_dispatch_config_khr first_dispatch_config{
+      command_handle, 1,       0,       0,       0,      &first_arg,
+      nullptr,        nullptr, nullptr, nullptr, nullptr};
 
-  EXPECT_SUCCESS(
-      clUpdateMutableCommandsKHR(command_buffer, &first_mutable_config));
+  cl_uint first_num_configs = 1;
+  cl_command_buffer_update_type_khr first_config_types[1] = {
+      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
+  const void *first_configs[1] = {&first_dispatch_config};
+  EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, first_num_configs,
+                                            first_config_types, first_configs));
   EXPECT_SUCCESS(clEnqueueCommandBufferKHR(0, nullptr, command_buffer, 0,
                                            nullptr, nullptr));
 
@@ -243,27 +226,17 @@ TEST_F(CommandBufferMutableBufferArgTest, UpdateOutputBufferTwice) {
   EXPECT_EQ(input_data, first_updated_output_data);
 
   // Enqueue the command buffer again updating the output buffer a second time.
-  const cl_mutable_dispatch_arg_khr second_arg{1, sizeof(cl_mem),
-                                               &second_updated_dst_buffer};
-  const cl_mutable_dispatch_config_khr second_dispatch_config{
-      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
-      nullptr,
-      command_handle,
-      1,
-      0,
-      0,
-      0,
-      &second_arg,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr};
-  const cl_mutable_base_config_khr second_mutable_config{
-      CL_STRUCTURE_TYPE_MUTABLE_BASE_CONFIG_KHR, nullptr, 1,
-      &second_dispatch_config};
-  EXPECT_SUCCESS(
-      clUpdateMutableCommandsKHR(command_buffer, &second_mutable_config));
+  cl_mutable_dispatch_arg_khr second_arg{1, sizeof(cl_mem),
+                                         &second_updated_dst_buffer};
+  cl_mutable_dispatch_config_khr second_dispatch_config{
+      command_handle, 1,       0,       0,       0,      &second_arg,
+      nullptr,        nullptr, nullptr, nullptr, nullptr};
+  cl_uint second_num_configs = 1;
+  cl_command_buffer_update_type_khr second_config_types[1] = {
+      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
+  const void *second_configs[1] = {&second_dispatch_config};
+  EXPECT_SUCCESS(clUpdateMutableCommandsKHR(
+      command_buffer, second_num_configs, second_config_types, second_configs));
   EXPECT_SUCCESS(clEnqueueCommandBufferKHR(0, nullptr, command_buffer, 0,
                                            nullptr, nullptr));
 
@@ -318,24 +291,16 @@ TEST_F(CommandBufferMutableBufferArgTest, UpdateInputBufferOnce) {
   EXPECT_EQ(input_data, output_data);
 
   // Now try and enqueue the command buffer updating the input buffer.
-  const cl_mutable_dispatch_arg_khr arg{0, sizeof(cl_mem), &updated_src_buffer};
-  const cl_mutable_dispatch_config_khr dispatch_config{
-      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
-      nullptr,
-      command_handle,
-      1,
-      0,
-      0,
-      0,
-      &arg,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr};
-  const cl_mutable_base_config_khr mutable_config{
-      CL_STRUCTURE_TYPE_MUTABLE_BASE_CONFIG_KHR, nullptr, 1, &dispatch_config};
-  EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, &mutable_config));
+  cl_mutable_dispatch_arg_khr arg{0, sizeof(cl_mem), &updated_src_buffer};
+  cl_mutable_dispatch_config_khr dispatch_config{
+      command_handle, 1,       0,       0,       0,      &arg,
+      nullptr,        nullptr, nullptr, nullptr, nullptr};
+  cl_uint num_configs = 1;
+  cl_command_buffer_update_type_khr config_types[1] = {
+      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
+  const void *configs[1] = {&dispatch_config};
+  EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, num_configs,
+                                            config_types, configs));
   EXPECT_SUCCESS(clEnqueueCommandBufferKHR(0, nullptr, command_buffer, 0,
                                            nullptr, nullptr));
 
@@ -400,27 +365,17 @@ TEST_F(CommandBufferMutableBufferArgTest, UpdateInputBufferTwice) {
   EXPECT_EQ(input_data, output_data);
 
   // Now try and enqueue the command buffer updating the input buffer.
-  const cl_mutable_dispatch_arg_khr first_arg{0, sizeof(cl_mem),
-                                              &first_updated_src_buffer};
-  const cl_mutable_dispatch_config_khr first_dispatch_config{
-      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
-      nullptr,
-      command_handle,
-      1,
-      0,
-      0,
-      0,
-      &first_arg,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr};
-  const cl_mutable_base_config_khr first_mutable_config{
-      CL_STRUCTURE_TYPE_MUTABLE_BASE_CONFIG_KHR, nullptr, 1,
-      &first_dispatch_config};
-  EXPECT_SUCCESS(
-      clUpdateMutableCommandsKHR(command_buffer, &first_mutable_config));
+  cl_mutable_dispatch_arg_khr first_arg{0, sizeof(cl_mem),
+                                        &first_updated_src_buffer};
+  cl_mutable_dispatch_config_khr first_dispatch_config{
+      command_handle, 1,       0,       0,       0,      &first_arg,
+      nullptr,        nullptr, nullptr, nullptr, nullptr};
+  cl_uint first_num_configs = 1;
+  cl_command_buffer_update_type_khr first_config_types[1] = {
+      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
+  const void *first_configs[1] = {&first_dispatch_config};
+  EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, first_num_configs,
+                                            first_config_types, first_configs));
   EXPECT_SUCCESS(clEnqueueCommandBufferKHR(0, nullptr, command_buffer, 0,
                                            nullptr, nullptr));
 
@@ -435,27 +390,17 @@ TEST_F(CommandBufferMutableBufferArgTest, UpdateInputBufferTwice) {
   EXPECT_EQ(first_updated_input_data, output_data);
 
   // Enqueue the command buffer a second time updating the input bufer again.
-  const cl_mutable_dispatch_arg_khr second_arg{0, sizeof(cl_mem),
-                                               &second_updated_src_buffer};
-  const cl_mutable_dispatch_config_khr second_dispatch_config{
-      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
-      nullptr,
-      command_handle,
-      1,
-      0,
-      0,
-      0,
-      &second_arg,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr};
-  const cl_mutable_base_config_khr second_mutable_config{
-      CL_STRUCTURE_TYPE_MUTABLE_BASE_CONFIG_KHR, nullptr, 1,
-      &second_dispatch_config};
-  EXPECT_SUCCESS(
-      clUpdateMutableCommandsKHR(command_buffer, &second_mutable_config));
+  cl_mutable_dispatch_arg_khr second_arg{0, sizeof(cl_mem),
+                                         &second_updated_src_buffer};
+  cl_mutable_dispatch_config_khr second_dispatch_config{
+      command_handle, 1,       0,       0,       0,      &second_arg,
+      nullptr,        nullptr, nullptr, nullptr, nullptr};
+  cl_uint second_num_configs = 1;
+  cl_command_buffer_update_type_khr second_config_types[1] = {
+      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
+  const void *second_configs[1] = {&second_dispatch_config};
+  EXPECT_SUCCESS(clUpdateMutableCommandsKHR(
+      command_buffer, second_num_configs, second_config_types, second_configs));
   EXPECT_SUCCESS(clEnqueueCommandBufferKHR(0, nullptr, command_buffer, 0,
                                            nullptr, nullptr));
 
@@ -521,23 +466,15 @@ TEST_F(CommandBufferMutableBufferArgTest,
   const cl_mutable_dispatch_arg_khr arg_2{1, sizeof(cl_mem),
                                           &updated_dst_buffer};
   cl_mutable_dispatch_arg_khr args[] = {arg_1, arg_2};
-  const cl_mutable_dispatch_config_khr dispatch_config{
-      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
-      nullptr,
-      command_handle,
-      2,
-      0,
-      0,
-      0,
-      args,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr};
-  const cl_mutable_base_config_khr mutable_config{
-      CL_STRUCTURE_TYPE_MUTABLE_BASE_CONFIG_KHR, nullptr, 1, &dispatch_config};
-  EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, &mutable_config));
+  cl_mutable_dispatch_config_khr dispatch_config{
+      command_handle, 2,       0,       0,       0,      args,
+      nullptr,        nullptr, nullptr, nullptr, nullptr};
+  cl_uint num_configs = 1;
+  cl_command_buffer_update_type_khr config_types[1] = {
+      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
+  const void *configs[1] = {&dispatch_config};
+  EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, num_configs,
+                                            config_types, configs));
   EXPECT_SUCCESS(clEnqueueCommandBufferKHR(0, nullptr, command_buffer, 0,
                                            nullptr, nullptr));
 
@@ -598,43 +535,21 @@ TEST_F(CommandBufferMutableBufferArgTest,
 
   // Now try and enqueue the command buffer updating the input and output
   // buffers.
-  const cl_mutable_dispatch_arg_khr arg_1{0, sizeof(cl_mem),
-                                          &updated_src_buffer};
-  const cl_mutable_dispatch_arg_khr arg_2{1, sizeof(cl_mem),
-                                          &updated_dst_buffer};
-  const cl_mutable_dispatch_config_khr dispatch_config_1{
+  cl_mutable_dispatch_arg_khr arg_1{0, sizeof(cl_mem), &updated_src_buffer};
+  cl_mutable_dispatch_arg_khr arg_2{1, sizeof(cl_mem), &updated_dst_buffer};
+  cl_mutable_dispatch_config_khr dispatch_config_1{
+      command_handle, 1,       0,       0,       0,      &arg_1,
+      nullptr,        nullptr, nullptr, nullptr, nullptr};
+  cl_mutable_dispatch_config_khr dispatch_config_2{
+      command_handle, 1,       0,       0,       0,      &arg_2,
+      nullptr,        nullptr, nullptr, nullptr, nullptr};
+  cl_uint num_configs = 2;
+  cl_command_buffer_update_type_khr config_types[2] = {
       CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
-      nullptr,
-      command_handle,
-      1,
-      0,
-      0,
-      0,
-      &arg_1,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr};
-  const cl_mutable_dispatch_config_khr dispatch_config_2{
-      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
-      nullptr,
-      command_handle,
-      1,
-      0,
-      0,
-      0,
-      &arg_2,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr};
-  cl_mutable_dispatch_config_khr dispatch_configs[] = {dispatch_config_1,
-                                                       dispatch_config_2};
-  const cl_mutable_base_config_khr mutable_config{
-      CL_STRUCTURE_TYPE_MUTABLE_BASE_CONFIG_KHR, nullptr, 2, dispatch_configs};
-  EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, &mutable_config));
+      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
+  const void *configs[2] = {&dispatch_config_1, &dispatch_config_2};
+  EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, num_configs,
+                                            config_types, configs));
   EXPECT_SUCCESS(clEnqueueCommandBufferKHR(0, nullptr, command_buffer, 0,
                                            nullptr, nullptr));
 
@@ -693,24 +608,16 @@ TEST_F(CommandBufferMutableBufferArgTest, UpdateToBiggerBufferSize) {
   EXPECT_EQ(input_data, output_data);
 
   // Now try and enqueue the command buffer updating the output buffer.
-  const cl_mutable_dispatch_arg_khr arg{1, sizeof(cl_mem), &updated_dst_buffer};
-  const cl_mutable_dispatch_config_khr dispatch_config{
-      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
-      nullptr,
-      command_handle,
-      1,
-      0,
-      0,
-      0,
-      &arg,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr};
-  const cl_mutable_base_config_khr mutable_config{
-      CL_STRUCTURE_TYPE_MUTABLE_BASE_CONFIG_KHR, nullptr, 1, &dispatch_config};
-  EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, &mutable_config));
+  cl_mutable_dispatch_arg_khr arg{1, sizeof(cl_mem), &updated_dst_buffer};
+  cl_mutable_dispatch_config_khr dispatch_config{
+      command_handle, 1,       0,       0,       0,      &arg,
+      nullptr,        nullptr, nullptr, nullptr, nullptr};
+  cl_uint num_configs = 1;
+  cl_command_buffer_update_type_khr config_types[1] = {
+      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
+  const void *configs[1] = {&dispatch_config};
+  EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, num_configs,
+                                            config_types, configs));
   EXPECT_SUCCESS(clEnqueueCommandBufferKHR(0, nullptr, command_buffer, 0,
                                            nullptr, nullptr));
 
@@ -762,24 +669,16 @@ TEST_F(CommandBufferMutableBufferArgTest, CheckUpdatePersists) {
   EXPECT_EQ(input_data, output_data);
 
   // Now try and enqueue the command buffer updating the output buffer.
-  const cl_mutable_dispatch_arg_khr arg{1, sizeof(cl_mem), &updated_dst_buffer};
-  const cl_mutable_dispatch_config_khr dispatch_config{
-      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
-      nullptr,
-      command_handle,
-      1,
-      0,
-      0,
-      0,
-      &arg,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr};
-  const cl_mutable_base_config_khr mutable_config{
-      CL_STRUCTURE_TYPE_MUTABLE_BASE_CONFIG_KHR, nullptr, 1, &dispatch_config};
-  EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, &mutable_config));
+  cl_mutable_dispatch_arg_khr arg{1, sizeof(cl_mem), &updated_dst_buffer};
+  cl_mutable_dispatch_config_khr dispatch_config{
+      command_handle, 1,       0,       0,       0,      &arg,
+      nullptr,        nullptr, nullptr, nullptr, nullptr};
+  cl_uint num_configs = 1;
+  cl_command_buffer_update_type_khr config_types[1] = {
+      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
+  const void *configs[1] = {&dispatch_config};
+  EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, num_configs,
+                                            config_types, configs));
   EXPECT_SUCCESS(clEnqueueCommandBufferKHR(0, nullptr, command_buffer, 0,
                                            nullptr, nullptr));
 
@@ -860,24 +759,16 @@ TEST_F(CommandBufferMutableBufferArgTest, FillThenNDRange) {
   EXPECT_EQ(input_data, output_data);
 
   // Now try and enqueue the command buffer updating the output buffer.
-  const cl_mutable_dispatch_arg_khr arg{1, sizeof(cl_mem), &updated_dst_buffer};
-  const cl_mutable_dispatch_config_khr dispatch_config{
-      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
-      nullptr,
-      command_handle,
-      1,
-      0,
-      0,
-      0,
-      &arg,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr};
-  const cl_mutable_base_config_khr mutable_config{
-      CL_STRUCTURE_TYPE_MUTABLE_BASE_CONFIG_KHR, nullptr, 1, &dispatch_config};
-  EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, &mutable_config));
+  cl_mutable_dispatch_arg_khr arg{1, sizeof(cl_mem), &updated_dst_buffer};
+  cl_mutable_dispatch_config_khr dispatch_config{
+      command_handle, 1,       0,       0,       0,      &arg,
+      nullptr,        nullptr, nullptr, nullptr, nullptr};
+  cl_uint num_configs = 1;
+  cl_command_buffer_update_type_khr config_types[1] = {
+      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
+  const void *configs[1] = {&dispatch_config};
+  EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, num_configs,
+                                            config_types, configs));
   EXPECT_SUCCESS(clEnqueueCommandBufferKHR(0, nullptr, command_buffer, 0,
                                            nullptr, nullptr));
 
@@ -938,24 +829,16 @@ TEST_F(CommandBufferMutableBufferArgTest, NDRangeThenFill) {
   EXPECT_EQ(input_data, output_data);
 
   // Now try and enqueue the command buffer updating the output buffer.
-  const cl_mutable_dispatch_arg_khr arg{1, sizeof(cl_mem), &updated_dst_buffer};
-  const cl_mutable_dispatch_config_khr dispatch_config{
-      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
-      nullptr,
-      command_handle,
-      1,
-      0,
-      0,
-      0,
-      &arg,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr};
-  const cl_mutable_base_config_khr mutable_config{
-      CL_STRUCTURE_TYPE_MUTABLE_BASE_CONFIG_KHR, nullptr, 1, &dispatch_config};
-  EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, &mutable_config));
+  cl_mutable_dispatch_arg_khr arg{1, sizeof(cl_mem), &updated_dst_buffer};
+  cl_mutable_dispatch_config_khr dispatch_config{
+      command_handle, 1,       0,       0,       0,      &arg,
+      nullptr,        nullptr, nullptr, nullptr, nullptr};
+  cl_uint num_configs = 1;
+  cl_command_buffer_update_type_khr config_types[1] = {
+      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
+  const void *configs[1] = {&dispatch_config};
+  EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, num_configs,
+                                            config_types, configs));
   EXPECT_SUCCESS(clEnqueueCommandBufferKHR(0, nullptr, command_buffer, 0,
                                            nullptr, nullptr));
 
@@ -1019,24 +902,16 @@ TEST_F(CommandBufferMutableBufferArgTest, FillTwiceThenNDRange) {
   EXPECT_EQ(input_data, output_data);
 
   // Now try and enqueue the command buffer updating the output buffer.
-  const cl_mutable_dispatch_arg_khr arg{1, sizeof(cl_mem), &updated_dst_buffer};
-  const cl_mutable_dispatch_config_khr dispatch_config{
-      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
-      nullptr,
-      command_handle,
-      1,
-      0,
-      0,
-      0,
-      &arg,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr};
-  const cl_mutable_base_config_khr mutable_config{
-      CL_STRUCTURE_TYPE_MUTABLE_BASE_CONFIG_KHR, nullptr, 1, &dispatch_config};
-  EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, &mutable_config));
+  cl_mutable_dispatch_arg_khr arg{1, sizeof(cl_mem), &updated_dst_buffer};
+  cl_mutable_dispatch_config_khr dispatch_config{
+      command_handle, 1,       0,       0,       0,      &arg,
+      nullptr,        nullptr, nullptr, nullptr, nullptr};
+  cl_uint num_configs = 1;
+  cl_command_buffer_update_type_khr config_types[1] = {
+      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
+  const void *configs[1] = {&dispatch_config};
+  EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, num_configs,
+                                            config_types, configs));
   EXPECT_SUCCESS(clEnqueueCommandBufferKHR(0, nullptr, command_buffer, 0,
                                            nullptr, nullptr));
 
@@ -1099,24 +974,16 @@ TEST_F(CommandBufferMutableBufferArgTest, CopyBufferThenNDRange) {
   EXPECT_EQ(input_data, output_data);
 
   // Now try and enqueue the command buffer updating the output buffer.
-  const cl_mutable_dispatch_arg_khr arg{1, sizeof(cl_mem), &updated_dst_buffer};
-  const cl_mutable_dispatch_config_khr dispatch_config{
-      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
-      nullptr,
-      command_handle,
-      1,
-      0,
-      0,
-      0,
-      &arg,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr};
-  const cl_mutable_base_config_khr mutable_config{
-      CL_STRUCTURE_TYPE_MUTABLE_BASE_CONFIG_KHR, nullptr, 1, &dispatch_config};
-  EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, &mutable_config));
+  cl_mutable_dispatch_arg_khr arg{1, sizeof(cl_mem), &updated_dst_buffer};
+  cl_mutable_dispatch_config_khr dispatch_config{
+      command_handle, 1,       0,       0,       0,      &arg,
+      nullptr,        nullptr, nullptr, nullptr, nullptr};
+  cl_uint num_configs = 1;
+  cl_command_buffer_update_type_khr config_types[1] = {
+      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
+  const void *configs[1] = {&dispatch_config};
+  EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, num_configs,
+                                            config_types, configs));
   EXPECT_SUCCESS(clEnqueueCommandBufferKHR(0, nullptr, command_buffer, 0,
                                            nullptr, nullptr));
 
@@ -1181,24 +1048,16 @@ TEST_F(CommandBufferMutableBufferArgTest, CopyBufferRectThenNDRange) {
   EXPECT_EQ(input_data, output_data);
 
   // Now try and enqueue the command buffer updating the output buffer.
-  const cl_mutable_dispatch_arg_khr arg{1, sizeof(cl_mem), &updated_dst_buffer};
-  const cl_mutable_dispatch_config_khr dispatch_config{
-      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
-      nullptr,
-      command_handle,
-      1,
-      0,
-      0,
-      0,
-      &arg,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr};
-  const cl_mutable_base_config_khr mutable_config{
-      CL_STRUCTURE_TYPE_MUTABLE_BASE_CONFIG_KHR, nullptr, 1, &dispatch_config};
-  EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, &mutable_config));
+  cl_mutable_dispatch_arg_khr arg{1, sizeof(cl_mem), &updated_dst_buffer};
+  cl_mutable_dispatch_config_khr dispatch_config{
+      command_handle, 1,       0,       0,       0,      &arg,
+      nullptr,        nullptr, nullptr, nullptr, nullptr};
+  cl_uint num_configs = 1;
+  cl_command_buffer_update_type_khr config_types[1] = {
+      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
+  const void *configs[1] = {&dispatch_config};
+  EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, num_configs,
+                                            config_types, configs));
   EXPECT_SUCCESS(clEnqueueCommandBufferKHR(0, nullptr, command_buffer, 0,
                                            nullptr, nullptr));
 
@@ -1270,24 +1129,16 @@ TEST_F(CommandBufferMutableBufferArgTest, RegularNDRangeThenMutableNDRange) {
   EXPECT_EQ(input_data, output_data);
 
   // Now try and enqueue the command buffer updating the output buffer.
-  const cl_mutable_dispatch_arg_khr arg{1, sizeof(cl_mem), &updated_dst_buffer};
-  const cl_mutable_dispatch_config_khr dispatch_config{
-      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
-      nullptr,
-      command_handle,
-      1,
-      0,
-      0,
-      0,
-      &arg,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr};
-  const cl_mutable_base_config_khr mutable_config{
-      CL_STRUCTURE_TYPE_MUTABLE_BASE_CONFIG_KHR, nullptr, 1, &dispatch_config};
-  EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, &mutable_config));
+  cl_mutable_dispatch_arg_khr arg{1, sizeof(cl_mem), &updated_dst_buffer};
+  cl_mutable_dispatch_config_khr dispatch_config{
+      command_handle, 1,       0,       0,       0,      &arg,
+      nullptr,        nullptr, nullptr, nullptr, nullptr};
+  cl_uint num_configs = 1;
+  cl_command_buffer_update_type_khr config_types[1] = {
+      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
+  const void *configs[1] = {&dispatch_config};
+  EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, num_configs,
+                                            config_types, configs));
   EXPECT_SUCCESS(clEnqueueCommandBufferKHR(0, nullptr, command_buffer, 0,
                                            nullptr, nullptr));
 
@@ -1424,24 +1275,16 @@ TEST_F(CommandBufferMultiMutableBufferArgTest, UpdateSingleDispatch) {
 
   // Now try and enqueue the command buffer updating the output buffer of the
   // first nd range.
-  const cl_mutable_dispatch_arg_khr arg{0, sizeof(cl_mem), &updated_src_buffer};
-  const cl_mutable_dispatch_config_khr dispatch_config{
-      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
-      nullptr,
-      command_handle,
-      1,
-      0,
-      0,
-      0,
-      &arg,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr};
-  const cl_mutable_base_config_khr mutable_config{
-      CL_STRUCTURE_TYPE_MUTABLE_BASE_CONFIG_KHR, nullptr, 1, &dispatch_config};
-  EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, &mutable_config));
+  cl_mutable_dispatch_arg_khr arg{0, sizeof(cl_mem), &updated_src_buffer};
+  cl_mutable_dispatch_config_khr dispatch_config{
+      command_handle, 1,       0,       0,       0,      &arg,
+      nullptr,        nullptr, nullptr, nullptr, nullptr};
+  cl_uint num_configs = 1;
+  cl_command_buffer_update_type_khr config_types[1] = {
+      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
+  const void *configs[1] = {&dispatch_config};
+  EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, num_configs,
+                                            config_types, configs));
   EXPECT_SUCCESS(clEnqueueCommandBufferKHR(0, nullptr, command_buffer, 0,
                                            nullptr, nullptr));
 
@@ -1512,46 +1355,33 @@ TEST_F(CommandBufferMultiMutableBufferArgTest, UpdateMultipleDispatches) {
 
   // Now try and enqueue the command buffer updating the input buffer of both
   // nd ranges.
-  const cl_mutable_dispatch_arg_khr first_arg{0, sizeof(cl_mem),
-                                              &first_updated_src_buffer};
-  const cl_mutable_dispatch_config_khr first_dispatch_config{
+  cl_mutable_dispatch_arg_khr first_arg{0, sizeof(cl_mem),
+                                        &first_updated_src_buffer};
+  cl_mutable_dispatch_config_khr first_dispatch_config{
+      command_handle, 1,       0,       0,       0,      &first_arg,
+      nullptr,        nullptr, nullptr, nullptr, nullptr};
+
+  cl_mutable_dispatch_arg_khr second_arg{0, sizeof(cl_mem),
+                                         &second_updated_src_buffer};
+  cl_mutable_dispatch_config_khr second_dispatch_config{second_command_handle,
+                                                        1,
+                                                        0,
+                                                        0,
+                                                        0,
+                                                        &second_arg,
+                                                        nullptr,
+                                                        nullptr,
+                                                        nullptr,
+                                                        nullptr,
+                                                        nullptr};
+
+  cl_uint num_configs = 2;
+  cl_command_buffer_update_type_khr config_types[2] = {
       CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
-      nullptr,
-      command_handle,
-      1,
-      0,
-      0,
-      0,
-      &first_arg,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr};
-
-  const cl_mutable_dispatch_arg_khr second_arg{0, sizeof(cl_mem),
-                                               &second_updated_src_buffer};
-  const cl_mutable_dispatch_config_khr second_dispatch_config{
-      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
-      nullptr,
-      second_command_handle,
-      1,
-      0,
-      0,
-      0,
-      &second_arg,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr};
-
-  cl_mutable_dispatch_config_khr dispatch_configs[]{first_dispatch_config,
-                                                    second_dispatch_config};
-
-  const cl_mutable_base_config_khr mutable_config{
-      CL_STRUCTURE_TYPE_MUTABLE_BASE_CONFIG_KHR, nullptr, 2, dispatch_configs};
-  EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, &mutable_config));
+      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
+  const void *configs[2] = {&first_dispatch_config, &second_dispatch_config};
+  EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, num_configs,
+                                            config_types, configs));
   EXPECT_SUCCESS(clEnqueueCommandBufferKHR(0, nullptr, command_buffer, 0,
                                            nullptr, nullptr));
 
@@ -1669,24 +1499,16 @@ TEST_F(MutableDispatchTest, UpdateConstantBuffer) {
   EXPECT_EQ(input_data, output_data);
 
   // Now try and enqueue the command buffer updating the input buffer.
-  const cl_mutable_dispatch_arg_khr arg{0, sizeof(cl_mem), &updated_src_buffer};
-  const cl_mutable_dispatch_config_khr dispatch_config{
-      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
-      nullptr,
-      command_handle,
-      1,
-      0,
-      0,
-      0,
-      &arg,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr};
-  const cl_mutable_base_config_khr mutable_config{
-      CL_STRUCTURE_TYPE_MUTABLE_BASE_CONFIG_KHR, nullptr, 1, &dispatch_config};
-  EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, &mutable_config));
+  cl_mutable_dispatch_arg_khr arg{0, sizeof(cl_mem), &updated_src_buffer};
+  cl_mutable_dispatch_config_khr dispatch_config{
+      command_handle, 1,       0,       0,       0,      &arg,
+      nullptr,        nullptr, nullptr, nullptr, nullptr};
+  cl_uint num_configs = 1;
+  cl_command_buffer_update_type_khr config_types[1] = {
+      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
+  const void *configs[1] = {&dispatch_config};
+  EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, num_configs,
+                                            config_types, configs));
   EXPECT_SUCCESS(clEnqueueCommandBufferKHR(0, nullptr, command_buffer, 0,
                                            nullptr, nullptr));
 
@@ -1784,24 +1606,16 @@ TEST_F(CommandBufferMutableLocalBufferArgTest, UpdateOnce) {
   EXPECT_SUCCESS(clFinish(command_queue));
 
   // Update the local buffer size.
-  const cl_mutable_dispatch_arg_khr arg{0, 32, nullptr};
-  const cl_mutable_dispatch_config_khr dispatch_config{
-      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
-      nullptr,
-      command_handle,
-      1,
-      0,
-      0,
-      0,
-      &arg,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr};
-  const cl_mutable_base_config_khr mutable_config{
-      CL_STRUCTURE_TYPE_MUTABLE_BASE_CONFIG_KHR, nullptr, 1, &dispatch_config};
-  EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, &mutable_config));
+  cl_mutable_dispatch_arg_khr arg{0, 32, nullptr};
+  cl_mutable_dispatch_config_khr dispatch_config{
+      command_handle, 1,       0,       0,       0,      &arg,
+      nullptr,        nullptr, nullptr, nullptr, nullptr};
+  cl_uint num_configs = 1;
+  cl_command_buffer_update_type_khr config_types[1] = {
+      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
+  const void *configs[1] = {&dispatch_config};
+  EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, num_configs,
+                                            config_types, configs));
   EXPECT_SUCCESS(clEnqueueCommandBufferKHR(0, nullptr, command_buffer, 0,
                                            nullptr, nullptr));
 }
@@ -1815,24 +1629,16 @@ TEST_F(CommandBufferMutableLocalBufferArgTest, UpdateTwice) {
   EXPECT_SUCCESS(clFinish(command_queue));
 
   // Update the local buffer size.
-  const cl_mutable_dispatch_arg_khr arg{0, 32, nullptr};
-  const cl_mutable_dispatch_config_khr dispatch_config{
-      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
-      nullptr,
-      command_handle,
-      1,
-      0,
-      0,
-      0,
-      &arg,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr};
-  const cl_mutable_base_config_khr mutable_config{
-      CL_STRUCTURE_TYPE_MUTABLE_BASE_CONFIG_KHR, nullptr, 1, &dispatch_config};
-  EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, &mutable_config));
+  cl_mutable_dispatch_arg_khr arg{0, 32, nullptr};
+  cl_mutable_dispatch_config_khr dispatch_config{
+      command_handle, 1,       0,       0,       0,      &arg,
+      nullptr,        nullptr, nullptr, nullptr, nullptr};
+  cl_uint num_configs = 1;
+  cl_command_buffer_update_type_khr config_types[1] = {
+      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
+  const void *configs[1] = {&dispatch_config};
+  EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, num_configs,
+                                            config_types, configs));
   EXPECT_SUCCESS(clEnqueueCommandBufferKHR(0, nullptr, command_buffer, 0,
                                            nullptr, nullptr));
 
@@ -1840,25 +1646,16 @@ TEST_F(CommandBufferMutableLocalBufferArgTest, UpdateTwice) {
   EXPECT_SUCCESS(clFinish(command_queue));
 
   // Update the local buffer size a second time.
-  const cl_mutable_dispatch_arg_khr arg_2{0, 32, nullptr};
-  const cl_mutable_dispatch_config_khr dispatch_config_2{
-      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
-      nullptr,
-      command_handle,
-      1,
-      0,
-      0,
-      0,
-      &arg_2,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr};
-  const cl_mutable_base_config_khr mutable_config_2{
-      CL_STRUCTURE_TYPE_MUTABLE_BASE_CONFIG_KHR, nullptr, 1,
-      &dispatch_config_2};
-  EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, &mutable_config_2));
+  cl_mutable_dispatch_arg_khr arg_2{0, 32, nullptr};
+  cl_mutable_dispatch_config_khr dispatch_config_2{
+      command_handle, 1,       0,       0,       0,      &arg_2,
+      nullptr,        nullptr, nullptr, nullptr, nullptr};
+  cl_uint num_configs_2 = 1;
+  cl_command_buffer_update_type_khr config_types_2[1] = {
+      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
+  const void *configs_2[1] = {&dispatch_config_2};
+  EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, num_configs_2,
+                                            config_types_2, configs_2));
   EXPECT_SUCCESS(clEnqueueCommandBufferKHR(0, nullptr, command_buffer, 0,
                                            nullptr, nullptr));
 }
@@ -1988,24 +1785,16 @@ TEST_F(DISABLED_CommandBufferMutableNullArgTest,
   EXPECT_EQ(output_data, std::vector<cl_int>(global_size, 0x0));
 
   // Update the input to null and enqueue a second time.
-  const cl_mutable_dispatch_arg_khr arg{0, sizeof(cl_mem), nullptr};
-  const cl_mutable_dispatch_config_khr dispatch_config{
-      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
-      nullptr,
-      command_handle,
-      1,
-      0,
-      0,
-      0,
-      &arg,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr};
-  const cl_mutable_base_config_khr mutable_config{
-      CL_STRUCTURE_TYPE_MUTABLE_BASE_CONFIG_KHR, nullptr, 1, &dispatch_config};
-  EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, &mutable_config));
+  cl_mutable_dispatch_arg_khr arg{0, sizeof(cl_mem), nullptr};
+  cl_mutable_dispatch_config_khr dispatch_config{
+      command_handle, 1,       0,       0,       0,      &arg,
+      nullptr,        nullptr, nullptr, nullptr, nullptr};
+  cl_uint num_configs = 1;
+  cl_command_buffer_update_type_khr config_types[1] = {
+      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
+  const void *configs[1] = {&dispatch_config};
+  EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, num_configs,
+                                            config_types, configs));
   EXPECT_SUCCESS(clEnqueueCommandBufferKHR(0, nullptr, command_buffer, 0,
                                            nullptr, nullptr));
 
@@ -2053,24 +1842,16 @@ TEST_F(DISABLED_CommandBufferMutableNullArgTest,
 
   // Update the input to pointer to null.
   const cl_int *null = nullptr;
-  const cl_mutable_dispatch_arg_khr arg{0, sizeof(cl_mem), &null};
-  const cl_mutable_dispatch_config_khr dispatch_config{
-      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
-      nullptr,
-      command_handle,
-      1,
-      0,
-      0,
-      0,
-      &arg,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr};
-  const cl_mutable_base_config_khr mutable_config{
-      CL_STRUCTURE_TYPE_MUTABLE_BASE_CONFIG_KHR, nullptr, 1, &dispatch_config};
-  EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, &mutable_config));
+  cl_mutable_dispatch_arg_khr arg{0, sizeof(cl_mem), &null};
+  cl_mutable_dispatch_config_khr dispatch_config{
+      command_handle, 1,       0,       0,       0,      &arg,
+      nullptr,        nullptr, nullptr, nullptr, nullptr};
+  cl_uint num_configs = 1;
+  cl_command_buffer_update_type_khr config_types[1] = {
+      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
+  const void *configs[1] = {&dispatch_config};
+  EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, num_configs,
+                                            config_types, configs));
   EXPECT_SUCCESS(clEnqueueCommandBufferKHR(0, nullptr, command_buffer, 0,
                                            nullptr, nullptr));
 
@@ -2116,24 +1897,16 @@ TEST_F(DISABLED_CommandBufferMutableNullArgTest,
   EXPECT_EQ(output_data, std::vector<cl_int>(global_size, 0x1));
 
   // Update the input to null.
-  const cl_mutable_dispatch_arg_khr arg{0, sizeof(cl_mem), &src_buffer};
-  const cl_mutable_dispatch_config_khr dispatch_config{
-      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
-      nullptr,
-      command_handle,
-      1,
-      0,
-      0,
-      0,
-      &arg,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr};
-  const cl_mutable_base_config_khr mutable_config{
-      CL_STRUCTURE_TYPE_MUTABLE_BASE_CONFIG_KHR, nullptr, 1, &dispatch_config};
-  EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, &mutable_config));
+  cl_mutable_dispatch_arg_khr arg{0, sizeof(cl_mem), &src_buffer};
+  cl_mutable_dispatch_config_khr dispatch_config{
+      command_handle, 1,       0,       0,       0,      &arg,
+      nullptr,        nullptr, nullptr, nullptr, nullptr};
+  cl_uint num_configs = 1;
+  cl_command_buffer_update_type_khr config_types[1] = {
+      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
+  const void *configs[1] = {&dispatch_config};
+  EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, num_configs,
+                                            config_types, configs));
   EXPECT_SUCCESS(clEnqueueCommandBufferKHR(0, nullptr, command_buffer, 0,
                                            nullptr, nullptr));
 
@@ -2180,24 +1953,16 @@ TEST_F(DISABLED_CommandBufferMutableNullArgTest,
   EXPECT_EQ(output_data, std::vector<cl_int>(global_size, 0x1));
 
   // Update the input to null.
-  const cl_mutable_dispatch_arg_khr arg{0, sizeof(cl_mem), &src_buffer};
-  const cl_mutable_dispatch_config_khr dispatch_config{
-      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
-      nullptr,
-      command_handle,
-      1,
-      0,
-      0,
-      0,
-      &arg,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr};
-  const cl_mutable_base_config_khr mutable_config{
-      CL_STRUCTURE_TYPE_MUTABLE_BASE_CONFIG_KHR, nullptr, 1, &dispatch_config};
-  EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, &mutable_config));
+  cl_mutable_dispatch_arg_khr arg{0, sizeof(cl_mem), &src_buffer};
+  cl_mutable_dispatch_config_khr dispatch_config{
+      command_handle, 1,       0,       0,       0,      &arg,
+      nullptr,        nullptr, nullptr, nullptr, nullptr};
+  cl_uint num_configs = 1;
+  cl_command_buffer_update_type_khr config_types[1] = {
+      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
+  const void *configs[1] = {&dispatch_config};
+  EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, num_configs,
+                                            config_types, configs));
   EXPECT_SUCCESS(clEnqueueCommandBufferKHR(0, nullptr, command_buffer, 0,
                                            nullptr, nullptr));
 
@@ -2241,24 +2006,16 @@ TEST_F(DISABLED_CommandBufferMutableNullArgTest, CheckUpdatePersists) {
   EXPECT_EQ(output_data, std::vector<cl_int>(global_size, 0x0));
 
   // Update the input to null and enqueue a second time.
-  const cl_mutable_dispatch_arg_khr arg{0, sizeof(cl_mem), nullptr};
-  const cl_mutable_dispatch_config_khr dispatch_config{
-      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
-      nullptr,
-      command_handle,
-      1,
-      0,
-      0,
-      0,
-      &arg,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr};
-  const cl_mutable_base_config_khr mutable_config{
-      CL_STRUCTURE_TYPE_MUTABLE_BASE_CONFIG_KHR, nullptr, 1, &dispatch_config};
-  EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, &mutable_config));
+  cl_mutable_dispatch_arg_khr arg{0, sizeof(cl_mem), nullptr};
+  cl_mutable_dispatch_config_khr dispatch_config{
+      command_handle, 1,       0,       0,       0,      &arg,
+      nullptr,        nullptr, nullptr, nullptr, nullptr};
+  cl_uint num_configs = 1;
+  cl_command_buffer_update_type_khr config_types[1] = {
+      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
+  const void *configs[1] = {&dispatch_config};
+  EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, num_configs,
+                                            config_types, configs));
   EXPECT_SUCCESS(clEnqueueCommandBufferKHR(0, nullptr, command_buffer, 0,
                                            nullptr, nullptr));
 
@@ -2383,24 +2140,16 @@ TEST_F(DISABLED_CommandBufferMultiMutableNullArgTest, UpdateSingleDispatch) {
   EXPECT_EQ(second_output_data, std::vector<cl_int>(global_size, 0x0));
 
   // Update the input of the first nd range to null and enqueue a second time.
-  const cl_mutable_dispatch_arg_khr arg{0, sizeof(cl_mem), nullptr};
-  const cl_mutable_dispatch_config_khr dispatch_config{
-      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
-      nullptr,
-      command_handle,
-      1,
-      0,
-      0,
-      0,
-      &arg,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr};
-  const cl_mutable_base_config_khr mutable_config{
-      CL_STRUCTURE_TYPE_MUTABLE_BASE_CONFIG_KHR, nullptr, 1, &dispatch_config};
-  EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, &mutable_config));
+  cl_mutable_dispatch_arg_khr arg{0, sizeof(cl_mem), nullptr};
+  cl_mutable_dispatch_config_khr dispatch_config{
+      command_handle, 1,       0,       0,       0,      &arg,
+      nullptr,        nullptr, nullptr, nullptr, nullptr};
+  cl_uint num_configs = 1;
+  cl_command_buffer_update_type_khr config_types[1] = {
+      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
+  const void *configs[1] = {&dispatch_config};
+  EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, num_configs,
+                                            config_types, configs));
   EXPECT_SUCCESS(clEnqueueCommandBufferKHR(0, nullptr, command_buffer, 0,
                                            nullptr, nullptr));
 
@@ -2440,44 +2189,31 @@ TEST_F(DISABLED_CommandBufferMultiMutableNullArgTest,
   EXPECT_EQ(second_output_data, std::vector<cl_int>(global_size, 0x0));
 
   // Update the input of both nd ranges to null and enqueue a second time.
-  const cl_mutable_dispatch_arg_khr first_arg{0, sizeof(cl_mem), nullptr};
-  const cl_mutable_dispatch_config_khr first_dispatch_config{
+  cl_mutable_dispatch_arg_khr first_arg{0, sizeof(cl_mem), nullptr};
+  cl_mutable_dispatch_config_khr first_dispatch_config{
+      command_handle, 1,       0,       0,       0,      &first_arg,
+      nullptr,        nullptr, nullptr, nullptr, nullptr};
+
+  cl_mutable_dispatch_arg_khr second_arg{0, sizeof(cl_mem), nullptr};
+  cl_mutable_dispatch_config_khr second_dispatch_config{second_command_handle,
+                                                        1,
+                                                        0,
+                                                        0,
+                                                        0,
+                                                        &second_arg,
+                                                        nullptr,
+                                                        nullptr,
+                                                        nullptr,
+                                                        nullptr,
+                                                        nullptr};
+
+  cl_uint num_configs = 2;
+  cl_command_buffer_update_type_khr config_types[2] = {
       CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
-      nullptr,
-      command_handle,
-      1,
-      0,
-      0,
-      0,
-      &first_arg,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr};
-
-  const cl_mutable_dispatch_arg_khr second_arg{0, sizeof(cl_mem), nullptr};
-  const cl_mutable_dispatch_config_khr second_dispatch_config{
-      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
-      nullptr,
-      second_command_handle,
-      1,
-      0,
-      0,
-      0,
-      &second_arg,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr};
-
-  cl_mutable_dispatch_config_khr dispatch_configs[]{first_dispatch_config,
-                                                    second_dispatch_config};
-
-  const cl_mutable_base_config_khr mutable_config{
-      CL_STRUCTURE_TYPE_MUTABLE_BASE_CONFIG_KHR, nullptr, 2, dispatch_configs};
-  EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, &mutable_config));
+      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
+  const void *configs[2] = {&first_dispatch_config, &second_dispatch_config};
+  EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, num_configs,
+                                            config_types, configs));
   EXPECT_SUCCESS(clEnqueueCommandBufferKHR(0, nullptr, command_buffer, 0,
                                            nullptr, nullptr));
 
@@ -2588,26 +2324,17 @@ TEST_F(CommandBufferMutablePODArgTest, InvalidArgSize) {
   // Now try and enqueue the command buffer updating the input value.
   const auto updated_input_value =
       ucl::Environment::instance->GetInputGenerator().GenerateInt<cl_int>();
-  const cl_mutable_dispatch_arg_khr arg{0, sizeof(cl_int4),
-                                        &updated_input_value};
-  const cl_mutable_dispatch_config_khr dispatch_config{
-      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
-      nullptr,
-      command_handle,
-      1,
-      0,
-      0,
-      0,
-      &arg,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr};
-  const cl_mutable_base_config_khr mutable_config{
-      CL_STRUCTURE_TYPE_MUTABLE_BASE_CONFIG_KHR, nullptr, 1, &dispatch_config};
-  EXPECT_EQ_ERRCODE(CL_INVALID_ARG_SIZE, clUpdateMutableCommandsKHR(
-                                             command_buffer, &mutable_config));
+  cl_mutable_dispatch_arg_khr arg{0, sizeof(cl_int4), &updated_input_value};
+  cl_mutable_dispatch_config_khr dispatch_config{
+      command_handle, 1,       0,       0,       0,      &arg,
+      nullptr,        nullptr, nullptr, nullptr, nullptr};
+  cl_uint num_configs = 1;
+  cl_command_buffer_update_type_khr config_types[1] = {
+      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
+  const void *configs[1] = {&dispatch_config};
+  EXPECT_EQ_ERRCODE(CL_INVALID_ARG_SIZE,
+                    clUpdateMutableCommandsKHR(command_buffer, num_configs,
+                                               config_types, configs));
 }
 
 TEST_F(CommandBufferMutablePODArgTest, UpdateInputOnce) {
@@ -2633,25 +2360,16 @@ TEST_F(CommandBufferMutablePODArgTest, UpdateInputOnce) {
   // Now try and enqueue the command buffer updating the input value.
   const auto updated_input_value =
       ucl::Environment::instance->GetInputGenerator().GenerateInt<cl_int>();
-  const cl_mutable_dispatch_arg_khr arg{0, sizeof(cl_int),
-                                        &updated_input_value};
-  const cl_mutable_dispatch_config_khr dispatch_config{
-      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
-      nullptr,
-      command_handle,
-      1,
-      0,
-      0,
-      0,
-      &arg,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr};
-  const cl_mutable_base_config_khr mutable_config{
-      CL_STRUCTURE_TYPE_MUTABLE_BASE_CONFIG_KHR, nullptr, 1, &dispatch_config};
-  EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, &mutable_config));
+  cl_mutable_dispatch_arg_khr arg{0, sizeof(cl_int), &updated_input_value};
+  cl_mutable_dispatch_config_khr dispatch_config{
+      command_handle, 1,       0,       0,       0,      &arg,
+      nullptr,        nullptr, nullptr, nullptr, nullptr};
+  cl_uint num_configs = 1;
+  cl_command_buffer_update_type_khr config_types[1] = {
+      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
+  const void *configs[1] = {&dispatch_config};
+  EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, num_configs,
+                                            config_types, configs));
   EXPECT_SUCCESS(clEnqueueCommandBufferKHR(0, nullptr, command_buffer, 0,
                                            nullptr, nullptr));
 
@@ -2687,27 +2405,17 @@ TEST_F(CommandBufferMutablePODArgTest, UpdateInputTwice) {
   // Now try and enqueue the command buffer updating the input value.
   const auto first_updated_input_value =
       ucl::Environment::instance->GetInputGenerator().GenerateInt<cl_int>();
-  const cl_mutable_dispatch_arg_khr first_arg{0, sizeof(cl_int),
-                                              &first_updated_input_value};
-  const cl_mutable_dispatch_config_khr first_dispatch_config{
-      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
-      nullptr,
-      command_handle,
-      1,
-      0,
-      0,
-      0,
-      &first_arg,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr};
-  const cl_mutable_base_config_khr first_mutable_config{
-      CL_STRUCTURE_TYPE_MUTABLE_BASE_CONFIG_KHR, nullptr, 1,
-      &first_dispatch_config};
-  EXPECT_SUCCESS(
-      clUpdateMutableCommandsKHR(command_buffer, &first_mutable_config));
+  cl_mutable_dispatch_arg_khr first_arg{0, sizeof(cl_int),
+                                        &first_updated_input_value};
+  cl_mutable_dispatch_config_khr first_dispatch_config{
+      command_handle, 1,       0,       0,       0,      &first_arg,
+      nullptr,        nullptr, nullptr, nullptr, nullptr};
+  cl_uint first_num_configs = 1;
+  cl_command_buffer_update_type_khr first_config_types[1] = {
+      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
+  const void *first_configs[1] = {&first_dispatch_config};
+  EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, first_num_configs,
+                                            first_config_types, first_configs));
   EXPECT_SUCCESS(clEnqueueCommandBufferKHR(0, nullptr, command_buffer, 0,
                                            nullptr, nullptr));
 
@@ -2727,27 +2435,17 @@ TEST_F(CommandBufferMutablePODArgTest, UpdateInputTwice) {
   // time.
   const auto second_updated_input_value =
       ucl::Environment::instance->GetInputGenerator().GenerateInt<cl_int>();
-  const cl_mutable_dispatch_arg_khr second_arg{0, sizeof(cl_int),
-                                               &second_updated_input_value};
-  const cl_mutable_dispatch_config_khr second_dispatch_config{
-      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
-      nullptr,
-      command_handle,
-      1,
-      0,
-      0,
-      0,
-      &second_arg,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr};
-  const cl_mutable_base_config_khr second_mutable_config{
-      CL_STRUCTURE_TYPE_MUTABLE_BASE_CONFIG_KHR, nullptr, 1,
-      &second_dispatch_config};
-  EXPECT_SUCCESS(
-      clUpdateMutableCommandsKHR(command_buffer, &second_mutable_config));
+  cl_mutable_dispatch_arg_khr second_arg{0, sizeof(cl_int),
+                                         &second_updated_input_value};
+  cl_mutable_dispatch_config_khr second_dispatch_config{
+      command_handle, 1,       0,       0,       0,      &second_arg,
+      nullptr,        nullptr, nullptr, nullptr, nullptr};
+  cl_uint second_num_configs = 1;
+  cl_command_buffer_update_type_khr second_config_types[1] = {
+      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
+  const void *second_configs[1] = {&second_dispatch_config};
+  EXPECT_SUCCESS(clUpdateMutableCommandsKHR(
+      command_buffer, second_num_configs, second_config_types, second_configs));
   EXPECT_SUCCESS(clEnqueueCommandBufferKHR(0, nullptr, command_buffer, 0,
                                            nullptr, nullptr));
 
@@ -2784,25 +2482,16 @@ TEST_F(CommandBufferMutablePODArgTest, CheckUpdatePersists) {
   // Now try and enqueue the command buffer updating the input value.
   const auto updated_input_value =
       ucl::Environment::instance->GetInputGenerator().GenerateInt<cl_int>();
-  const cl_mutable_dispatch_arg_khr arg{0, sizeof(cl_int),
-                                        &updated_input_value};
-  const cl_mutable_dispatch_config_khr dispatch_config{
-      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
-      nullptr,
-      command_handle,
-      1,
-      0,
-      0,
-      0,
-      &arg,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr};
-  const cl_mutable_base_config_khr mutable_config{
-      CL_STRUCTURE_TYPE_MUTABLE_BASE_CONFIG_KHR, nullptr, 1, &dispatch_config};
-  EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, &mutable_config));
+  cl_mutable_dispatch_arg_khr arg{0, sizeof(cl_int), &updated_input_value};
+  cl_mutable_dispatch_config_khr dispatch_config{
+      command_handle, 1,       0,       0,       0,      &arg,
+      nullptr,        nullptr, nullptr, nullptr, nullptr};
+  cl_uint num_configs = 1;
+  cl_command_buffer_update_type_khr config_types[1] = {
+      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
+  const void *configs[1] = {&dispatch_config};
+  EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, num_configs,
+                                            config_types, configs));
   EXPECT_SUCCESS(clEnqueueCommandBufferKHR(0, nullptr, command_buffer, 0,
                                            nullptr, nullptr));
 
@@ -2926,25 +2615,16 @@ TEST_F(CommandBufferMultiMutablePODArgTest, UpdateSingleDispatch) {
   // first nd range only.
   const auto updated_input_value =
       ucl::Environment::instance->GetInputGenerator().GenerateInt<cl_int>();
-  const cl_mutable_dispatch_arg_khr arg{0, sizeof(cl_int),
-                                        &updated_input_value};
-  const cl_mutable_dispatch_config_khr dispatch_config{
-      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
-      nullptr,
-      command_handle,
-      1,
-      0,
-      0,
-      0,
-      &arg,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr};
-  const cl_mutable_base_config_khr mutable_config{
-      CL_STRUCTURE_TYPE_MUTABLE_BASE_CONFIG_KHR, nullptr, 1, &dispatch_config};
-  EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, &mutable_config));
+  cl_mutable_dispatch_arg_khr arg{0, sizeof(cl_int), &updated_input_value};
+  cl_mutable_dispatch_config_khr dispatch_config{
+      command_handle, 1,       0,       0,       0,      &arg,
+      nullptr,        nullptr, nullptr, nullptr, nullptr};
+  cl_uint num_configs = 1;
+  cl_command_buffer_update_type_khr config_types[1] = {
+      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
+  const void *configs[1] = {&dispatch_config};
+  EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, num_configs,
+                                            config_types, configs));
   EXPECT_SUCCESS(clEnqueueCommandBufferKHR(0, nullptr, command_buffer, 0,
                                            nullptr, nullptr));
 
@@ -2997,47 +2677,36 @@ TEST_F(CommandBufferMultiMutablePODArgTest, UpdateMultipleDispatches) {
   // ranges.
   const auto first_updated_input_value =
       ucl::Environment::instance->GetInputGenerator().GenerateInt<cl_int>();
-  const cl_mutable_dispatch_arg_khr first_arg{0, sizeof(cl_int),
-                                              &first_updated_input_value};
-  const cl_mutable_dispatch_config_khr first_dispatch_config{
-      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
-      nullptr,
-      command_handle,
-      1,
-      0,
-      0,
-      0,
-      &first_arg,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr};
+  cl_mutable_dispatch_arg_khr first_arg{0, sizeof(cl_int),
+                                        &first_updated_input_value};
+  cl_mutable_dispatch_config_khr first_dispatch_config{
+      command_handle, 1,       0,       0,       0,      &first_arg,
+      nullptr,        nullptr, nullptr, nullptr, nullptr};
 
   const auto second_updated_input_value =
       ucl::Environment::instance->GetInputGenerator().GenerateInt<cl_int>();
-  const cl_mutable_dispatch_arg_khr second_arg{0, sizeof(cl_int),
-                                               &second_updated_input_value};
-  const cl_mutable_dispatch_config_khr second_dispatch_config{
-      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
-      nullptr,
-      second_command_handle,
-      1,
-      0,
-      0,
-      0,
-      &second_arg,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr};
-  cl_mutable_dispatch_config_khr mutable_configs[]{first_dispatch_config,
-                                                   second_dispatch_config};
-  const cl_mutable_base_config_khr mutable_config{
-      CL_STRUCTURE_TYPE_MUTABLE_BASE_CONFIG_KHR, nullptr, 2, mutable_configs};
+  cl_mutable_dispatch_arg_khr second_arg{0, sizeof(cl_int),
+                                         &second_updated_input_value};
+  cl_mutable_dispatch_config_khr second_dispatch_config{second_command_handle,
+                                                        1,
+                                                        0,
+                                                        0,
+                                                        0,
+                                                        &second_arg,
+                                                        nullptr,
+                                                        nullptr,
+                                                        nullptr,
+                                                        nullptr,
+                                                        nullptr};
 
-  EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, &mutable_config));
+  cl_uint num_configs = 2;
+  cl_command_buffer_update_type_khr config_types[2] = {
+      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
+      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
+
+  const void *configs[2] = {&first_dispatch_config, &second_dispatch_config};
+  EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, num_configs,
+                                            config_types, configs));
   EXPECT_SUCCESS(clEnqueueCommandBufferKHR(0, nullptr, command_buffer, 0,
                                            nullptr, nullptr));
 
@@ -3185,23 +2854,15 @@ TEST_F(CommandBufferMutablePODMultiArgTest,
   const cl_mutable_dispatch_arg_khr arg_2{1, sizeof(cl_int),
                                           &updated_input_y_data};
   cl_mutable_dispatch_arg_khr args[] = {arg_1, arg_2};
-  const cl_mutable_dispatch_config_khr dispatch_config{
-      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
-      nullptr,
-      command_handle,
-      2,
-      0,
-      0,
-      0,
-      args,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr};
-  const cl_mutable_base_config_khr mutable_config{
-      CL_STRUCTURE_TYPE_MUTABLE_BASE_CONFIG_KHR, nullptr, 1, &dispatch_config};
-  EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, &mutable_config));
+  cl_mutable_dispatch_config_khr dispatch_config{
+      command_handle, 2,       0,       0,       0,      args,
+      nullptr,        nullptr, nullptr, nullptr, nullptr};
+  cl_uint num_configs = 1;
+  cl_command_buffer_update_type_khr config_types[1] = {
+      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
+  const void *configs[1] = {&dispatch_config};
+  EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, num_configs,
+                                            config_types, configs));
   EXPECT_SUCCESS(clEnqueueCommandBufferKHR(0, nullptr, command_buffer, 0,
                                            nullptr, nullptr));
   // Check the results.
@@ -3240,43 +2901,21 @@ TEST_F(CommandBufferMutablePODMultiArgTest,
   cl_int updated_input_y_data =
       ucl::Environment::instance->GetInputGenerator().GenerateInt<cl_int>();
 
-  const cl_mutable_dispatch_arg_khr arg_1{0, sizeof(cl_int),
-                                          &updated_input_x_data};
-  const cl_mutable_dispatch_arg_khr arg_2{1, sizeof(cl_int),
-                                          &updated_input_y_data};
-  const cl_mutable_dispatch_config_khr dispatch_config_1{
+  cl_mutable_dispatch_arg_khr arg_1{0, sizeof(cl_int), &updated_input_x_data};
+  cl_mutable_dispatch_arg_khr arg_2{1, sizeof(cl_int), &updated_input_y_data};
+  cl_mutable_dispatch_config_khr dispatch_config_1{
+      command_handle, 1,       0,       0,       0,      &arg_1,
+      nullptr,        nullptr, nullptr, nullptr, nullptr};
+  cl_mutable_dispatch_config_khr dispatch_config_2{
+      command_handle, 1,       0,       0,       0,      &arg_2,
+      nullptr,        nullptr, nullptr, nullptr, nullptr};
+  cl_uint num_configs = 2;
+  cl_command_buffer_update_type_khr config_types[2] = {
       CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
-      nullptr,
-      command_handle,
-      1,
-      0,
-      0,
-      0,
-      &arg_1,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr};
-  const cl_mutable_dispatch_config_khr dispatch_config_2{
-      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
-      nullptr,
-      command_handle,
-      1,
-      0,
-      0,
-      0,
-      &arg_2,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr};
-  cl_mutable_dispatch_config_khr dispatch_configs[]{dispatch_config_1,
-                                                    dispatch_config_2};
-  const cl_mutable_base_config_khr mutable_config{
-      CL_STRUCTURE_TYPE_MUTABLE_BASE_CONFIG_KHR, nullptr, 2, dispatch_configs};
-  EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, &mutable_config));
+      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
+  const void *configs[2] = {&dispatch_config_1, &dispatch_config_2};
+  EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, num_configs,
+                                            config_types, configs));
   EXPECT_SUCCESS(clEnqueueCommandBufferKHR(0, nullptr, command_buffer, 0,
                                            nullptr, nullptr));
   // Check the results.
@@ -3379,24 +3018,16 @@ TEST_F(CommandBufferMutableStructArgTest, UpdateInputOnce) {
 
   // Now try and enqueue the command buffer updating the output buffer.
   const test_struct second_value{99, 42.0f, 'j'};
-  const cl_mutable_dispatch_arg_khr arg{0, sizeof(test_struct), &second_value};
-  const cl_mutable_dispatch_config_khr dispatch_config{
-      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
-      nullptr,
-      command_handle,
-      1,
-      0,
-      0,
-      0,
-      &arg,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr};
-  const cl_mutable_base_config_khr mutable_config{
-      CL_STRUCTURE_TYPE_MUTABLE_BASE_CONFIG_KHR, nullptr, 1, &dispatch_config};
-  EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, &mutable_config));
+  cl_mutable_dispatch_arg_khr arg{0, sizeof(test_struct), &second_value};
+  cl_mutable_dispatch_config_khr dispatch_config{
+      command_handle, 1,       0,       0,       0,      &arg,
+      nullptr,        nullptr, nullptr, nullptr, nullptr};
+  cl_uint num_configs = 1;
+  cl_command_buffer_update_type_khr config_types[1] = {
+      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
+  const void *configs[1] = {&dispatch_config};
+  EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, num_configs,
+                                            config_types, configs));
   EXPECT_SUCCESS(clEnqueueCommandBufferKHR(0, nullptr, command_buffer, 0,
                                            nullptr, nullptr));
   // Check the results.

--- a/source/cl/test/UnitCL/source/cl_khr_command_buffer_mutable_dispatch/clEnqueueCommandBufferKHRMutability.cpp
+++ b/source/cl/test/UnitCL/source/cl_khr_command_buffer_mutable_dispatch/clEnqueueCommandBufferKHRMutability.cpp
@@ -140,12 +140,12 @@ TEST_F(CommandBufferMutableBufferArgTest, UpdateOutputBufferOnce) {
 
   // Now try and enqueue the command buffer updating the output buffer.
   const cl_mutable_dispatch_arg_khr arg{1, sizeof(cl_mem), &updated_dst_buffer};
-  cl_mutable_dispatch_config_khr dispatch_config{
+  const cl_mutable_dispatch_config_khr dispatch_config{
       command_handle, 1,       0,       0,       0,      &arg,
       nullptr,        nullptr, nullptr, nullptr, nullptr};
 
   const cl_uint num_configs = 1;
-  cl_command_buffer_update_type_khr config_types[1] = {
+  const cl_command_buffer_update_type_khr config_types[1] = {
       CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
   const void *configs[1] = {&dispatch_config};
   EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, num_configs,
@@ -202,12 +202,12 @@ TEST_F(CommandBufferMutableBufferArgTest, UpdateOutputBufferTwice) {
   // Now try and enqueue the command buffer updating the output buffer.
   const cl_mutable_dispatch_arg_khr first_arg{1, sizeof(cl_mem),
                                               &first_updated_dst_buffer};
-  cl_mutable_dispatch_config_khr first_dispatch_config{
+  const cl_mutable_dispatch_config_khr first_dispatch_config{
       command_handle, 1,       0,       0,       0,      &first_arg,
       nullptr,        nullptr, nullptr, nullptr, nullptr};
 
   const cl_uint first_num_configs = 1;
-  cl_command_buffer_update_type_khr first_config_types[1] = {
+  const cl_command_buffer_update_type_khr first_config_types[1] = {
       CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
   const void *first_configs[1] = {&first_dispatch_config};
   EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, first_num_configs,
@@ -228,11 +228,11 @@ TEST_F(CommandBufferMutableBufferArgTest, UpdateOutputBufferTwice) {
   // Enqueue the command buffer again updating the output buffer a second time.
   const cl_mutable_dispatch_arg_khr second_arg{1, sizeof(cl_mem),
                                                &second_updated_dst_buffer};
-  cl_mutable_dispatch_config_khr second_dispatch_config{
+  const cl_mutable_dispatch_config_khr second_dispatch_config{
       command_handle, 1,       0,       0,       0,      &second_arg,
       nullptr,        nullptr, nullptr, nullptr, nullptr};
   const cl_uint second_num_configs = 1;
-  cl_command_buffer_update_type_khr second_config_types[1] = {
+  const cl_command_buffer_update_type_khr second_config_types[1] = {
       CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
   const void *second_configs[1] = {&second_dispatch_config};
   EXPECT_SUCCESS(clUpdateMutableCommandsKHR(
@@ -292,11 +292,11 @@ TEST_F(CommandBufferMutableBufferArgTest, UpdateInputBufferOnce) {
 
   // Now try and enqueue the command buffer updating the input buffer.
   const cl_mutable_dispatch_arg_khr arg{0, sizeof(cl_mem), &updated_src_buffer};
-  cl_mutable_dispatch_config_khr dispatch_config{
+  const cl_mutable_dispatch_config_khr dispatch_config{
       command_handle, 1,       0,       0,       0,      &arg,
       nullptr,        nullptr, nullptr, nullptr, nullptr};
   const cl_uint num_configs = 1;
-  cl_command_buffer_update_type_khr config_types[1] = {
+  const cl_command_buffer_update_type_khr config_types[1] = {
       CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
   const void *configs[1] = {&dispatch_config};
   EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, num_configs,
@@ -367,11 +367,11 @@ TEST_F(CommandBufferMutableBufferArgTest, UpdateInputBufferTwice) {
   // Now try and enqueue the command buffer updating the input buffer.
   const cl_mutable_dispatch_arg_khr first_arg{0, sizeof(cl_mem),
                                               &first_updated_src_buffer};
-  cl_mutable_dispatch_config_khr first_dispatch_config{
+  const cl_mutable_dispatch_config_khr first_dispatch_config{
       command_handle, 1,       0,       0,       0,      &first_arg,
       nullptr,        nullptr, nullptr, nullptr, nullptr};
   const cl_uint first_num_configs = 1;
-  cl_command_buffer_update_type_khr first_config_types[1] = {
+  const cl_command_buffer_update_type_khr first_config_types[1] = {
       CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
   const void *first_configs[1] = {&first_dispatch_config};
   EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, first_num_configs,
@@ -392,11 +392,11 @@ TEST_F(CommandBufferMutableBufferArgTest, UpdateInputBufferTwice) {
   // Enqueue the command buffer a second time updating the input bufer again.
   const cl_mutable_dispatch_arg_khr second_arg{0, sizeof(cl_mem),
                                                &second_updated_src_buffer};
-  cl_mutable_dispatch_config_khr second_dispatch_config{
+  const cl_mutable_dispatch_config_khr second_dispatch_config{
       command_handle, 1,       0,       0,       0,      &second_arg,
       nullptr,        nullptr, nullptr, nullptr, nullptr};
   const cl_uint second_num_configs = 1;
-  cl_command_buffer_update_type_khr second_config_types[1] = {
+  const cl_command_buffer_update_type_khr second_config_types[1] = {
       CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
   const void *second_configs[1] = {&second_dispatch_config};
   EXPECT_SUCCESS(clUpdateMutableCommandsKHR(
@@ -466,11 +466,11 @@ TEST_F(CommandBufferMutableBufferArgTest,
   const cl_mutable_dispatch_arg_khr arg_2{1, sizeof(cl_mem),
                                           &updated_dst_buffer};
   const cl_mutable_dispatch_arg_khr args[] = {arg_1, arg_2};
-  cl_mutable_dispatch_config_khr dispatch_config{
+  const cl_mutable_dispatch_config_khr dispatch_config{
       command_handle, 2,       0,       0,       0,      args,
       nullptr,        nullptr, nullptr, nullptr, nullptr};
   const cl_uint num_configs = 1;
-  cl_command_buffer_update_type_khr config_types[1] = {
+  const cl_command_buffer_update_type_khr config_types[1] = {
       CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
   const void *configs[1] = {&dispatch_config};
   EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, num_configs,
@@ -539,14 +539,14 @@ TEST_F(CommandBufferMutableBufferArgTest,
                                           &updated_src_buffer};
   const cl_mutable_dispatch_arg_khr arg_2{1, sizeof(cl_mem),
                                           &updated_dst_buffer};
-  cl_mutable_dispatch_config_khr dispatch_config_1{
+  const cl_mutable_dispatch_config_khr dispatch_config_1{
       command_handle, 1,       0,       0,       0,      &arg_1,
       nullptr,        nullptr, nullptr, nullptr, nullptr};
-  cl_mutable_dispatch_config_khr dispatch_config_2{
+  const cl_mutable_dispatch_config_khr dispatch_config_2{
       command_handle, 1,       0,       0,       0,      &arg_2,
       nullptr,        nullptr, nullptr, nullptr, nullptr};
   const cl_uint num_configs = 2;
-  cl_command_buffer_update_type_khr config_types[2] = {
+  const cl_command_buffer_update_type_khr config_types[2] = {
       CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
       CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
   const void *configs[2] = {&dispatch_config_1, &dispatch_config_2};
@@ -611,11 +611,11 @@ TEST_F(CommandBufferMutableBufferArgTest, UpdateToBiggerBufferSize) {
 
   // Now try and enqueue the command buffer updating the output buffer.
   const cl_mutable_dispatch_arg_khr arg{1, sizeof(cl_mem), &updated_dst_buffer};
-  cl_mutable_dispatch_config_khr dispatch_config{
+  const cl_mutable_dispatch_config_khr dispatch_config{
       command_handle, 1,       0,       0,       0,      &arg,
       nullptr,        nullptr, nullptr, nullptr, nullptr};
   const cl_uint num_configs = 1;
-  cl_command_buffer_update_type_khr config_types[1] = {
+  const cl_command_buffer_update_type_khr config_types[1] = {
       CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
   const void *configs[1] = {&dispatch_config};
   EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, num_configs,
@@ -672,11 +672,11 @@ TEST_F(CommandBufferMutableBufferArgTest, CheckUpdatePersists) {
 
   // Now try and enqueue the command buffer updating the output buffer.
   const cl_mutable_dispatch_arg_khr arg{1, sizeof(cl_mem), &updated_dst_buffer};
-  cl_mutable_dispatch_config_khr dispatch_config{
+  const cl_mutable_dispatch_config_khr dispatch_config{
       command_handle, 1,       0,       0,       0,      &arg,
       nullptr,        nullptr, nullptr, nullptr, nullptr};
   const cl_uint num_configs = 1;
-  cl_command_buffer_update_type_khr config_types[1] = {
+  const cl_command_buffer_update_type_khr config_types[1] = {
       CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
   const void *configs[1] = {&dispatch_config};
   EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, num_configs,
@@ -762,11 +762,11 @@ TEST_F(CommandBufferMutableBufferArgTest, FillThenNDRange) {
 
   // Now try and enqueue the command buffer updating the output buffer.
   const cl_mutable_dispatch_arg_khr arg{1, sizeof(cl_mem), &updated_dst_buffer};
-  cl_mutable_dispatch_config_khr dispatch_config{
+  const cl_mutable_dispatch_config_khr dispatch_config{
       command_handle, 1,       0,       0,       0,      &arg,
       nullptr,        nullptr, nullptr, nullptr, nullptr};
   const cl_uint num_configs = 1;
-  cl_command_buffer_update_type_khr config_types[1] = {
+  const cl_command_buffer_update_type_khr config_types[1] = {
       CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
   const void *configs[1] = {&dispatch_config};
   EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, num_configs,
@@ -832,11 +832,11 @@ TEST_F(CommandBufferMutableBufferArgTest, NDRangeThenFill) {
 
   // Now try and enqueue the command buffer updating the output buffer.
   const cl_mutable_dispatch_arg_khr arg{1, sizeof(cl_mem), &updated_dst_buffer};
-  cl_mutable_dispatch_config_khr dispatch_config{
+  const cl_mutable_dispatch_config_khr dispatch_config{
       command_handle, 1,       0,       0,       0,      &arg,
       nullptr,        nullptr, nullptr, nullptr, nullptr};
   const cl_uint num_configs = 1;
-  cl_command_buffer_update_type_khr config_types[1] = {
+  const cl_command_buffer_update_type_khr config_types[1] = {
       CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
   const void *configs[1] = {&dispatch_config};
   EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, num_configs,
@@ -905,11 +905,11 @@ TEST_F(CommandBufferMutableBufferArgTest, FillTwiceThenNDRange) {
 
   // Now try and enqueue the command buffer updating the output buffer.
   const cl_mutable_dispatch_arg_khr arg{1, sizeof(cl_mem), &updated_dst_buffer};
-  cl_mutable_dispatch_config_khr dispatch_config{
+  const cl_mutable_dispatch_config_khr dispatch_config{
       command_handle, 1,       0,       0,       0,      &arg,
       nullptr,        nullptr, nullptr, nullptr, nullptr};
   const cl_uint num_configs = 1;
-  cl_command_buffer_update_type_khr config_types[1] = {
+  const cl_command_buffer_update_type_khr config_types[1] = {
       CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
   const void *configs[1] = {&dispatch_config};
   EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, num_configs,
@@ -977,11 +977,11 @@ TEST_F(CommandBufferMutableBufferArgTest, CopyBufferThenNDRange) {
 
   // Now try and enqueue the command buffer updating the output buffer.
   const cl_mutable_dispatch_arg_khr arg{1, sizeof(cl_mem), &updated_dst_buffer};
-  cl_mutable_dispatch_config_khr dispatch_config{
+  const cl_mutable_dispatch_config_khr dispatch_config{
       command_handle, 1,       0,       0,       0,      &arg,
       nullptr,        nullptr, nullptr, nullptr, nullptr};
   const cl_uint num_configs = 1;
-  cl_command_buffer_update_type_khr config_types[1] = {
+  const cl_command_buffer_update_type_khr config_types[1] = {
       CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
   const void *configs[1] = {&dispatch_config};
   EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, num_configs,
@@ -1051,11 +1051,11 @@ TEST_F(CommandBufferMutableBufferArgTest, CopyBufferRectThenNDRange) {
 
   // Now try and enqueue the command buffer updating the output buffer.
   const cl_mutable_dispatch_arg_khr arg{1, sizeof(cl_mem), &updated_dst_buffer};
-  cl_mutable_dispatch_config_khr dispatch_config{
+  const cl_mutable_dispatch_config_khr dispatch_config{
       command_handle, 1,       0,       0,       0,      &arg,
       nullptr,        nullptr, nullptr, nullptr, nullptr};
   const cl_uint num_configs = 1;
-  cl_command_buffer_update_type_khr config_types[1] = {
+  const cl_command_buffer_update_type_khr config_types[1] = {
       CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
   const void *configs[1] = {&dispatch_config};
   EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, num_configs,
@@ -1132,11 +1132,11 @@ TEST_F(CommandBufferMutableBufferArgTest, RegularNDRangeThenMutableNDRange) {
 
   // Now try and enqueue the command buffer updating the output buffer.
   const cl_mutable_dispatch_arg_khr arg{1, sizeof(cl_mem), &updated_dst_buffer};
-  cl_mutable_dispatch_config_khr dispatch_config{
+  const cl_mutable_dispatch_config_khr dispatch_config{
       command_handle, 1,       0,       0,       0,      &arg,
       nullptr,        nullptr, nullptr, nullptr, nullptr};
   const cl_uint num_configs = 1;
-  cl_command_buffer_update_type_khr config_types[1] = {
+  const cl_command_buffer_update_type_khr config_types[1] = {
       CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
   const void *configs[1] = {&dispatch_config};
   EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, num_configs,
@@ -1278,11 +1278,11 @@ TEST_F(CommandBufferMultiMutableBufferArgTest, UpdateSingleDispatch) {
   // Now try and enqueue the command buffer updating the output buffer of the
   // first nd range.
   const cl_mutable_dispatch_arg_khr arg{0, sizeof(cl_mem), &updated_src_buffer};
-  cl_mutable_dispatch_config_khr dispatch_config{
+  const cl_mutable_dispatch_config_khr dispatch_config{
       command_handle, 1,       0,       0,       0,      &arg,
       nullptr,        nullptr, nullptr, nullptr, nullptr};
   const cl_uint num_configs = 1;
-  cl_command_buffer_update_type_khr config_types[1] = {
+  const cl_command_buffer_update_type_khr config_types[1] = {
       CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
   const void *configs[1] = {&dispatch_config};
   EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, num_configs,
@@ -1359,26 +1359,27 @@ TEST_F(CommandBufferMultiMutableBufferArgTest, UpdateMultipleDispatches) {
   // nd ranges.
   const cl_mutable_dispatch_arg_khr first_arg{0, sizeof(cl_mem),
                                               &first_updated_src_buffer};
-  cl_mutable_dispatch_config_khr first_dispatch_config{
+  const cl_mutable_dispatch_config_khr first_dispatch_config{
       command_handle, 1,       0,       0,       0,      &first_arg,
       nullptr,        nullptr, nullptr, nullptr, nullptr};
 
   const cl_mutable_dispatch_arg_khr second_arg{0, sizeof(cl_mem),
                                                &second_updated_src_buffer};
-  cl_mutable_dispatch_config_khr second_dispatch_config{second_command_handle,
-                                                        1,
-                                                        0,
-                                                        0,
-                                                        0,
-                                                        &second_arg,
-                                                        nullptr,
-                                                        nullptr,
-                                                        nullptr,
-                                                        nullptr,
-                                                        nullptr};
+  const cl_mutable_dispatch_config_khr second_dispatch_config{
+      second_command_handle,
+      1,
+      0,
+      0,
+      0,
+      &second_arg,
+      nullptr,
+      nullptr,
+      nullptr,
+      nullptr,
+      nullptr};
 
   const cl_uint num_configs = 2;
-  cl_command_buffer_update_type_khr config_types[2] = {
+  const cl_command_buffer_update_type_khr config_types[2] = {
       CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
       CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
   const void *configs[2] = {&first_dispatch_config, &second_dispatch_config};
@@ -1502,11 +1503,11 @@ TEST_F(MutableDispatchTest, UpdateConstantBuffer) {
 
   // Now try and enqueue the command buffer updating the input buffer.
   const cl_mutable_dispatch_arg_khr arg{0, sizeof(cl_mem), &updated_src_buffer};
-  cl_mutable_dispatch_config_khr dispatch_config{
+  const cl_mutable_dispatch_config_khr dispatch_config{
       command_handle, 1,       0,       0,       0,      &arg,
       nullptr,        nullptr, nullptr, nullptr, nullptr};
   const cl_uint num_configs = 1;
-  cl_command_buffer_update_type_khr config_types[1] = {
+  const cl_command_buffer_update_type_khr config_types[1] = {
       CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
   const void *configs[1] = {&dispatch_config};
   EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, num_configs,
@@ -1609,11 +1610,11 @@ TEST_F(CommandBufferMutableLocalBufferArgTest, UpdateOnce) {
 
   // Update the local buffer size.
   const cl_mutable_dispatch_arg_khr arg{0, 32, nullptr};
-  cl_mutable_dispatch_config_khr dispatch_config{
+  const cl_mutable_dispatch_config_khr dispatch_config{
       command_handle, 1,       0,       0,       0,      &arg,
       nullptr,        nullptr, nullptr, nullptr, nullptr};
   const cl_uint num_configs = 1;
-  cl_command_buffer_update_type_khr config_types[1] = {
+  const cl_command_buffer_update_type_khr config_types[1] = {
       CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
   const void *configs[1] = {&dispatch_config};
   EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, num_configs,
@@ -1632,11 +1633,11 @@ TEST_F(CommandBufferMutableLocalBufferArgTest, UpdateTwice) {
 
   // Update the local buffer size.
   const cl_mutable_dispatch_arg_khr arg{0, 32, nullptr};
-  cl_mutable_dispatch_config_khr dispatch_config{
+  const cl_mutable_dispatch_config_khr dispatch_config{
       command_handle, 1,       0,       0,       0,      &arg,
       nullptr,        nullptr, nullptr, nullptr, nullptr};
   const cl_uint num_configs = 1;
-  cl_command_buffer_update_type_khr config_types[1] = {
+  const cl_command_buffer_update_type_khr config_types[1] = {
       CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
   const void *configs[1] = {&dispatch_config};
   EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, num_configs,
@@ -1649,11 +1650,11 @@ TEST_F(CommandBufferMutableLocalBufferArgTest, UpdateTwice) {
 
   // Update the local buffer size a second time.
   const cl_mutable_dispatch_arg_khr arg_2{0, 32, nullptr};
-  cl_mutable_dispatch_config_khr dispatch_config_2{
+  const cl_mutable_dispatch_config_khr dispatch_config_2{
       command_handle, 1,       0,       0,       0,      &arg_2,
       nullptr,        nullptr, nullptr, nullptr, nullptr};
   const cl_uint num_configs_2 = 1;
-  cl_command_buffer_update_type_khr config_types_2[1] = {
+  const cl_command_buffer_update_type_khr config_types_2[1] = {
       CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
   const void *configs_2[1] = {&dispatch_config_2};
   EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, num_configs_2,
@@ -1788,11 +1789,11 @@ TEST_F(DISABLED_CommandBufferMutableNullArgTest,
 
   // Update the input to null and enqueue a second time.
   const cl_mutable_dispatch_arg_khr arg{0, sizeof(cl_mem), nullptr};
-  cl_mutable_dispatch_config_khr dispatch_config{
+  const cl_mutable_dispatch_config_khr dispatch_config{
       command_handle, 1,       0,       0,       0,      &arg,
       nullptr,        nullptr, nullptr, nullptr, nullptr};
   const cl_uint num_configs = 1;
-  cl_command_buffer_update_type_khr config_types[1] = {
+  const cl_command_buffer_update_type_khr config_types[1] = {
       CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
   const void *configs[1] = {&dispatch_config};
   EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, num_configs,
@@ -1845,11 +1846,11 @@ TEST_F(DISABLED_CommandBufferMutableNullArgTest,
   // Update the input to pointer to null.
   const cl_int *null = nullptr;
   const cl_mutable_dispatch_arg_khr arg{0, sizeof(cl_mem), &null};
-  cl_mutable_dispatch_config_khr dispatch_config{
+  const cl_mutable_dispatch_config_khr dispatch_config{
       command_handle, 1,       0,       0,       0,      &arg,
       nullptr,        nullptr, nullptr, nullptr, nullptr};
   const cl_uint num_configs = 1;
-  cl_command_buffer_update_type_khr config_types[1] = {
+  const cl_command_buffer_update_type_khr config_types[1] = {
       CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
   const void *configs[1] = {&dispatch_config};
   EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, num_configs,
@@ -1900,11 +1901,11 @@ TEST_F(DISABLED_CommandBufferMutableNullArgTest,
 
   // Update the input to null.
   const cl_mutable_dispatch_arg_khr arg{0, sizeof(cl_mem), &src_buffer};
-  cl_mutable_dispatch_config_khr dispatch_config{
+  const cl_mutable_dispatch_config_khr dispatch_config{
       command_handle, 1,       0,       0,       0,      &arg,
       nullptr,        nullptr, nullptr, nullptr, nullptr};
   const cl_uint num_configs = 1;
-  cl_command_buffer_update_type_khr config_types[1] = {
+  const cl_command_buffer_update_type_khr config_types[1] = {
       CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
   const void *configs[1] = {&dispatch_config};
   EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, num_configs,
@@ -1956,11 +1957,11 @@ TEST_F(DISABLED_CommandBufferMutableNullArgTest,
 
   // Update the input to null.
   const cl_mutable_dispatch_arg_khr arg{0, sizeof(cl_mem), &src_buffer};
-  cl_mutable_dispatch_config_khr dispatch_config{
+  const cl_mutable_dispatch_config_khr dispatch_config{
       command_handle, 1,       0,       0,       0,      &arg,
       nullptr,        nullptr, nullptr, nullptr, nullptr};
   const cl_uint num_configs = 1;
-  cl_command_buffer_update_type_khr config_types[1] = {
+  const cl_command_buffer_update_type_khr config_types[1] = {
       CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
   const void *configs[1] = {&dispatch_config};
   EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, num_configs,
@@ -2009,11 +2010,11 @@ TEST_F(DISABLED_CommandBufferMutableNullArgTest, CheckUpdatePersists) {
 
   // Update the input to null and enqueue a second time.
   const cl_mutable_dispatch_arg_khr arg{0, sizeof(cl_mem), nullptr};
-  cl_mutable_dispatch_config_khr dispatch_config{
+  const cl_mutable_dispatch_config_khr dispatch_config{
       command_handle, 1,       0,       0,       0,      &arg,
       nullptr,        nullptr, nullptr, nullptr, nullptr};
   const cl_uint num_configs = 1;
-  cl_command_buffer_update_type_khr config_types[1] = {
+  const cl_command_buffer_update_type_khr config_types[1] = {
       CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
   const void *configs[1] = {&dispatch_config};
   EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, num_configs,
@@ -2143,11 +2144,11 @@ TEST_F(DISABLED_CommandBufferMultiMutableNullArgTest, UpdateSingleDispatch) {
 
   // Update the input of the first nd range to null and enqueue a second time.
   const cl_mutable_dispatch_arg_khr arg{0, sizeof(cl_mem), nullptr};
-  cl_mutable_dispatch_config_khr dispatch_config{
+  const cl_mutable_dispatch_config_khr dispatch_config{
       command_handle, 1,       0,       0,       0,      &arg,
       nullptr,        nullptr, nullptr, nullptr, nullptr};
   const cl_uint num_configs = 1;
-  cl_command_buffer_update_type_khr config_types[1] = {
+  const cl_command_buffer_update_type_khr config_types[1] = {
       CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
   const void *configs[1] = {&dispatch_config};
   EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, num_configs,
@@ -2192,25 +2193,26 @@ TEST_F(DISABLED_CommandBufferMultiMutableNullArgTest,
 
   // Update the input of both nd ranges to null and enqueue a second time.
   const cl_mutable_dispatch_arg_khr first_arg{0, sizeof(cl_mem), nullptr};
-  cl_mutable_dispatch_config_khr first_dispatch_config{
+  const cl_mutable_dispatch_config_khr first_dispatch_config{
       command_handle, 1,       0,       0,       0,      &first_arg,
       nullptr,        nullptr, nullptr, nullptr, nullptr};
 
   const cl_mutable_dispatch_arg_khr second_arg{0, sizeof(cl_mem), nullptr};
-  cl_mutable_dispatch_config_khr second_dispatch_config{second_command_handle,
-                                                        1,
-                                                        0,
-                                                        0,
-                                                        0,
-                                                        &second_arg,
-                                                        nullptr,
-                                                        nullptr,
-                                                        nullptr,
-                                                        nullptr,
-                                                        nullptr};
+  const cl_mutable_dispatch_config_khr second_dispatch_config{
+      second_command_handle,
+      1,
+      0,
+      0,
+      0,
+      &second_arg,
+      nullptr,
+      nullptr,
+      nullptr,
+      nullptr,
+      nullptr};
 
   const cl_uint num_configs = 2;
-  cl_command_buffer_update_type_khr config_types[2] = {
+  const cl_command_buffer_update_type_khr config_types[2] = {
       CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
       CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
   const void *configs[2] = {&first_dispatch_config, &second_dispatch_config};
@@ -2328,11 +2330,11 @@ TEST_F(CommandBufferMutablePODArgTest, InvalidArgSize) {
       ucl::Environment::instance->GetInputGenerator().GenerateInt<cl_int>();
   const cl_mutable_dispatch_arg_khr arg{0, sizeof(cl_int4),
                                         &updated_input_value};
-  cl_mutable_dispatch_config_khr dispatch_config{
+  const cl_mutable_dispatch_config_khr dispatch_config{
       command_handle, 1,       0,       0,       0,      &arg,
       nullptr,        nullptr, nullptr, nullptr, nullptr};
   const cl_uint num_configs = 1;
-  cl_command_buffer_update_type_khr config_types[1] = {
+  const cl_command_buffer_update_type_khr config_types[1] = {
       CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
   const void *configs[1] = {&dispatch_config};
   EXPECT_EQ_ERRCODE(CL_INVALID_ARG_SIZE,
@@ -2365,11 +2367,11 @@ TEST_F(CommandBufferMutablePODArgTest, UpdateInputOnce) {
       ucl::Environment::instance->GetInputGenerator().GenerateInt<cl_int>();
   const cl_mutable_dispatch_arg_khr arg{0, sizeof(cl_int),
                                         &updated_input_value};
-  cl_mutable_dispatch_config_khr dispatch_config{
+  const cl_mutable_dispatch_config_khr dispatch_config{
       command_handle, 1,       0,       0,       0,      &arg,
       nullptr,        nullptr, nullptr, nullptr, nullptr};
   const cl_uint num_configs = 1;
-  cl_command_buffer_update_type_khr config_types[1] = {
+  const cl_command_buffer_update_type_khr config_types[1] = {
       CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
   const void *configs[1] = {&dispatch_config};
   EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, num_configs,
@@ -2411,11 +2413,11 @@ TEST_F(CommandBufferMutablePODArgTest, UpdateInputTwice) {
       ucl::Environment::instance->GetInputGenerator().GenerateInt<cl_int>();
   const cl_mutable_dispatch_arg_khr first_arg{0, sizeof(cl_int),
                                               &first_updated_input_value};
-  cl_mutable_dispatch_config_khr first_dispatch_config{
+  const cl_mutable_dispatch_config_khr first_dispatch_config{
       command_handle, 1,       0,       0,       0,      &first_arg,
       nullptr,        nullptr, nullptr, nullptr, nullptr};
   const cl_uint first_num_configs = 1;
-  cl_command_buffer_update_type_khr first_config_types[1] = {
+  const cl_command_buffer_update_type_khr first_config_types[1] = {
       CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
   const void *first_configs[1] = {&first_dispatch_config};
   EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, first_num_configs,
@@ -2441,11 +2443,11 @@ TEST_F(CommandBufferMutablePODArgTest, UpdateInputTwice) {
       ucl::Environment::instance->GetInputGenerator().GenerateInt<cl_int>();
   const cl_mutable_dispatch_arg_khr second_arg{0, sizeof(cl_int),
                                                &second_updated_input_value};
-  cl_mutable_dispatch_config_khr second_dispatch_config{
+  const cl_mutable_dispatch_config_khr second_dispatch_config{
       command_handle, 1,       0,       0,       0,      &second_arg,
       nullptr,        nullptr, nullptr, nullptr, nullptr};
   const cl_uint second_num_configs = 1;
-  cl_command_buffer_update_type_khr second_config_types[1] = {
+  const cl_command_buffer_update_type_khr second_config_types[1] = {
       CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
   const void *second_configs[1] = {&second_dispatch_config};
   EXPECT_SUCCESS(clUpdateMutableCommandsKHR(
@@ -2488,11 +2490,11 @@ TEST_F(CommandBufferMutablePODArgTest, CheckUpdatePersists) {
       ucl::Environment::instance->GetInputGenerator().GenerateInt<cl_int>();
   const cl_mutable_dispatch_arg_khr arg{0, sizeof(cl_int),
                                         &updated_input_value};
-  cl_mutable_dispatch_config_khr dispatch_config{
+  const cl_mutable_dispatch_config_khr dispatch_config{
       command_handle, 1,       0,       0,       0,      &arg,
       nullptr,        nullptr, nullptr, nullptr, nullptr};
   const cl_uint num_configs = 1;
-  cl_command_buffer_update_type_khr config_types[1] = {
+  const cl_command_buffer_update_type_khr config_types[1] = {
       CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
   const void *configs[1] = {&dispatch_config};
   EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, num_configs,
@@ -2622,11 +2624,11 @@ TEST_F(CommandBufferMultiMutablePODArgTest, UpdateSingleDispatch) {
       ucl::Environment::instance->GetInputGenerator().GenerateInt<cl_int>();
   const cl_mutable_dispatch_arg_khr arg{0, sizeof(cl_int),
                                         &updated_input_value};
-  cl_mutable_dispatch_config_khr dispatch_config{
+  const cl_mutable_dispatch_config_khr dispatch_config{
       command_handle, 1,       0,       0,       0,      &arg,
       nullptr,        nullptr, nullptr, nullptr, nullptr};
   const cl_uint num_configs = 1;
-  cl_command_buffer_update_type_khr config_types[1] = {
+  const cl_command_buffer_update_type_khr config_types[1] = {
       CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
   const void *configs[1] = {&dispatch_config};
   EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, num_configs,
@@ -2685,7 +2687,7 @@ TEST_F(CommandBufferMultiMutablePODArgTest, UpdateMultipleDispatches) {
       ucl::Environment::instance->GetInputGenerator().GenerateInt<cl_int>();
   const cl_mutable_dispatch_arg_khr first_arg{0, sizeof(cl_int),
                                               &first_updated_input_value};
-  cl_mutable_dispatch_config_khr first_dispatch_config{
+  const cl_mutable_dispatch_config_khr first_dispatch_config{
       command_handle, 1,       0,       0,       0,      &first_arg,
       nullptr,        nullptr, nullptr, nullptr, nullptr};
 
@@ -2693,20 +2695,21 @@ TEST_F(CommandBufferMultiMutablePODArgTest, UpdateMultipleDispatches) {
       ucl::Environment::instance->GetInputGenerator().GenerateInt<cl_int>();
   const cl_mutable_dispatch_arg_khr second_arg{0, sizeof(cl_int),
                                                &second_updated_input_value};
-  cl_mutable_dispatch_config_khr second_dispatch_config{second_command_handle,
-                                                        1,
-                                                        0,
-                                                        0,
-                                                        0,
-                                                        &second_arg,
-                                                        nullptr,
-                                                        nullptr,
-                                                        nullptr,
-                                                        nullptr,
-                                                        nullptr};
+  const cl_mutable_dispatch_config_khr second_dispatch_config{
+      second_command_handle,
+      1,
+      0,
+      0,
+      0,
+      &second_arg,
+      nullptr,
+      nullptr,
+      nullptr,
+      nullptr,
+      nullptr};
 
   const cl_uint num_configs = 2;
-  cl_command_buffer_update_type_khr config_types[2] = {
+  const cl_command_buffer_update_type_khr config_types[2] = {
       CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
       CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
 
@@ -2860,11 +2863,11 @@ TEST_F(CommandBufferMutablePODMultiArgTest,
   const cl_mutable_dispatch_arg_khr arg_2{1, sizeof(cl_int),
                                           &updated_input_y_data};
   const cl_mutable_dispatch_arg_khr args[] = {arg_1, arg_2};
-  cl_mutable_dispatch_config_khr dispatch_config{
+  const cl_mutable_dispatch_config_khr dispatch_config{
       command_handle, 2,       0,       0,       0,      args,
       nullptr,        nullptr, nullptr, nullptr, nullptr};
   const cl_uint num_configs = 1;
-  cl_command_buffer_update_type_khr config_types[1] = {
+  const cl_command_buffer_update_type_khr config_types[1] = {
       CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
   const void *configs[1] = {&dispatch_config};
   EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, num_configs,
@@ -2911,14 +2914,14 @@ TEST_F(CommandBufferMutablePODMultiArgTest,
                                           &updated_input_x_data};
   const cl_mutable_dispatch_arg_khr arg_2{1, sizeof(cl_int),
                                           &updated_input_y_data};
-  cl_mutable_dispatch_config_khr dispatch_config_1{
+  const cl_mutable_dispatch_config_khr dispatch_config_1{
       command_handle, 1,       0,       0,       0,      &arg_1,
       nullptr,        nullptr, nullptr, nullptr, nullptr};
-  cl_mutable_dispatch_config_khr dispatch_config_2{
+  const cl_mutable_dispatch_config_khr dispatch_config_2{
       command_handle, 1,       0,       0,       0,      &arg_2,
       nullptr,        nullptr, nullptr, nullptr, nullptr};
   const cl_uint num_configs = 2;
-  cl_command_buffer_update_type_khr config_types[2] = {
+  const cl_command_buffer_update_type_khr config_types[2] = {
       CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
       CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
   const void *configs[2] = {&dispatch_config_1, &dispatch_config_2};
@@ -3027,11 +3030,11 @@ TEST_F(CommandBufferMutableStructArgTest, UpdateInputOnce) {
   // Now try and enqueue the command buffer updating the output buffer.
   const test_struct second_value{99, 42.0f, 'j'};
   const cl_mutable_dispatch_arg_khr arg{0, sizeof(test_struct), &second_value};
-  cl_mutable_dispatch_config_khr dispatch_config{
+  const cl_mutable_dispatch_config_khr dispatch_config{
       command_handle, 1,       0,       0,       0,      &arg,
       nullptr,        nullptr, nullptr, nullptr, nullptr};
   const cl_uint num_configs = 1;
-  cl_command_buffer_update_type_khr config_types[1] = {
+  const cl_command_buffer_update_type_khr config_types[1] = {
       CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
   const void *configs[1] = {&dispatch_config};
   EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, num_configs,

--- a/source/cl/test/UnitCL/source/cl_khr_command_buffer_mutable_dispatch/clUpdateMutableCommandsKHR.cpp
+++ b/source/cl/test/UnitCL/source/cl_khr_command_buffer_mutable_dispatch/clUpdateMutableCommandsKHR.cpp
@@ -176,7 +176,7 @@ TEST_F(CommandBufferUpdateNDKernel, NullHandle) {
                                                  nullptr,
                                                  nullptr};
 
-  cl_uint num_configs = 1;
+  const cl_uint num_configs = 1;
   cl_command_buffer_update_type_khr config_types[1] = {
       CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
   const void *configs[1] = {&dispatch_config};
@@ -204,7 +204,7 @@ TEST_F(CommandBufferUpdateNDKernel, InvalidHandle) {
       &global_size, nullptr, 0, nullptr, nullptr, &new_command_handle));
   EXPECT_SUCCESS(clFinalizeCommandBufferKHR(new_command_buffer));
 
-  cl_mutable_dispatch_arg_khr arg{1, sizeof(cl_mem), &dst_buffer};
+  const cl_mutable_dispatch_arg_khr arg{1, sizeof(cl_mem), &dst_buffer};
   cl_mutable_dispatch_config_khr dispatch_config{
       new_command_handle /* command */,
       1,
@@ -218,7 +218,7 @@ TEST_F(CommandBufferUpdateNDKernel, InvalidHandle) {
       nullptr,
       nullptr};
 
-  cl_uint num_configs = 1;
+  const cl_uint num_configs = 1;
   cl_command_buffer_update_type_khr config_types[1] = {
       CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
   const void *configs[1] = {&dispatch_config};
@@ -294,11 +294,11 @@ TEST_F(CommandBufferUpdateNDKernel, ImmutablePropertyBit) {
       &global_size, nullptr, 0, nullptr, nullptr, &command_handle));
   ASSERT_SUCCESS(clFinalizeCommandBufferKHR(command_buffer));
 
-  cl_mutable_dispatch_arg_khr arg{1, sizeof(cl_mem), &dst_buffer};
+  const cl_mutable_dispatch_arg_khr arg{1, sizeof(cl_mem), &dst_buffer};
   cl_mutable_dispatch_config_khr dispatch_config{
       command_handle, 1,       0,       0,       0,      &arg,
       nullptr,        nullptr, nullptr, nullptr, nullptr};
-  cl_uint num_configs = 1;
+  const cl_uint num_configs = 1;
   cl_command_buffer_update_type_khr config_types[1] = {
       CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
   const void *configs[1] = {&dispatch_config};
@@ -332,7 +332,7 @@ TEST_F(CommandBufferUpdateNDKernel, InvalidArgList) {
                                                  nullptr,
                                                  nullptr};
 
-  cl_uint num_configs = 1;
+  const cl_uint num_configs = 1;
   cl_command_buffer_update_type_khr config_types[1] = {
       CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
   const void *configs[1] = {&dispatch_config};
@@ -341,7 +341,7 @@ TEST_F(CommandBufferUpdateNDKernel, InvalidArgList) {
                     clUpdateMutableCommandsKHR(command_buffer, num_configs,
                                                config_types, configs));
 
-  cl_mutable_dispatch_arg_khr arg{1, sizeof(cl_mem), &dst_buffer};
+  const cl_mutable_dispatch_arg_khr arg{1, sizeof(cl_mem), &dst_buffer};
   dispatch_config = {command_handle,
                      0 /* num_args */,
                      0,
@@ -370,13 +370,13 @@ TEST_F(CommandBufferUpdateNDKernel, InvalidArgIndex) {
       &global_size, nullptr, 0, nullptr, nullptr, &command_handle));
 
   ASSERT_SUCCESS(clFinalizeCommandBufferKHR(command_buffer));
-  cl_mutable_dispatch_arg_khr arg = {3 /* arg_index */, sizeof(cl_mem),
-                                     &src_buffer};
+  const cl_mutable_dispatch_arg_khr arg = {3 /* arg_index */, sizeof(cl_mem),
+                                           &src_buffer};
   cl_mutable_dispatch_config_khr dispatch_config{
       command_handle, 1,       0,       0,       0,      &arg,
       nullptr,        nullptr, nullptr, nullptr, nullptr};
 
-  cl_uint num_configs = 1;
+  const cl_uint num_configs = 1;
   cl_command_buffer_update_type_khr config_types[1] = {
       CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
   const void *configs[1] = {&dispatch_config};
@@ -430,12 +430,13 @@ TEST_F(CommandBufferUpdateNDKernel, InvalidArgValue) {
       &global_size, nullptr, 0, nullptr, nullptr, &command_handle));
 
   EXPECT_SUCCESS(clFinalizeCommandBufferKHR(command_buffer));
-  cl_mutable_dispatch_arg_khr arg = {0, sizeof(cl_mem), &image /* arg_value */};
+  const cl_mutable_dispatch_arg_khr arg = {0, sizeof(cl_mem),
+                                           &image /* arg_value */};
   cl_mutable_dispatch_config_khr dispatch_config{
       command_handle, 1,       0,       0,       0,      &arg,
       nullptr,        nullptr, nullptr, nullptr, nullptr};
 
-  cl_uint num_configs = 1;
+  const cl_uint num_configs = 1;
   cl_command_buffer_update_type_khr config_types[1] = {
       CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
   const void *configs[1] = {&dispatch_config};
@@ -458,12 +459,12 @@ TEST_F(CommandBufferUpdateNDKernel, InvalidArgSize) {
       &global_size, nullptr, 0, nullptr, nullptr, &command_handle));
 
   ASSERT_SUCCESS(clFinalizeCommandBufferKHR(command_buffer));
-  cl_mutable_dispatch_arg_khr arg = {0, 2 /* arg_size */, &src_buffer};
+  const cl_mutable_dispatch_arg_khr arg = {0, 2 /* arg_size */, &src_buffer};
   cl_mutable_dispatch_config_khr dispatch_config{
       command_handle, 1,       0,       0,       0,      &arg,
       nullptr,        nullptr, nullptr, nullptr, nullptr};
 
-  cl_uint num_configs = 1;
+  const cl_uint num_configs = 1;
   cl_command_buffer_update_type_khr config_types[1] = {
       CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
   const void *configs[1] = {&dispatch_config};
@@ -525,7 +526,7 @@ TEST_F(CommandBufferUpdateNDKernel, IterativeArgumentUpdate) {
       command_handle, 1,       0,       0,       0,      &arg,
       nullptr,        nullptr, nullptr, nullptr, nullptr};
 
-  cl_uint num_configs = 1;
+  const cl_uint num_configs = 1;
   cl_command_buffer_update_type_khr config_types[1] = {
       CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
   const void *configs[1] = {&dispatch_config};
@@ -609,7 +610,7 @@ TEST_F(CommandBufferUpdateNDKernel, OverwriteArgumentUpdate) {
   cl_mutable_dispatch_config_khr dispatch_config{
       command_handle, 1,       0,       0,       0,      &arg,
       nullptr,        nullptr, nullptr, nullptr, nullptr};
-  cl_uint num_configs = 1;
+  const cl_uint num_configs = 1;
   cl_command_buffer_update_type_khr config_types[1] = {
       CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
   const void *configs[1] = {&dispatch_config};
@@ -675,12 +676,12 @@ TEST_F(CommandBufferUpdateNDKernel, NoMutablePropertiesSet) {
   EXPECT_SUCCESS(clFinalizeCommandBufferKHR(command_buffer));
 
   // Update the output buffer
-  cl_mutable_dispatch_arg_khr arg{1, sizeof(cl_mem), &updated_dst_buffer};
+  const cl_mutable_dispatch_arg_khr arg{1, sizeof(cl_mem), &updated_dst_buffer};
   cl_mutable_dispatch_config_khr dispatch_config{
       command_handle, 1,       0,       0,       0,      &arg,
       nullptr,        nullptr, nullptr, nullptr, nullptr};
 
-  cl_uint num_configs = 1;
+  const cl_uint num_configs = 1;
   cl_command_buffer_update_type_khr config_types[1] = {
       CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
   const void *configs[1] = {&dispatch_config};
@@ -795,14 +796,14 @@ TEST_F(CommandBufferSimultaneousUpdate, UpdatePending) {
       0, nullptr, simultaneous_command_buffer, 1, &user_event, nullptr));
 
   // Update the kernel inputs & output arguments
-  cl_mutable_dispatch_arg_khr args[2] = {
+  const cl_mutable_dispatch_arg_khr args[2] = {
       {0, sizeof(cl_mem), &updated_src_buffer},
       {1, sizeof(cl_mem), &updated_dst_buffer}};
   cl_mutable_dispatch_config_khr dispatch_config{
       command_handle, 2,       0,       0,       0,      args,
       nullptr,        nullptr, nullptr, nullptr, nullptr};
 
-  cl_uint num_configs = 1;
+  const cl_uint num_configs = 1;
   cl_command_buffer_update_type_khr config_types[1] = {
       CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
   const void *configs[1] = {&dispatch_config};
@@ -852,7 +853,7 @@ TEST_F(CommandBufferSimultaneousUpdate, ConsecutiveUpdate) {
       command_handle, 1,       0,       0,       0,      &input_arg,
       nullptr,        nullptr, nullptr, nullptr, nullptr};
 
-  cl_uint num_configs = 1;
+  const cl_uint num_configs = 1;
   cl_command_buffer_update_type_khr config_types[1] = {
       CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
   const void *configs[1] = {&dispatch_config};
@@ -931,7 +932,7 @@ TEST_F(CommandBufferSimultaneousUpdate, MultipleCommands) {
       {command_handle2, 1, 0, 0, 0, &arg2, nullptr, nullptr, nullptr, nullptr,
        nullptr}};
 
-  cl_uint num_configs = 2;
+  const cl_uint num_configs = 2;
   cl_command_buffer_update_type_khr config_types[2] = {
       CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
       CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};

--- a/source/cl/test/UnitCL/source/cl_khr_command_buffer_mutable_dispatch/clUpdateMutableCommandsKHR.cpp
+++ b/source/cl/test/UnitCL/source/cl_khr_command_buffer_mutable_dispatch/clUpdateMutableCommandsKHR.cpp
@@ -164,20 +164,20 @@ TEST_F(CommandBufferUpdateNDKernel, InvalidSimulataneousUse) {
 // command object
 TEST_F(CommandBufferUpdateNDKernel, NullHandle) {
   ASSERT_SUCCESS(clFinalizeCommandBufferKHR(command_buffer));
-  cl_mutable_dispatch_config_khr dispatch_config{nullptr /* command */,
-                                                 0,
-                                                 0,
-                                                 0,
-                                                 0,
-                                                 nullptr,
-                                                 nullptr,
-                                                 nullptr,
-                                                 nullptr,
-                                                 nullptr,
-                                                 nullptr};
+  const cl_mutable_dispatch_config_khr dispatch_config{nullptr /* command */,
+                                                       0,
+                                                       0,
+                                                       0,
+                                                       0,
+                                                       nullptr,
+                                                       nullptr,
+                                                       nullptr,
+                                                       nullptr,
+                                                       nullptr,
+                                                       nullptr};
 
   const cl_uint num_configs = 1;
-  cl_command_buffer_update_type_khr config_types[1] = {
+  const cl_command_buffer_update_type_khr config_types[1] = {
       CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
   const void *configs[1] = {&dispatch_config};
 
@@ -205,7 +205,7 @@ TEST_F(CommandBufferUpdateNDKernel, InvalidHandle) {
   EXPECT_SUCCESS(clFinalizeCommandBufferKHR(new_command_buffer));
 
   const cl_mutable_dispatch_arg_khr arg{1, sizeof(cl_mem), &dst_buffer};
-  cl_mutable_dispatch_config_khr dispatch_config{
+  const cl_mutable_dispatch_config_khr dispatch_config{
       new_command_handle /* command */,
       1,
       0,
@@ -219,7 +219,7 @@ TEST_F(CommandBufferUpdateNDKernel, InvalidHandle) {
       nullptr};
 
   const cl_uint num_configs = 1;
-  cl_command_buffer_update_type_khr config_types[1] = {
+  const cl_command_buffer_update_type_khr config_types[1] = {
       CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
   const void *configs[1] = {&dispatch_config};
 
@@ -295,11 +295,11 @@ TEST_F(CommandBufferUpdateNDKernel, ImmutablePropertyBit) {
   ASSERT_SUCCESS(clFinalizeCommandBufferKHR(command_buffer));
 
   const cl_mutable_dispatch_arg_khr arg{1, sizeof(cl_mem), &dst_buffer};
-  cl_mutable_dispatch_config_khr dispatch_config{
+  const cl_mutable_dispatch_config_khr dispatch_config{
       command_handle, 1,       0,       0,       0,      &arg,
       nullptr,        nullptr, nullptr, nullptr, nullptr};
   const cl_uint num_configs = 1;
-  cl_command_buffer_update_type_khr config_types[1] = {
+  const cl_command_buffer_update_type_khr config_types[1] = {
       CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
   const void *configs[1] = {&dispatch_config};
 
@@ -333,7 +333,7 @@ TEST_F(CommandBufferUpdateNDKernel, InvalidArgList) {
                                                  nullptr};
 
   const cl_uint num_configs = 1;
-  cl_command_buffer_update_type_khr config_types[1] = {
+  const cl_command_buffer_update_type_khr config_types[1] = {
       CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
   const void *configs[1] = {&dispatch_config};
 
@@ -372,12 +372,12 @@ TEST_F(CommandBufferUpdateNDKernel, InvalidArgIndex) {
   ASSERT_SUCCESS(clFinalizeCommandBufferKHR(command_buffer));
   const cl_mutable_dispatch_arg_khr arg = {3 /* arg_index */, sizeof(cl_mem),
                                            &src_buffer};
-  cl_mutable_dispatch_config_khr dispatch_config{
+  const cl_mutable_dispatch_config_khr dispatch_config{
       command_handle, 1,       0,       0,       0,      &arg,
       nullptr,        nullptr, nullptr, nullptr, nullptr};
 
   const cl_uint num_configs = 1;
-  cl_command_buffer_update_type_khr config_types[1] = {
+  const cl_command_buffer_update_type_khr config_types[1] = {
       CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
   const void *configs[1] = {&dispatch_config};
 
@@ -432,12 +432,12 @@ TEST_F(CommandBufferUpdateNDKernel, InvalidArgValue) {
   EXPECT_SUCCESS(clFinalizeCommandBufferKHR(command_buffer));
   const cl_mutable_dispatch_arg_khr arg = {0, sizeof(cl_mem),
                                            &image /* arg_value */};
-  cl_mutable_dispatch_config_khr dispatch_config{
+  const cl_mutable_dispatch_config_khr dispatch_config{
       command_handle, 1,       0,       0,       0,      &arg,
       nullptr,        nullptr, nullptr, nullptr, nullptr};
 
   const cl_uint num_configs = 1;
-  cl_command_buffer_update_type_khr config_types[1] = {
+  const cl_command_buffer_update_type_khr config_types[1] = {
       CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
   const void *configs[1] = {&dispatch_config};
 
@@ -460,12 +460,12 @@ TEST_F(CommandBufferUpdateNDKernel, InvalidArgSize) {
 
   ASSERT_SUCCESS(clFinalizeCommandBufferKHR(command_buffer));
   const cl_mutable_dispatch_arg_khr arg = {0, 2 /* arg_size */, &src_buffer};
-  cl_mutable_dispatch_config_khr dispatch_config{
+  const cl_mutable_dispatch_config_khr dispatch_config{
       command_handle, 1,       0,       0,       0,      &arg,
       nullptr,        nullptr, nullptr, nullptr, nullptr};
 
   const cl_uint num_configs = 1;
-  cl_command_buffer_update_type_khr config_types[1] = {
+  const cl_command_buffer_update_type_khr config_types[1] = {
       CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
   const void *configs[1] = {&dispatch_config};
 
@@ -522,12 +522,12 @@ TEST_F(CommandBufferUpdateNDKernel, IterativeArgumentUpdate) {
   // Update both the input and output buffer, reusing the same
   // cl_mutable_dispatch_arg_khr struct
   cl_mutable_dispatch_arg_khr arg{0, sizeof(cl_mem), &updated_src_buffer};
-  cl_mutable_dispatch_config_khr dispatch_config{
+  const cl_mutable_dispatch_config_khr dispatch_config{
       command_handle, 1,       0,       0,       0,      &arg,
       nullptr,        nullptr, nullptr, nullptr, nullptr};
 
   const cl_uint num_configs = 1;
-  cl_command_buffer_update_type_khr config_types[1] = {
+  const cl_command_buffer_update_type_khr config_types[1] = {
       CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
   const void *configs[1] = {&dispatch_config};
 
@@ -607,11 +607,11 @@ TEST_F(CommandBufferUpdateNDKernel, OverwriteArgumentUpdate) {
   // Update both the input and output buffer, reusing the same
   // cl_mutable_dispatch_arg_khr struct
   cl_mutable_dispatch_arg_khr arg{1, sizeof(cl_mem), &unused_dst_buffer};
-  cl_mutable_dispatch_config_khr dispatch_config{
+  const cl_mutable_dispatch_config_khr dispatch_config{
       command_handle, 1,       0,       0,       0,      &arg,
       nullptr,        nullptr, nullptr, nullptr, nullptr};
   const cl_uint num_configs = 1;
-  cl_command_buffer_update_type_khr config_types[1] = {
+  const cl_command_buffer_update_type_khr config_types[1] = {
       CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
   const void *configs[1] = {&dispatch_config};
 
@@ -677,12 +677,12 @@ TEST_F(CommandBufferUpdateNDKernel, NoMutablePropertiesSet) {
 
   // Update the output buffer
   const cl_mutable_dispatch_arg_khr arg{1, sizeof(cl_mem), &updated_dst_buffer};
-  cl_mutable_dispatch_config_khr dispatch_config{
+  const cl_mutable_dispatch_config_khr dispatch_config{
       command_handle, 1,       0,       0,       0,      &arg,
       nullptr,        nullptr, nullptr, nullptr, nullptr};
 
   const cl_uint num_configs = 1;
-  cl_command_buffer_update_type_khr config_types[1] = {
+  const cl_command_buffer_update_type_khr config_types[1] = {
       CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
   const void *configs[1] = {&dispatch_config};
 
@@ -799,12 +799,12 @@ TEST_F(CommandBufferSimultaneousUpdate, UpdatePending) {
   const cl_mutable_dispatch_arg_khr args[2] = {
       {0, sizeof(cl_mem), &updated_src_buffer},
       {1, sizeof(cl_mem), &updated_dst_buffer}};
-  cl_mutable_dispatch_config_khr dispatch_config{
+  const cl_mutable_dispatch_config_khr dispatch_config{
       command_handle, 2,       0,       0,       0,      args,
       nullptr,        nullptr, nullptr, nullptr, nullptr};
 
   const cl_uint num_configs = 1;
-  cl_command_buffer_update_type_khr config_types[1] = {
+  const cl_command_buffer_update_type_khr config_types[1] = {
       CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
   const void *configs[1] = {&dispatch_config};
 
@@ -854,7 +854,7 @@ TEST_F(CommandBufferSimultaneousUpdate, ConsecutiveUpdate) {
       nullptr,        nullptr, nullptr, nullptr, nullptr};
 
   const cl_uint num_configs = 1;
-  cl_command_buffer_update_type_khr config_types[1] = {
+  const cl_command_buffer_update_type_khr config_types[1] = {
       CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
   const void *configs[1] = {&dispatch_config};
 
@@ -926,14 +926,14 @@ TEST_F(CommandBufferSimultaneousUpdate, MultipleCommands) {
                                             &updated_dst_buffer};
   const cl_mutable_dispatch_arg_khr arg2 = {0, sizeof(cl_mem),
                                             &updated_dst_buffer};
-  cl_mutable_dispatch_config_khr dispatch_configs[2] = {
+  const cl_mutable_dispatch_config_khr dispatch_configs[2] = {
       {command_handle, 1, 0, 0, 0, &arg1, nullptr, nullptr, nullptr, nullptr,
        nullptr},
       {command_handle2, 1, 0, 0, 0, &arg2, nullptr, nullptr, nullptr, nullptr,
        nullptr}};
 
   const cl_uint num_configs = 2;
-  cl_command_buffer_update_type_khr config_types[2] = {
+  const cl_command_buffer_update_type_khr config_types[2] = {
       CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
       CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
   const void *configs[2] = {&dispatch_configs[0], &dispatch_configs[1]};

--- a/source/cl/test/UnitCL/source/cl_khr_command_buffer_mutable_dispatch/thread_safety.cpp
+++ b/source/cl/test/UnitCL/source/cl_khr_command_buffer_mutable_dispatch/thread_safety.cpp
@@ -107,27 +107,18 @@ TEST_F(MutableDispatchThreadSafetyTest, UpdateInParallel) {
   auto update_input_value_and_enqueue = [&](size_t id) {
     const cl_int updated_input_value = id;
     // Create a mutable config.
-    const cl_mutable_dispatch_arg_khr arg{0, sizeof(cl_int),
-                                          &updated_input_value};
-    const cl_mutable_dispatch_config_khr dispatch_config{
-        CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
-        nullptr,
-        command_handle,
-        1,
-        0,
-        0,
-        0,
-        &arg,
-        nullptr,
-        nullptr,
-        nullptr,
-        nullptr,
-        nullptr};
-    const cl_mutable_base_config_khr mutable_config{
-        CL_STRUCTURE_TYPE_MUTABLE_BASE_CONFIG_KHR, nullptr, 1,
-        &dispatch_config};
+    cl_mutable_dispatch_arg_khr arg{0, sizeof(cl_int), &updated_input_value};
+    cl_mutable_dispatch_config_khr dispatch_config{
+        command_handle, 1,       0,       0,       0,      &arg,
+        nullptr,        nullptr, nullptr, nullptr, nullptr};
     // Update the nd range.
-    EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, &mutable_config));
+    cl_uint num_configs = 1;
+    cl_command_buffer_update_type_khr config_types[1] = {
+        CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
+    const void *configs[1] = {&dispatch_config};
+
+    EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, num_configs,
+                                              config_types, configs));
     EXPECT_SUCCESS(clEnqueueCommandBufferKHR(0, nullptr, command_buffer, 0,
                                              nullptr, nullptr));
   };

--- a/source/cl/test/UnitCL/source/cl_khr_command_buffer_mutable_dispatch/thread_safety.cpp
+++ b/source/cl/test/UnitCL/source/cl_khr_command_buffer_mutable_dispatch/thread_safety.cpp
@@ -107,12 +107,13 @@ TEST_F(MutableDispatchThreadSafetyTest, UpdateInParallel) {
   auto update_input_value_and_enqueue = [&](size_t id) {
     const cl_int updated_input_value = id;
     // Create a mutable config.
-    cl_mutable_dispatch_arg_khr arg{0, sizeof(cl_int), &updated_input_value};
+    const cl_mutable_dispatch_arg_khr arg{0, sizeof(cl_int),
+                                          &updated_input_value};
     cl_mutable_dispatch_config_khr dispatch_config{
         command_handle, 1,       0,       0,       0,      &arg,
         nullptr,        nullptr, nullptr, nullptr, nullptr};
     // Update the nd range.
-    cl_uint num_configs = 1;
+    const cl_uint num_configs = 1;
     cl_command_buffer_update_type_khr config_types[1] = {
         CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
     const void *configs[1] = {&dispatch_config};

--- a/source/cl/test/UnitCL/source/cl_khr_command_buffer_mutable_dispatch/thread_safety.cpp
+++ b/source/cl/test/UnitCL/source/cl_khr_command_buffer_mutable_dispatch/thread_safety.cpp
@@ -109,12 +109,12 @@ TEST_F(MutableDispatchThreadSafetyTest, UpdateInParallel) {
     // Create a mutable config.
     const cl_mutable_dispatch_arg_khr arg{0, sizeof(cl_int),
                                           &updated_input_value};
-    cl_mutable_dispatch_config_khr dispatch_config{
+    const cl_mutable_dispatch_config_khr dispatch_config{
         command_handle, 1,       0,       0,       0,      &arg,
         nullptr,        nullptr, nullptr, nullptr, nullptr};
     // Update the nd range.
     const cl_uint num_configs = 1;
-    cl_command_buffer_update_type_khr config_types[1] = {
+    const cl_command_buffer_update_type_khr config_types[1] = {
         CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
     const void *configs[1] = {&dispatch_config};
 

--- a/source/cl/test/UnitCL/source/cl_khr_command_buffer_mutable_dispatch/usm_arg_update.cpp
+++ b/source/cl/test/UnitCL/source/cl_khr_command_buffer_mutable_dispatch/usm_arg_update.cpp
@@ -138,30 +138,28 @@ TEST_F(MutableDispatchUSMTest, InvalidArgList) {
 
   ASSERT_SUCCESS(clFinalizeCommandBufferKHR(command_buffer));
 
-  cl_mutable_dispatch_config_khr dispatch_config{
-      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
-      nullptr,
-      command_handle,
-      0,
-      1 /* num_svm_args */,
-      0,
-      0,
-      nullptr,
-      nullptr /* arg_svm_list */,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr};
-  const cl_mutable_base_config_khr mutable_config{
-      CL_STRUCTURE_TYPE_MUTABLE_BASE_CONFIG_KHR, nullptr, 1, &dispatch_config};
+  cl_mutable_dispatch_config_khr dispatch_config{command_handle,
+                                                 0,
+                                                 1 /* num_svm_args */,
+                                                 0,
+                                                 0,
+                                                 nullptr,
+                                                 nullptr /* arg_svm_list */,
+                                                 nullptr,
+                                                 nullptr,
+                                                 nullptr,
+                                                 nullptr};
 
-  ASSERT_EQ_ERRCODE(CL_INVALID_VALUE, clUpdateMutableCommandsKHR(
-                                          command_buffer, &mutable_config));
+  cl_uint num_configs = 1;
+  cl_command_buffer_update_type_khr config_types[1] = {
+      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
+  const void *configs[1] = {&dispatch_config};
+  ASSERT_EQ_ERRCODE(CL_INVALID_VALUE,
+                    clUpdateMutableCommandsKHR(command_buffer, num_configs,
+                                               config_types, configs));
 
-  const cl_mutable_dispatch_arg_khr arg{0, 0, device_ptrs[1]};
-  dispatch_config = {CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
-                     nullptr,
-                     command_handle,
+  cl_mutable_dispatch_arg_khr arg{0, 0, device_ptrs[1]};
+  dispatch_config = {command_handle,
                      0,
                      0 /* num_svm_args */,
                      0,
@@ -173,8 +171,9 @@ TEST_F(MutableDispatchUSMTest, InvalidArgList) {
                      nullptr,
                      nullptr};
 
-  ASSERT_EQ_ERRCODE(CL_INVALID_VALUE, clUpdateMutableCommandsKHR(
-                                          command_buffer, &mutable_config));
+  ASSERT_EQ_ERRCODE(CL_INVALID_VALUE,
+                    clUpdateMutableCommandsKHR(command_buffer, num_configs,
+                                               config_types, configs));
 }
 
 // Test clSetKernelMemPointerINTEL error code for CL_INVALID_ARG_INDEX if
@@ -191,26 +190,26 @@ TEST_F(MutableDispatchUSMTest, InvalidArgIndex) {
 
   ASSERT_SUCCESS(clFinalizeCommandBufferKHR(command_buffer));
 
-  const cl_mutable_dispatch_arg_khr arg{2 /* arg index */, 0, device_ptrs[1]};
-  const cl_mutable_dispatch_config_khr dispatch_config{
-      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
-      nullptr,
-      command_handle,
-      0,
-      1 /* num_svm_args */,
-      0,
-      0,
-      nullptr,
-      &arg /* arg_svm_list */,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr};
-  const cl_mutable_base_config_khr mutable_config{
-      CL_STRUCTURE_TYPE_MUTABLE_BASE_CONFIG_KHR, nullptr, 1, &dispatch_config};
+  cl_mutable_dispatch_arg_khr arg{2 /* arg index */, 0, device_ptrs[1]};
+  cl_mutable_dispatch_config_khr dispatch_config{command_handle,
+                                                 0,
+                                                 1 /* num_svm_args */,
+                                                 0,
+                                                 0,
+                                                 nullptr,
+                                                 &arg /* arg_svm_list */,
+                                                 nullptr,
+                                                 nullptr,
+                                                 nullptr,
+                                                 nullptr};
 
-  ASSERT_EQ_ERRCODE(CL_INVALID_ARG_INDEX, clUpdateMutableCommandsKHR(
-                                              command_buffer, &mutable_config));
+  cl_uint num_configs = 1;
+  cl_command_buffer_update_type_khr config_types[1] = {
+      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
+  const void *configs[1] = {&dispatch_config};
+  ASSERT_EQ_ERRCODE(CL_INVALID_ARG_INDEX,
+                    clUpdateMutableCommandsKHR(command_buffer, num_configs,
+                                               config_types, configs));
 }
 
 TEST_F(MutableDispatchUSMTest, InvalidArgValue) {
@@ -225,29 +224,30 @@ TEST_F(MutableDispatchUSMTest, InvalidArgValue) {
 
   ASSERT_SUCCESS(clFinalizeCommandBufferKHR(command_buffer));
 
-  const cl_mutable_dispatch_arg_khr arg{0, 0, &out_buffer};
-  const cl_mutable_dispatch_config_khr dispatch_config{
-      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
-      nullptr,
-      command_handle,
-      0,
-      1 /* num_svm_args */,
-      0,
-      0,
-      nullptr,
-      &arg /* arg_svm_list */,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr};
-  const cl_mutable_base_config_khr mutable_config{
-      CL_STRUCTURE_TYPE_MUTABLE_BASE_CONFIG_KHR, nullptr, 1, &dispatch_config};
+  cl_mutable_dispatch_arg_khr arg{0, 0, &out_buffer};
+  cl_mutable_dispatch_config_khr dispatch_config{command_handle,
+                                                 0,
+                                                 1 /* num_svm_args */,
+                                                 0,
+                                                 0,
+                                                 nullptr,
+                                                 &arg /* arg_svm_list */,
+                                                 nullptr,
+                                                 nullptr,
+                                                 nullptr,
+                                                 nullptr};
 
   // The interaction between cl_intel_unified_shared_memory and
   // cl_khr_command_buffer_mutable_dispatch is not specified but we assume that
   // if clSetKernelArgMemPointerINTEL would not report invalid values, neither
   // will clUpdateMutableCommandsKHR.
-  ASSERT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, &mutable_config));
+
+  cl_uint num_configs = 1;
+  cl_command_buffer_update_type_khr config_types[1] = {
+      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
+  const void *configs[1] = {&dispatch_config};
+  ASSERT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, num_configs,
+                                            config_types, configs));
 }
 
 // Tests for updating USM arguments to a command-buffer kernel command are
@@ -319,24 +319,24 @@ TEST_P(MutableDispatchUpdateUSMArgs, NoOffset) {
   ASSERT_EQ(inputA, output);
 
   // Update both the input and argument to second device USM allocation
-  const cl_mutable_dispatch_arg_khr arg{0, 0, ptrB};
-  const cl_mutable_dispatch_config_khr dispatch_config{
-      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
-      nullptr,
-      command_handle,
-      0,
-      1, /* num_svm_args */
-      0,
-      0,
-      nullptr,
-      &arg, /* arg_svm_list */
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr};
-  const cl_mutable_base_config_khr mutable_config{
-      CL_STRUCTURE_TYPE_MUTABLE_BASE_CONFIG_KHR, nullptr, 1, &dispatch_config};
-  ASSERT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, &mutable_config));
+  cl_mutable_dispatch_arg_khr arg{0, 0, ptrB};
+  cl_mutable_dispatch_config_khr dispatch_config{command_handle,
+                                                 0,
+                                                 1, /* num_svm_args */
+                                                 0,
+                                                 0,
+                                                 nullptr,
+                                                 &arg, /* arg_svm_list */
+                                                 nullptr,
+                                                 nullptr,
+                                                 nullptr,
+                                                 nullptr};
+  cl_uint num_configs = 1;
+  cl_command_buffer_update_type_khr config_types[1] = {
+      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
+  const void *configs[1] = {&dispatch_config};
+  ASSERT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, num_configs,
+                                            config_types, configs));
 
   // Enqueue the command buffer.
   ASSERT_SUCCESS(clEnqueueCommandBufferKHR(0, nullptr, command_buffer, 0,
@@ -409,24 +409,24 @@ TEST_P(MutableDispatchUpdateUSMArgs, Offset) {
   ASSERT_EQ(inputA, output);
 
   // Update both the input and argument to second device USM allocation
-  const cl_mutable_dispatch_arg_khr arg{0, 0, offset_ptrB};
-  const cl_mutable_dispatch_config_khr dispatch_config{
-      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
-      nullptr,
-      command_handle,
-      0,
-      1, /* num_svm_args */
-      0,
-      0,
-      nullptr,
-      &arg, /* arg_svm_list */
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr};
-  const cl_mutable_base_config_khr mutable_config{
-      CL_STRUCTURE_TYPE_MUTABLE_BASE_CONFIG_KHR, nullptr, 1, &dispatch_config};
-  ASSERT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, &mutable_config));
+  cl_mutable_dispatch_arg_khr arg{0, 0, offset_ptrB};
+  cl_mutable_dispatch_config_khr dispatch_config{command_handle,
+                                                 0,
+                                                 1, /* num_svm_args */
+                                                 0,
+                                                 0,
+                                                 nullptr,
+                                                 &arg, /* arg_svm_list */
+                                                 nullptr,
+                                                 nullptr,
+                                                 nullptr,
+                                                 nullptr};
+  cl_uint num_configs = 1;
+  cl_command_buffer_update_type_khr config_types[1] = {
+      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
+  const void *configs[1] = {&dispatch_config};
+  ASSERT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, num_configs,
+                                            config_types, configs));
 
   // Enqueue the command buffer.
   ASSERT_SUCCESS(clEnqueueCommandBufferKHR(0, nullptr, command_buffer, 0,
@@ -534,24 +534,24 @@ TEST_F(MutableDispatchUSMTest, DISABLED_UpdateBlockingFree) {
   ASSERT_EQ(inputA, output);
 
   // Update both the input and argument to second device USM allocation
-  const cl_mutable_dispatch_arg_khr arg{0, 0, usm_ptrB};
-  const cl_mutable_dispatch_config_khr dispatch_config{
-      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
-      nullptr,
-      command_handle,
-      0,
-      1, /* num_svm_args */
-      0,
-      0,
-      nullptr,
-      &arg, /* arg_svm_list */
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr};
-  const cl_mutable_base_config_khr mutable_config{
-      CL_STRUCTURE_TYPE_MUTABLE_BASE_CONFIG_KHR, nullptr, 1, &dispatch_config};
-  ASSERT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, &mutable_config));
+  cl_mutable_dispatch_arg_khr arg{0, 0, usm_ptrB};
+  cl_mutable_dispatch_config_khr dispatch_config{command_handle,
+                                                 0,
+                                                 1, /* num_svm_args */
+                                                 0,
+                                                 0,
+                                                 nullptr,
+                                                 &arg, /* arg_svm_list */
+                                                 nullptr,
+                                                 nullptr,
+                                                 nullptr,
+                                                 nullptr};
+  cl_uint num_configs = 1;
+  cl_command_buffer_update_type_khr config_types[1] = {
+      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
+  const void *configs[1] = {&dispatch_config};
+  ASSERT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, num_configs,
+                                            config_types, configs));
 
   // Enqueue the command buffer.
   ASSERT_SUCCESS(clEnqueueCommandBufferKHR(0, nullptr, command_buffer, 0,

--- a/source/cl/test/UnitCL/source/cl_khr_command_buffer_mutable_dispatch/usm_arg_update.cpp
+++ b/source/cl/test/UnitCL/source/cl_khr_command_buffer_mutable_dispatch/usm_arg_update.cpp
@@ -150,7 +150,7 @@ TEST_F(MutableDispatchUSMTest, InvalidArgList) {
                                                  nullptr,
                                                  nullptr};
 
-  cl_uint num_configs = 1;
+  const cl_uint num_configs = 1;
   cl_command_buffer_update_type_khr config_types[1] = {
       CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
   const void *configs[1] = {&dispatch_config};
@@ -158,7 +158,7 @@ TEST_F(MutableDispatchUSMTest, InvalidArgList) {
                     clUpdateMutableCommandsKHR(command_buffer, num_configs,
                                                config_types, configs));
 
-  cl_mutable_dispatch_arg_khr arg{0, 0, device_ptrs[1]};
+  const cl_mutable_dispatch_arg_khr arg{0, 0, device_ptrs[1]};
   dispatch_config = {command_handle,
                      0,
                      0 /* num_svm_args */,
@@ -190,7 +190,7 @@ TEST_F(MutableDispatchUSMTest, InvalidArgIndex) {
 
   ASSERT_SUCCESS(clFinalizeCommandBufferKHR(command_buffer));
 
-  cl_mutable_dispatch_arg_khr arg{2 /* arg index */, 0, device_ptrs[1]};
+  const cl_mutable_dispatch_arg_khr arg{2 /* arg index */, 0, device_ptrs[1]};
   cl_mutable_dispatch_config_khr dispatch_config{command_handle,
                                                  0,
                                                  1 /* num_svm_args */,
@@ -203,7 +203,7 @@ TEST_F(MutableDispatchUSMTest, InvalidArgIndex) {
                                                  nullptr,
                                                  nullptr};
 
-  cl_uint num_configs = 1;
+  const cl_uint num_configs = 1;
   cl_command_buffer_update_type_khr config_types[1] = {
       CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
   const void *configs[1] = {&dispatch_config};
@@ -224,7 +224,7 @@ TEST_F(MutableDispatchUSMTest, InvalidArgValue) {
 
   ASSERT_SUCCESS(clFinalizeCommandBufferKHR(command_buffer));
 
-  cl_mutable_dispatch_arg_khr arg{0, 0, &out_buffer};
+  const cl_mutable_dispatch_arg_khr arg{0, 0, &out_buffer};
   cl_mutable_dispatch_config_khr dispatch_config{command_handle,
                                                  0,
                                                  1 /* num_svm_args */,
@@ -242,7 +242,7 @@ TEST_F(MutableDispatchUSMTest, InvalidArgValue) {
   // if clSetKernelArgMemPointerINTEL would not report invalid values, neither
   // will clUpdateMutableCommandsKHR.
 
-  cl_uint num_configs = 1;
+  const cl_uint num_configs = 1;
   cl_command_buffer_update_type_khr config_types[1] = {
       CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
   const void *configs[1] = {&dispatch_config};
@@ -319,7 +319,7 @@ TEST_P(MutableDispatchUpdateUSMArgs, NoOffset) {
   ASSERT_EQ(inputA, output);
 
   // Update both the input and argument to second device USM allocation
-  cl_mutable_dispatch_arg_khr arg{0, 0, ptrB};
+  const cl_mutable_dispatch_arg_khr arg{0, 0, ptrB};
   cl_mutable_dispatch_config_khr dispatch_config{command_handle,
                                                  0,
                                                  1, /* num_svm_args */
@@ -331,7 +331,7 @@ TEST_P(MutableDispatchUpdateUSMArgs, NoOffset) {
                                                  nullptr,
                                                  nullptr,
                                                  nullptr};
-  cl_uint num_configs = 1;
+  const cl_uint num_configs = 1;
   cl_command_buffer_update_type_khr config_types[1] = {
       CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
   const void *configs[1] = {&dispatch_config};
@@ -409,7 +409,7 @@ TEST_P(MutableDispatchUpdateUSMArgs, Offset) {
   ASSERT_EQ(inputA, output);
 
   // Update both the input and argument to second device USM allocation
-  cl_mutable_dispatch_arg_khr arg{0, 0, offset_ptrB};
+  const cl_mutable_dispatch_arg_khr arg{0, 0, offset_ptrB};
   cl_mutable_dispatch_config_khr dispatch_config{command_handle,
                                                  0,
                                                  1, /* num_svm_args */
@@ -421,7 +421,7 @@ TEST_P(MutableDispatchUpdateUSMArgs, Offset) {
                                                  nullptr,
                                                  nullptr,
                                                  nullptr};
-  cl_uint num_configs = 1;
+  const cl_uint num_configs = 1;
   cl_command_buffer_update_type_khr config_types[1] = {
       CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
   const void *configs[1] = {&dispatch_config};
@@ -534,7 +534,7 @@ TEST_F(MutableDispatchUSMTest, DISABLED_UpdateBlockingFree) {
   ASSERT_EQ(inputA, output);
 
   // Update both the input and argument to second device USM allocation
-  cl_mutable_dispatch_arg_khr arg{0, 0, usm_ptrB};
+  const cl_mutable_dispatch_arg_khr arg{0, 0, usm_ptrB};
   cl_mutable_dispatch_config_khr dispatch_config{command_handle,
                                                  0,
                                                  1, /* num_svm_args */
@@ -546,7 +546,7 @@ TEST_F(MutableDispatchUSMTest, DISABLED_UpdateBlockingFree) {
                                                  nullptr,
                                                  nullptr,
                                                  nullptr};
-  cl_uint num_configs = 1;
+  const cl_uint num_configs = 1;
   cl_command_buffer_update_type_khr config_types[1] = {
       CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
   const void *configs[1] = {&dispatch_config};

--- a/source/cl/test/UnitCL/source/cl_khr_command_buffer_mutable_dispatch/usm_arg_update.cpp
+++ b/source/cl/test/UnitCL/source/cl_khr_command_buffer_mutable_dispatch/usm_arg_update.cpp
@@ -151,7 +151,7 @@ TEST_F(MutableDispatchUSMTest, InvalidArgList) {
                                                  nullptr};
 
   const cl_uint num_configs = 1;
-  cl_command_buffer_update_type_khr config_types[1] = {
+  const cl_command_buffer_update_type_khr config_types[1] = {
       CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
   const void *configs[1] = {&dispatch_config};
   ASSERT_EQ_ERRCODE(CL_INVALID_VALUE,
@@ -191,20 +191,20 @@ TEST_F(MutableDispatchUSMTest, InvalidArgIndex) {
   ASSERT_SUCCESS(clFinalizeCommandBufferKHR(command_buffer));
 
   const cl_mutable_dispatch_arg_khr arg{2 /* arg index */, 0, device_ptrs[1]};
-  cl_mutable_dispatch_config_khr dispatch_config{command_handle,
-                                                 0,
-                                                 1 /* num_svm_args */,
-                                                 0,
-                                                 0,
-                                                 nullptr,
-                                                 &arg /* arg_svm_list */,
-                                                 nullptr,
-                                                 nullptr,
-                                                 nullptr,
-                                                 nullptr};
+  const cl_mutable_dispatch_config_khr dispatch_config{command_handle,
+                                                       0,
+                                                       1 /* num_svm_args */,
+                                                       0,
+                                                       0,
+                                                       nullptr,
+                                                       &arg /* arg_svm_list */,
+                                                       nullptr,
+                                                       nullptr,
+                                                       nullptr,
+                                                       nullptr};
 
   const cl_uint num_configs = 1;
-  cl_command_buffer_update_type_khr config_types[1] = {
+  const cl_command_buffer_update_type_khr config_types[1] = {
       CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
   const void *configs[1] = {&dispatch_config};
   ASSERT_EQ_ERRCODE(CL_INVALID_ARG_INDEX,
@@ -225,17 +225,17 @@ TEST_F(MutableDispatchUSMTest, InvalidArgValue) {
   ASSERT_SUCCESS(clFinalizeCommandBufferKHR(command_buffer));
 
   const cl_mutable_dispatch_arg_khr arg{0, 0, &out_buffer};
-  cl_mutable_dispatch_config_khr dispatch_config{command_handle,
-                                                 0,
-                                                 1 /* num_svm_args */,
-                                                 0,
-                                                 0,
-                                                 nullptr,
-                                                 &arg /* arg_svm_list */,
-                                                 nullptr,
-                                                 nullptr,
-                                                 nullptr,
-                                                 nullptr};
+  const cl_mutable_dispatch_config_khr dispatch_config{command_handle,
+                                                       0,
+                                                       1 /* num_svm_args */,
+                                                       0,
+                                                       0,
+                                                       nullptr,
+                                                       &arg /* arg_svm_list */,
+                                                       nullptr,
+                                                       nullptr,
+                                                       nullptr,
+                                                       nullptr};
 
   // The interaction between cl_intel_unified_shared_memory and
   // cl_khr_command_buffer_mutable_dispatch is not specified but we assume that
@@ -243,7 +243,7 @@ TEST_F(MutableDispatchUSMTest, InvalidArgValue) {
   // will clUpdateMutableCommandsKHR.
 
   const cl_uint num_configs = 1;
-  cl_command_buffer_update_type_khr config_types[1] = {
+  const cl_command_buffer_update_type_khr config_types[1] = {
       CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
   const void *configs[1] = {&dispatch_config};
   ASSERT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, num_configs,
@@ -320,19 +320,19 @@ TEST_P(MutableDispatchUpdateUSMArgs, NoOffset) {
 
   // Update both the input and argument to second device USM allocation
   const cl_mutable_dispatch_arg_khr arg{0, 0, ptrB};
-  cl_mutable_dispatch_config_khr dispatch_config{command_handle,
-                                                 0,
-                                                 1, /* num_svm_args */
-                                                 0,
-                                                 0,
-                                                 nullptr,
-                                                 &arg, /* arg_svm_list */
-                                                 nullptr,
-                                                 nullptr,
-                                                 nullptr,
-                                                 nullptr};
+  const cl_mutable_dispatch_config_khr dispatch_config{command_handle,
+                                                       0,
+                                                       1, /* num_svm_args */
+                                                       0,
+                                                       0,
+                                                       nullptr,
+                                                       &arg, /* arg_svm_list */
+                                                       nullptr,
+                                                       nullptr,
+                                                       nullptr,
+                                                       nullptr};
   const cl_uint num_configs = 1;
-  cl_command_buffer_update_type_khr config_types[1] = {
+  const cl_command_buffer_update_type_khr config_types[1] = {
       CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
   const void *configs[1] = {&dispatch_config};
   ASSERT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, num_configs,
@@ -410,19 +410,19 @@ TEST_P(MutableDispatchUpdateUSMArgs, Offset) {
 
   // Update both the input and argument to second device USM allocation
   const cl_mutable_dispatch_arg_khr arg{0, 0, offset_ptrB};
-  cl_mutable_dispatch_config_khr dispatch_config{command_handle,
-                                                 0,
-                                                 1, /* num_svm_args */
-                                                 0,
-                                                 0,
-                                                 nullptr,
-                                                 &arg, /* arg_svm_list */
-                                                 nullptr,
-                                                 nullptr,
-                                                 nullptr,
-                                                 nullptr};
+  const cl_mutable_dispatch_config_khr dispatch_config{command_handle,
+                                                       0,
+                                                       1, /* num_svm_args */
+                                                       0,
+                                                       0,
+                                                       nullptr,
+                                                       &arg, /* arg_svm_list */
+                                                       nullptr,
+                                                       nullptr,
+                                                       nullptr,
+                                                       nullptr};
   const cl_uint num_configs = 1;
-  cl_command_buffer_update_type_khr config_types[1] = {
+  const cl_command_buffer_update_type_khr config_types[1] = {
       CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
   const void *configs[1] = {&dispatch_config};
   ASSERT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, num_configs,
@@ -535,19 +535,19 @@ TEST_F(MutableDispatchUSMTest, DISABLED_UpdateBlockingFree) {
 
   // Update both the input and argument to second device USM allocation
   const cl_mutable_dispatch_arg_khr arg{0, 0, usm_ptrB};
-  cl_mutable_dispatch_config_khr dispatch_config{command_handle,
-                                                 0,
-                                                 1, /* num_svm_args */
-                                                 0,
-                                                 0,
-                                                 nullptr,
-                                                 &arg, /* arg_svm_list */
-                                                 nullptr,
-                                                 nullptr,
-                                                 nullptr,
-                                                 nullptr};
+  const cl_mutable_dispatch_config_khr dispatch_config{command_handle,
+                                                       0,
+                                                       1, /* num_svm_args */
+                                                       0,
+                                                       0,
+                                                       nullptr,
+                                                       &arg, /* arg_svm_list */
+                                                       nullptr,
+                                                       nullptr,
+                                                       nullptr,
+                                                       nullptr};
   const cl_uint num_configs = 1;
-  cl_command_buffer_update_type_khr config_types[1] = {
+  const cl_command_buffer_update_type_khr config_types[1] = {
       CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
   const void *configs[1] = {&dispatch_config};
   ASSERT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, num_configs,


### PR DESCRIPTION
# Overview

Update cl_khr_command_buffer_mutable_dispatch implementation to reflect specification changes merged in https://github.com/KhronosGroup/OpenCL-Docs/issues/1041

Reflects changes from upstream in:

* https://github.com/KhronosGroup/OpenCL-Headers/pull/245
* https://github.com/KhronosGroup/OpenCL-CTS/pull/1984


# Description of change

Updates our implementation from spec revision 0.9.1 of cl_khr_command_buffer_mutable_dispatch to revision 0.9.2 which made a breaking API change to `clUpdateMutableCommandsKHR()`.



# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-17](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
