### PR TITLE
Update README file after migration to UXL foundation organization

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-1.4-4baaaa.svg)](CODE_OF_CONDUCT.md)
-[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/codeplaysoftware/oneapi-construction-kit/badge)](https://scorecard.dev/viewer/?uri=github.com/codeplaysoftware/oneapi-construction-kit)
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/uxlfoundation/oneapi-construction-kit/badge)](https://scorecard.dev/viewer/?uri=github.com/uxlfoundation/oneapi-construction-kit)
 
 # oneAPI Construction Kit
 


### PR DESCRIPTION
# Overview

Update OpenSSF scorecard badge and link on UXL foundation organization. 

# Reason for change

It's showing the score when the repository was on Codeplay organization. 

# Description of change

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-19](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
