### PR TITLE
add single pr job

### DIFF
--- a/.github/actions/do_build_ock/action.yml
+++ b/.github/actions/do_build_ock/action.yml
@@ -100,6 +100,12 @@ inputs:
   gtest_launcher:
     description: "Googletest suite launcher command"
     default: "/usr/bin/python;-u;${{ github.workspace }}/scripts/gtest-terse-runner.py"
+  c_compiler:
+    description: "C compiler"
+    default: "gcc"
+  cxx_compiler:
+    description: "C++ compiler"
+    default: "g++"
 
 runs:
   # We don't want a new docker just a list of steps, so mark as composite
@@ -148,6 +154,8 @@ runs:
               -DCA_EXTERNAL_CLC=${{ inputs.external_clc }} \
               -DCA_CL_DISABLE_UNITCL_VECZ_CHECKS=${{ inputs.disable_unitcl_vecz_checks }} \
               -DCA_GTEST_LAUNCHER="${{ inputs.gtest_launcher }}" \
+              -DCMAKE_C_COMPILER="${{ inputs.c_compiler }}" \
+              -DCMAKE_CXX_COMPILER="${{ inputs.cxx_compiler }}" \
                $ARCH \
                ${{ inputs.extra_flags }} \
                .

--- a/.github/actions/do_build_ock/action.yml
+++ b/.github/actions/do_build_ock/action.yml
@@ -76,7 +76,7 @@ inputs:
   enable_rvv_scalable_vecz_check:
     description: "Enable RVV scalable vecz check (default OFF)"
     default: OFF
-  enable_rvv_scalable_VP_vecz_check:
+  enable_rvv_scalable_vp_vecz_check:
     description: "Enable RVV scalable vecz VP check (default OFF)"
     default: OFF
   install_dir:

--- a/.github/actions/do_build_ock/do_build_m1/action.yml
+++ b/.github/actions/do_build_ock/do_build_m1/action.yml
@@ -22,5 +22,5 @@ runs:
         external_compiler_dirs: "${{ github.workspace }}/examples/refsi/refsi_m1/compiler/refsi_m1"
         riscv_enabled: ON
         enable_rvv_scalable_vecz_check: ON
