### PR TITLE
[NFC] Address remaining clang-tidy warnings.

### DIFF
--- a/modules/mux/targets/host/test/UnitCL/hostBuiltInKernels.cpp
+++ b/modules/mux/targets/host/test/UnitCL/hostBuiltInKernels.cpp
@@ -136,9 +136,11 @@ TEST_F(hostCreateProgramWithBuiltInKernelsTest, CopyBuffer) {
   EXPECT_TRUE(outMem);
   EXPECT_SUCCESS(status);
 
-  ASSERT_SUCCESS(clSetKernelArg(kernel, 0, sizeof(cl_mem), &inMem));
+  ASSERT_SUCCESS(
+      clSetKernelArg(kernel, 0, sizeof(cl_mem), static_cast<void *>(&inMem)));
 
-  ASSERT_SUCCESS(clSetKernelArg(kernel, 1, sizeof(cl_mem), &outMem));
+  ASSERT_SUCCESS(
+      clSetKernelArg(kernel, 1, sizeof(cl_mem), static_cast<void *>(&outMem)));
 
   cl_command_queue queue = clCreateCommandQueue(context, device, 0, &status);
   EXPECT_TRUE(queue);
@@ -285,9 +287,11 @@ TEST_F(hostCreateProgramWithBuiltInKernelsTest, TwoKernelsFirstKernel) {
   EXPECT_TRUE(outMem);
   EXPECT_SUCCESS(status);
 
-  ASSERT_SUCCESS(clSetKernelArg(kernel, 0, sizeof(cl_mem), &inMem));
+  ASSERT_SUCCESS(
+      clSetKernelArg(kernel, 0, sizeof(cl_mem), static_cast<void *>(&inMem)));
 
-  ASSERT_SUCCESS(clSetKernelArg(kernel, 1, sizeof(cl_mem), &outMem));
+  ASSERT_SUCCESS(
+      clSetKernelArg(kernel, 1, sizeof(cl_mem), static_cast<void *>(&outMem)));
 
   cl_command_queue queue;
   queue = clCreateCommandQueue(context, device, 0, &status);
@@ -378,9 +382,11 @@ TEST_F(hostCreateProgramWithBuiltInKernelsTest, TwoKernelsSecondKernel) {
   EXPECT_TRUE(outMem);
   EXPECT_SUCCESS(status);
 
-  ASSERT_SUCCESS(clSetKernelArg(kernel, 0, sizeof(cl_mem), &inMem));
+  ASSERT_SUCCESS(
+      clSetKernelArg(kernel, 0, sizeof(cl_mem), static_cast<void *>(&inMem)));
 
-  ASSERT_SUCCESS(clSetKernelArg(kernel, 1, sizeof(cl_mem), &outMem));
+  ASSERT_SUCCESS(
+      clSetKernelArg(kernel, 1, sizeof(cl_mem), static_cast<void *>(&outMem)));
 
   cl_command_queue queue;
   queue = clCreateCommandQueue(context, device, 0, &status);


### PR DESCRIPTION
# Overview

[NFC] Address remaining clang-tidy warnings.

# Reason for change

clang-tidy wants multi-level pointer conversions to be explicit.

# Description of change

Do so.

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-19](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
