### PR TITLE
Fix build with MSVC, fix VectorAddition test.

### DIFF
--- a/modules/compiler/builtins/abacus/generate/abacus_detail_geometric/abacus_detail_geometric.in
+++ b/modules/compiler/builtins/abacus/generate/abacus_detail_geometric/abacus_detail_geometric.in
@@ -289,8 +289,8 @@ T normalize(T p) {
       // Otherwise, take the largest exponent that guarantees no overflow will
       // occur, and try to scale p so that its largest element will have that
       // exponent.
-      constexpr ElementType max = TypeTraits<ElementType>::max();
-      constexpr ElementType elem_upper_limit = []() -> ElementType {
+      static constexpr ElementType max = TypeTraits<ElementType>::max();
+      static constexpr ElementType elem_upper_limit = []() -> ElementType {
         if (sizeof(ElementType) == 2) return 0x1.ffcp6;
         if (sizeof(ElementType) == 4) return 0x1.fffffep62;
         if (sizeof(ElementType) == 8) return 0x1.fffffffffffffp510;

--- a/source/vk/examples/VectorAddition/source/main.c
+++ b/source/vk/examples/VectorAddition/source/main.c
@@ -537,6 +537,7 @@ int main(void) {
   // Map our output buffer back to host memory
   IS_VK_SUCCESS(vkMapMemory(device, memory, 2 * buffer_size, buffer_size, 0,
                             &mapped_ptr_void));
+  mapped_ptr = mapped_ptr_void;
 
   // Verify our results
   for (int32_t i = 0; i < NUM_WORK_ITEMS; ++i) {


### PR DESCRIPTION
# Overview

Fix build with MSVC, fix VectorAddition test.

# Reason for change

- MSVC wants max to be captured if it has automatic storage. It should not, but the MSVC option to behave in a standards-conforming manner is only available in newer versions than what we aim to support.
- VectorAddition calls vkMapMemory which takes a pointer to a void* output parameter, then copies the result to a int32_t* variable for easier access. In commit ea1a63d005, I missed one copy.

# Description of change

- Work around this by changing the storage to static.
- Add the missing copy.

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-19](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