-        enable_rvv_scalable_VP_vecz_check: ON
+        enable_rvv_scalable_vp_vecz_check: ON
         extra_flags: ${{ inputs.extra_flags }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,0 +1,73 @@
+name: ComputeAorta/ci-github-mrexport
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+    - source/**
+    - clik/**
+    - modules/**
+    - examples/**
+    - cmake/**
+    - hal/**
+    - .github/actions/do_build_ock/**
+    - .github/actions/setup_ubuntu_build/**
+    - .github/workflows/run_pr_tests.yml
+    - CMakeLists.txt
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+jobs:
+
+############### JOB   mr-ubuntu-gcc-x86_64-riscv-fp16-cl3-0-unitcl_vecz:
+
+  mr-ubuntu-gcc-x86_64-riscv-fp16-cl3-0-unitcl_vecz:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 60
+    env:
+      EXTERNAL_MUX_COMPILER_DIRS: ${{ github.workspace }}/code/examples/refsi/refsi_m1/compiler/refsi_m1
+      MUX_COMPILERS_TO_ENABLE: riscv
+      HAL_DESCRIPTION: RV64GCV_Zfh
+      HAL_REFSI_SOC: G1
+      HAL_REFSI_THREAD_MODE: WG
+      TARGET: check-ock-UnitCL-group-vecz
+      DISABLE_VECZ_CHECKS: OFF
+      Compiler: gcc
+      CXXCompiler: g++
+    steps:
+    - name: Checkout repo
+      uses: actions/checkout@v4.1.0
+      with:
+        path: code
+    - run: cp -R code/.github .github
+    - name: setup-ubuntu
+      uses: ./.github/actions/setup_ubuntu_build
+      with:
+        llvm_version: '18'
+        llvm_build_type: RelAssert
+    - run: echo WORKSPACE is $GITHUB_WORKSPACE && echo PWD is `pwd` && ls -al
+    - name: build ock
+      uses: ./.github/actions/do_build_ock
+      with:
+        path: $GITHUB_WORKSPACE/code
+        install_dir: $GITHUB_WORKSPACE/install
+        llvm_install_dir: $GITHUB_WORKSPACE/llvm_install
+        build_type: ReleaseAssert
+        build_targets: $TARGET
+        host_image: OFF
+        enable_api: cl
+        mux_targets_enable: riscv
+        external_compiler_dirs: $EXTERNAL_MUX_COMPILER_DIRS
+        mux_compilers_enable: $MUX_COMPILERS_TO_ENABLE
+        riscv_enabled: ON
+        disable_unitcl_vecz_checks: $DISABLE_VECZ_CHECKS
+        enable_rvv_scalable_vecz_check: ON
+        enable_rvv_scalable_vp_vecz_check: ON
+        command_buffer: ON
+        use_linker: gold
+        hal_description: $HAL_DESCRIPTION
+        hal_refsi_soc: $HAL_REFSI_SOC
+        hal_refsi_thread_mode: $HAL_REFSI_THREAD_MODE
+        build_dir: $GITHUB_WORKSPACE/build
+        debug_support: ON
+        gtest_launcher: "/usr/bin/python;-u;${{ github.workspace }}/code/scripts/gtest-terse-runner.py"
+        extra_flags: -DCMAKE_C_COMPILER=$Compiler -DCMAKE_CXX_COMPILER=$CXXCompiler

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -11,7 +11,6 @@ on:
     - hal/**
     - .github/actions/do_build_ock/**
     - .github/actions/setup_ubuntu_build/**
-    - .github/workflows/run_pr_tests.yml
     - .github/workflows/pull-request.yml
     - CMakeLists.txt
 concurrency:
@@ -43,7 +42,6 @@ jobs:
         install_dir: $GITHUB_WORKSPACE/install
         build_targets: check-ock-UnitCL-group-vecz
         mux_targets_enable: riscv
-        external_compiler_dirs: ${{ github.workspace }}/code/examples/refsi/refsi_m1/compiler/refsi_m1
         mux_compilers_enable: riscv
         riscv_enabled: ON
         enable_rvv_scalable_vecz_check: ON
@@ -55,4 +53,3 @@ jobs:
         build_dir: $GITHUB_WORKSPACE/build
         debug_support: ON
         gtest_launcher: "/usr/bin/python;-u;${{ github.workspace }}/code/scripts/gtest-terse-runner.py"
-        extra_flags: -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -24,16 +24,6 @@ jobs:
   mr-ubuntu-gcc-x86_64-riscv-fp16-cl3-0-unitcl_vecz:
     runs-on: ubuntu-22.04
     timeout-minutes: 60
-    env:
-      EXTERNAL_MUX_COMPILER_DIRS: ${{ github.workspace }}/code/examples/refsi/refsi_m1/compiler/refsi_m1
-      MUX_COMPILERS_TO_ENABLE: riscv
-      HAL_DESCRIPTION: RV64GCV_Zfh
-      HAL_REFSI_SOC: G1
-      HAL_REFSI_THREAD_MODE: WG
-      TARGET: check-ock-UnitCL-group-vecz
-      DISABLE_VECZ_CHECKS: OFF
-      Compiler: gcc
-      CXXCompiler: g++
     steps:
     - name: Checkout repo
       uses: actions/checkout@v4.1.0
@@ -51,24 +41,18 @@ jobs:
       with:
         path: $GITHUB_WORKSPACE/code
         install_dir: $GITHUB_WORKSPACE/install
-        llvm_install_dir: $GITHUB_WORKSPACE/llvm_install
-        build_type: ReleaseAssert
-        build_targets: $TARGET
-        host_image: OFF
-        enable_api: cl
+        build_targets: check-ock-UnitCL-group-vecz
         mux_targets_enable: riscv
-        external_compiler_dirs: $EXTERNAL_MUX_COMPILER_DIRS
-        mux_compilers_enable: $MUX_COMPILERS_TO_ENABLE
+        external_compiler_dirs: ${{ github.workspace }}/code/examples/refsi/refsi_m1/compiler/refsi_m1
+        mux_compilers_enable: riscv
         riscv_enabled: ON
-        disable_unitcl_vecz_checks: $DISABLE_VECZ_CHECKS
         enable_rvv_scalable_vecz_check: ON
         enable_rvv_scalable_vp_vecz_check: ON
-        command_buffer: ON
         use_linker: gold
-        hal_description: $HAL_DESCRIPTION
-        hal_refsi_soc: $HAL_REFSI_SOC
-        hal_refsi_thread_mode: $HAL_REFSI_THREAD_MODE
+        hal_description: RV64GCV_Zfh
+        hal_refsi_soc: G1
+        hal_refsi_thread_mode: WG
         build_dir: $GITHUB_WORKSPACE/build
         debug_support: ON
         gtest_launcher: "/usr/bin/python;-u;${{ github.workspace }}/code/scripts/gtest-terse-runner.py"
-        extra_flags: -DCMAKE_C_COMPILER=$Compiler -DCMAKE_CXX_COMPILER=$CXXCompiler
+        extra_flags: -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,4 +1,4 @@
-name: ComputeAorta/ci-github-mrexport
+name: pull-request
 on:
   workflow_dispatch:
   pull_request:
@@ -12,6 +12,7 @@ on:
     - .github/actions/do_build_ock/**
     - .github/actions/setup_ubuntu_build/**
     - .github/workflows/run_pr_tests.yml
+    - .github/workflows/pull-request.yml
     - CMakeLists.txt
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,4 +1,4 @@
-name: pull-request
+name: Pull Request
 on:
   workflow_dispatch:
   pull_request:
@@ -11,7 +11,7 @@ on:
     - hal/**
     - .github/actions/do_build_ock/**
     - .github/actions/setup_ubuntu_build/**
-    - .github/workflows/pull-request.yml
+    - .github/workflows/pull_request.yml
     - CMakeLists.txt
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -26,9 +26,6 @@ jobs:
     steps:
     - name: Checkout repo
       uses: actions/checkout@v4.1.0
-      with:
-        path: code
-    - run: cp -R code/.github .github
     - name: setup-ubuntu
       uses: ./.github/actions/setup_ubuntu_build
       with:
@@ -38,8 +35,6 @@ jobs:
     - name: build ock
       uses: ./.github/actions/do_build_ock
       with:
-        path: $GITHUB_WORKSPACE/code
-        install_dir: $GITHUB_WORKSPACE/install
         build_targets: check-ock-UnitCL-group-vecz
         mux_targets_enable: riscv
         mux_compilers_enable: riscv
@@ -50,6 +45,5 @@ jobs:
         hal_description: RV64GCV_Zfh
         hal_refsi_soc: G1
         hal_refsi_thread_mode: WG
-        build_dir: $GITHUB_WORKSPACE/build
         debug_support: ON
-        gtest_launcher: "/usr/bin/python;-u;${{ github.workspace }}/code/scripts/gtest-terse-runner.py"
+        gtest_launcher: "/usr/bin/python;-u;${{ github.workspace }}/scripts/gtest-terse-runner.py"


### PR DESCRIPTION
# Overview
Add an initial PR job: mr-ubuntu-gcc-x86_64-riscv-fp16-cl3-0-unitcl_vecz
Also fix an upper-case anomaly with the build action inputs strings.

# Reason for change
Allows basic PR testing - a single job with others to follow.

# Description of change
Add pull-request workflow containing single PR job.

# Anything else we should know?
Notable changes from Gitlab:
- build.py is retired. PR job calls an updated Github build action instead.
- setup and build actions are subject to change as other PR jobs are added.

Test results are the same as for the latest corresponding Gitlab MR job.