### PR TITLE
Fix build with LLVM 20.

### DIFF
--- a/modules/compiler/compiler_pipeline/source/add_scheduling_parameters_pass.cpp
+++ b/modules/compiler/compiler_pipeline/source/add_scheduling_parameters_pass.cpp
@@ -25,7 +25,6 @@
 #include <llvm/IR/Module.h>
 #include <llvm/Transforms/Utils/Cloning.h>
 #include <llvm/Transforms/Utils/ValueMapper.h>
-#include <multi_llvm/multi_llvm.h>
 
 #define DEBUG_TYPE "add-sched-params"
 
@@ -232,7 +231,8 @@ PreservedAnalyses compiler::utils::AddSchedulingParametersPass::run(
               NewArgs,
               ArrayRef(FArgs.data(), FArgs.size()).take_back(NumSchedParams));
 
-          auto *NewCB = CallInst::Create(NewF, NewArgs, "", CB);
+          auto *NewCB = CallInst::Create(NewF, NewArgs);
+          NewCB->insertBefore(CB->getIterator());
           NewCB->takeName(CB);
           NewCB->copyMetadata(*CB);
           // Copy over all the old attributes from the call

--- a/modules/compiler/compiler_pipeline/source/barrier_regions.cpp
+++ b/modules/compiler/compiler_pipeline/source/barrier_regions.cpp
@@ -38,7 +38,7 @@
 #include <llvm/Transforms/Utils/Cloning.h>
 #include <llvm/Transforms/Utils/LCSSA.h>
 #include <llvm/Transforms/Utils/Local.h>
-#include <multi_llvm/multi_llvm.h>
+#include <multi_llvm/vector_type_helper.h>
 
 #include <optional>
 
@@ -580,14 +580,12 @@ void compiler::utils::Barrier::SplitBlockwithBarrier() {
       auto id = ConstantInt::get(Type::getInt32Ty(module_.getContext()),
                                  barrier_id - kBarrier_StartNewID);
       // Call invoking entry stub
-      auto entry_caller =
-          CallInst::Create(entry_stub, id, "", (Instruction *)nullptr);
+      auto entry_caller = CallInst::Create(entry_stub, id);
       entry_caller->setDebugLoc(split_point->getDebugLoc());
       entry_caller->setCallingConv(entry_stub->getCallingConv());
 
       // Call invoking exit stub
-      auto exit_caller =
-          CallInst::Create(exit_stub, id, "", (Instruction *)nullptr);
+      auto exit_caller = CallInst::Create(exit_stub, id);
       exit_caller->setDebugLoc(split_point->getDebugLoc());
       exit_caller->setCallingConv(exit_stub->getCallingConv());
 
@@ -1163,7 +1161,8 @@ Function *compiler::utils::Barrier::GenerateNewKernel(BarrierRegion &region) {
       // Change return instruction with end barrier number.
       ConstantInt *cst_zero =
           ConstantInt::get(Type::getInt32Ty(context), kBarrier_EndID);
-      ReturnInst *new_ret = ReturnInst::Create(context, cst_zero, ret);
+      ReturnInst *new_ret = ReturnInst::Create(context, cst_zero);
+      new_ret->insertBefore(ret->getIterator());
       ret->replaceAllUsesWith(new_ret);
       ret->eraseFromParent();
 

--- a/modules/compiler/compiler_pipeline/source/builtin_info.cpp
+++ b/modules/compiler/compiler_pipeline/source/builtin_info.cpp
@@ -23,6 +23,7 @@
 #include <llvm/ADT/StringExtras.h>
 #include <llvm/ADT/StringSwitch.h>
 #include <llvm/IR/Module.h>
+#include <multi_llvm/intrinsic.h>
 
 using namespace llvm;
 
@@ -538,7 +539,7 @@ Function *BuiltinInfo::getScalarEquivalent(const Builtin &B, Module *M) {
     Type *ScalarType = VecRetTy->getElementType();
     // Get the scalar version of the intrinsic
     Function *ScalarIntrinsic =
-        Intrinsic::getDeclaration(M, IntrinsicID, ScalarType);
+        multi_llvm::GetOrInsertIntrinsicDeclaration(M, IntrinsicID, ScalarType);
 
     return ScalarIntrinsic;
   }

--- a/modules/compiler/compiler_pipeline/source/degenerate_sub_group_pass.cpp
+++ b/modules/compiler/compiler_pipeline/source/degenerate_sub_group_pass.cpp
@@ -115,7 +115,8 @@ void replaceSubgroupBuiltinCall(CallInst *CI,
     for (auto &arg : CI->args()) {
       Args.push_back(arg);
     }
-    auto *WGCI = CallInst::Create(WorkGroupBuiltinFn, Args, "", CI);
+    auto *WGCI = CallInst::Create(WorkGroupBuiltinFn, Args);
+    WGCI->insertBefore(CI->getIterator());
     WGCI->setCallingConv(CI->getCallingConv());
     CI->replaceAllUsesWith(WGCI);
     return;
@@ -217,11 +218,13 @@ void replaceSubgroupWorkItemBuiltinCall(CallInst *CI,
         compiler::utils::eMuxBuiltinGetLocalLinearId, *M);
     GetLocalLinearID->setCallingConv(CI->getCallingConv());
     auto *const LocalLinearIDCall =
-        CallInst::Create(GetLocalLinearID, {}, "", CI);
+        CallInst::Create(GetLocalLinearID, ArrayRef<Value *>{});
+    LocalLinearIDCall->insertBefore(CI->getIterator());
     LocalLinearIDCall->setCallingConv(CI->getCallingConv());
     auto *const LocalLinearID = CastInst::CreateIntegerCast(
         LocalLinearIDCall, Type::getInt32Ty(M->getContext()),
-        /* isSigned */ false, "", CI);
+        /* isSigned */ false);
+    LocalLinearID->insertBefore(CI->getIterator());
     CI->replaceAllUsesWith(LocalLinearID);
   } else {
     llvm_unreachable("unhandled sub-group builtin function");

--- a/modules/compiler/compiler_pipeline/source/pass_functions.cpp
+++ b/modules/compiler/compiler_pipeline/source/pass_functions.cpp
@@ -31,7 +31,6 @@
 #include <llvm/IR/Module.h>
 #include <llvm/Transforms/Utils/Cloning.h>
 #include <multi_llvm/llvm_version.h>
-#include <multi_llvm/multi_llvm.h>
 #include <multi_llvm/vector_type_helper.h>
 
 #include <cassert>
@@ -440,7 +439,8 @@ void remapClonedCallsites(llvm::Function &oldFunc, llvm::Function &newFunc,
       }
 
       // create our new call instruction to replace the old one
-      auto newCi = llvm::CallInst::Create(&newFunc, args, name, ci);
+      auto newCi = llvm::CallInst::Create(&newFunc, args, name);
+      newCi->insertBefore(ci->getIterator());
 
       // use the debug location from the old call (if any)
       newCi->setDebugLoc(ci->getDebugLoc());

--- a/modules/compiler/compiler_pipeline/source/replace_local_module_scope_variables_pass.cpp
+++ b/modules/compiler/compiler_pipeline/source/replace_local_module_scope_variables_pass.cpp
@@ -60,8 +60,8 @@ GetElementPtrInst *generateStructGEP(Instruction &inst,
   // create a new GEP just before the instruction
   auto GEP = GetElementPtrInst::CreateInBounds(
       funcsStructTy, funcsStruct,
-      {ConstantInt::get(indexTy, 0), ConstantInt::get(indexTy, index)}, "",
-      &inst);
+      {ConstantInt::get(indexTy, 0), ConstantInt::get(indexTy, index)});
+  GEP->insertBefore(inst.getIterator());
   return GEP;
 }
 
@@ -436,7 +436,8 @@ PreservedAnalyses compiler::utils::ReplaceLocalModuleScopeVariablesPass::run(
         auto local = generateStructGEP(*gep, structTy, index_map[global]);
 
         auto castedLocal =
-            CastInst::CreatePointerCast(local, global->getType(), "", gep);
+            CastInst::CreatePointerCast(local, global->getType());
+        castedLocal->insertBefore(gep->getIterator());
 
         gep->setOperand(0, castedLocal);
         gep->setIsInBounds();
@@ -444,21 +445,25 @@ PreservedAnalyses compiler::utils::ReplaceLocalModuleScopeVariablesPass::run(
         auto local = generateStructGEP(*cast, structTy, index_map[global]);
 
         auto castedLocal =
-            CastInst::CreatePointerCast(local, global->getType(), "", cast);
+            CastInst::CreatePointerCast(local, global->getType());
+        castedLocal->insertBefore(cast->getIterator());
 
         cast->setOperand(0, castedLocal);
       } else if (LoadInst *load = dyn_cast<LoadInst>(user)) {
         auto local = generateStructGEP(*load, structTy, index_map[global]);
 
         auto castedLocal =
-            CastInst::CreatePointerCast(local, global->getType(), "", load);
+            CastInst::CreatePointerCast(local, global->getType());
+        castedLocal->insertBefore(load->getIterator());
 
         load->setOperand(0, castedLocal);
       } else if (StoreInst *store = dyn_cast<StoreInst>(user)) {
         auto local = generateStructGEP(*store, structTy, index_map[global]);
 
         auto castedLocal =
-            CastInst::CreatePointerCast(local, global->getType(), "", store);
+            CastInst::CreatePointerCast(local, global->getType());
+        castedLocal->insertBefore(store->getIterator());
+
         // global could be pointer or value operand of the store
         if (store->getValueOperand() == global) {
           store->setOperand(0, castedLocal);
@@ -474,7 +479,8 @@ PreservedAnalyses compiler::utils::ReplaceLocalModuleScopeVariablesPass::run(
           auto local = generateStructGEP(*inst, structTy, index_map[global]);
 
           auto castedLocal =
-              CastInst::CreatePointerCast(local, global->getType(), "", inst);
+              CastInst::CreatePointerCast(local, global->getType());
+          castedLocal->insertBefore(inst->getIterator());
 
           auto indexTy = Type::getInt32Ty(M.getContext());
           Value *newCv = UndefValue::get(cv->getType());
@@ -482,14 +488,16 @@ PreservedAnalyses compiler::utils::ReplaceLocalModuleScopeVariablesPass::run(
           // We can't simply 'setOperand' in a 'ConstantVector'. We have to
           // recreate it from scratch.
           for (unsigned i = 0; i < cv->getNumOperands(); ++i) {
+            Instruction *newCvInst;
             if (cv->getOperand(i) == global) {
-              newCv = InsertElementInst::Create(
-                  newCv, castedLocal, ConstantInt::get(indexTy, i), "", inst);
+              newCvInst = InsertElementInst::Create(
+                  newCv, castedLocal, ConstantInt::get(indexTy, i));
             } else {
-              newCv = InsertElementInst::Create(newCv, cv->getOperand(i),
-                                                ConstantInt::get(indexTy, i),
-                                                "", inst);
+              newCvInst = InsertElementInst::Create(
+                  newCv, cv->getOperand(i), ConstantInt::get(indexTy, i));
             }
+            newCvInst->insertBefore(inst->getIterator());
+            newCv = newCvInst;
           }
 
           // And don't forget to replace 'cv' by 'newCv'.
@@ -505,8 +513,9 @@ PreservedAnalyses compiler::utils::ReplaceLocalModuleScopeVariablesPass::run(
             auto local =
                 generateStructGEP(*incomingBlockT, structTy, index_map[global]);
 
-            auto castedLocal = CastInst::CreatePointerCast(
-                local, global->getType(), "", incomingBlockT);
+            auto castedLocal =
+                CastInst::CreatePointerCast(local, global->getType());
+            castedLocal->insertBefore(incomingBlockT->getIterator());
 
             phi->setIncomingValue(i, castedLocal);
           }
@@ -515,7 +524,8 @@ PreservedAnalyses compiler::utils::ReplaceLocalModuleScopeVariablesPass::run(
         auto local = generateStructGEP(*atomic, structTy, index_map[global]);
 
         auto castedLocal =
-            CastInst::CreatePointerCast(local, global->getType(), "", atomic);
+            CastInst::CreatePointerCast(local, global->getType());
+        castedLocal->insertBefore(atomic->getIterator());
 
         // global could be pointer or value operand of the atomic
         if (atomic->getPointerOperand() == global) {
@@ -527,7 +537,8 @@ PreservedAnalyses compiler::utils::ReplaceLocalModuleScopeVariablesPass::run(
         const auto local =
             generateStructGEP(*atomic, structTy, index_map[global]);
         const auto castedLocal =
-            CastInst::CreatePointerCast(local, global->getType(), "", atomic);
+            CastInst::CreatePointerCast(local, global->getType());
+        castedLocal->insertBefore(atomic->getIterator());
 
         // global could be the pointer
         if (atomic->getPointerOperand() == global) {
@@ -545,7 +556,8 @@ PreservedAnalyses compiler::utils::ReplaceLocalModuleScopeVariablesPass::run(
         auto local = generateStructGEP(*select, structTy, index_map[global]);
 
         auto castedLocal =
-            CastInst::CreatePointerCast(local, global->getType(), "", select);
+            CastInst::CreatePointerCast(local, global->getType());
+        castedLocal->insertBefore(select->getIterator());
 
         // global could be the true or false value of the select
         if (select->getTrueValue() == global) {
@@ -557,7 +569,8 @@ PreservedAnalyses compiler::utils::ReplaceLocalModuleScopeVariablesPass::run(
         auto local = generateStructGEP(*call, structTy, index_map[global]);
 
         auto castedLocal =
-            CastInst::CreatePointerCast(local, global->getType(), "", call);
+            CastInst::CreatePointerCast(local, global->getType());
+        castedLocal->insertBefore(call->getIterator());
 
         unsigned i = 0;
         for (; i < call->getNumOperands(); ++i) {
@@ -568,15 +581,19 @@ PreservedAnalyses compiler::utils::ReplaceLocalModuleScopeVariablesPass::run(
       } else if (InsertElementInst *insertIns =
                      dyn_cast<InsertElementInst>(user)) {
         auto local = generateStructGEP(*insertIns, structTy, index_map[global]);
-        auto castedLocal = CastInst::CreatePointerCast(local, global->getType(),
-                                                       "", insertIns);
+        auto castedLocal =
+            CastInst::CreatePointerCast(local, global->getType());
+        castedLocal->insertBefore(insertIns->getIterator());
+
         // Update middle operand as the others are the vector and index
         insertIns->setOperand(1, castedLocal);
       } else if (auto *cmpIns = dyn_cast<CmpInst>(user)) {
         const auto local =
             generateStructGEP(*cmpIns, structTy, index_map[global]);
         const auto castedLocal =
-            CastInst::CreatePointerCast(local, global->getType(), "", cmpIns);
+            CastInst::CreatePointerCast(local, global->getType());
+        castedLocal->insertBefore(cmpIns->getIterator());
+
         // global could be either side of the compare
         if (cmpIns->getOperand(0) == global) {
           cmpIns->setOperand(0, castedLocal);

--- a/modules/compiler/multi_llvm/include/multi_llvm/intrinsic.h
+++ b/modules/compiler/multi_llvm/include/multi_llvm/intrinsic.h
@@ -1,0 +1,35 @@
+// Copyright (C) Codeplay Software Limited
+//
+// Licensed under the Apache License, Version 2.0 (the "License") with LLVM
+// Exceptions; you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/LICENSE.txt
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef MULTI_LLVM_MULTI_INTRINSIC_H_INCLUDED
+#define MULTI_LLVM_MULTI_INTRINSIC_H_INCLUDED
+
+#include <multi_llvm/llvm_version.h>
+
+namespace multi_llvm {
+static inline auto GetOrInsertIntrinsicDeclaration(
+    llvm::Module *M, llvm::Intrinsic::ID id,
+    llvm::ArrayRef<llvm::Type *> Tys = {}) {
+#if LLVM_VERSION_GREATER_EQUAL(20, 0)
+  return llvm::Intrinsic::getOrInsertDeclaration(M, id, Tys);
+#else
+  return llvm::Intrinsic::getDeclaration(M, id, Tys);
+#endif
+}
+
+}  // namespace multi_llvm
+
+#endif  // MULTI_LLVM_MULTI_INTRINSIC_H_INCLUDED

--- a/modules/compiler/source/base/source/builtin_simplification_pass.cpp
+++ b/modules/compiler/source/base/source/builtin_simplification_pass.cpp
@@ -175,7 +175,8 @@ bool powToX(Module &module, const std::map<std::string, std::string> &map,
     args.push_back(newY);
 
     // create a new call that calls the replacement fast function
-    auto newCi = CallInst::Create(newFunc, args, bundles, "", ci);
+    auto newCi = CallInst::Create(newFunc, args, bundles);
+    newCi->insertBefore(ci->getIterator());
 
     // take the name of the old call instruction
     newCi->takeName(ci);

--- a/modules/compiler/source/base/source/fast_math_pass.cpp
+++ b/modules/compiler/source/base/source/fast_math_pass.cpp
@@ -13,6 +13,7 @@
 // under the License.
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
 #include <base/fast_math_pass.h>
 #include <compiler/utils/metadata.h>
 #include <llvm/ADT/StringMap.h>
@@ -191,7 +192,8 @@ bool replaceFastMathCalls(Module &M) {
       args.push_back(arg);
     }
 
-    auto newCi = CallInst::Create(newFunc, args, bundles, "", ci);
+    auto newCi = CallInst::Create(newFunc, args, bundles);
+    newCi->insertBefore(ci->getIterator());
     newCi->takeName(ci);
     newCi->setCallingConv(ci->getCallingConv());
     ci->replaceAllUsesWith(newCi);

--- a/modules/compiler/source/base/source/printf_replacement_pass.cpp
+++ b/modules/compiler/source/base/source/printf_replacement_pass.cpp
@@ -803,7 +803,8 @@ void compiler::PrintfReplacementPass::rewritePrintfCall(
   const std::string name = ci->getName().str();
   ci->setName("");
 
-  auto newCi = CallInst::Create(callFunction, new_args, name, ci);
+  auto newCi = CallInst::Create(callFunction, new_args, name);
+  newCi->insertBefore(ci->getIterator());
   newCi->setDebugLoc(ci->getDebugLoc());
   newCi->setCallingConv(ci->getCallingConv());
 

--- a/modules/compiler/source/base/source/software_division_pass.cpp
+++ b/modules/compiler/source/base/source/software_division_pass.cpp
@@ -40,30 +40,35 @@ llvm::PreservedAnalyses compiler::SoftwareDivisionPass::run(
           CmpInst *const topCompare = ICmpInst::Create(
               Instruction::ICmp, ICmpInst::ICMP_EQ, I.getOperand(0),
               ConstantInt::get(
-                  type, APInt::getSignedMinValue(type->getScalarSizeInBits())),
-              "", &I);
+                  type, APInt::getSignedMinValue(type->getScalarSizeInBits())));
+          topCompare->insertBefore(I.getIterator());
 
           // Compare divisor to -1
-          CmpInst *const botCompare = ICmpInst::Create(
-              Instruction::ICmp, ICmpInst::ICMP_EQ, I.getOperand(1),
-              ConstantInt::get(type, -1), "", &I);
+          CmpInst *const botCompare =
+              ICmpInst::Create(Instruction::ICmp, ICmpInst::ICMP_EQ,
+                               I.getOperand(1), ConstantInt::get(type, -1));
+          botCompare->insertBefore(I.getIterator());
 
           // Binary And between dividend and divisor comparison checks
-          Value *const minDivCondition = BinaryOperator::Create(
-              Instruction::And, topCompare, botCompare, "", &I);
+          Instruction *const minDivCondition =
+              BinaryOperator::Create(Instruction::And, topCompare, botCompare);
+          minDivCondition->insertBefore(I.getIterator());
 
           // Compare divisor to zero for divide by zero error
-          CmpInst *const zeroCompare = ICmpInst::Create(
-              Instruction::ICmp, ICmpInst::ICMP_EQ, I.getOperand(1),
-              ConstantInt::get(type, 0), "", &I);
+          CmpInst *const zeroCompare =
+              ICmpInst::Create(Instruction::ICmp, ICmpInst::ICMP_EQ,
+                               I.getOperand(1), ConstantInt::get(type, 0));
+          zeroCompare->insertBefore(I.getIterator());
 
           // Binary Or between both of the error case checks
-          Value *const errCondition = BinaryOperator::Create(
-              Instruction::Or, zeroCompare, minDivCondition, "", &I);
+          Instruction *const errCondition = BinaryOperator::Create(
+              Instruction::Or, zeroCompare, minDivCondition);
+          errCondition->insertBefore(I.getIterator());
 
           // In the case of an error condition set the divisor to +1
           SelectInst *const select = SelectInst::Create(
-              errCondition, ConstantInt::get(type, 1), I.getOperand(1), "", &I);
+              errCondition, ConstantInt::get(type, 1), I.getOperand(1));
+          select->insertBefore(I.getIterator());
 
           I.setOperand(1, select);
 
@@ -76,13 +81,15 @@ llvm::PreservedAnalyses compiler::SoftwareDivisionPass::run(
           Type *const type = I.getType();
 
           // Equality comparison between divisor and zero
-          CmpInst *const compare = ICmpInst::Create(
-              Instruction::ICmp, ICmpInst::ICMP_EQ, I.getOperand(1),
-              ConstantInt::get(type, 0), "", &I);
+          CmpInst *const compare =
+              ICmpInst::Create(Instruction::ICmp, ICmpInst::ICMP_EQ,
+                               I.getOperand(1), ConstantInt::get(type, 0));
+          compare->insertBefore(I.getIterator());
 
           // If divisor is zero use select to fallback to +1 for divisor.
           SelectInst *const select = SelectInst::Create(
-              compare, ConstantInt::get(type, 1), I.getOperand(1), "", &I);
+              compare, ConstantInt::get(type, 1), I.getOperand(1));
+          select->insertBefore(I.getIterator());
 
           I.setOperand(1, select);
 

--- a/modules/compiler/spirv-ll/source/builder.cpp
+++ b/modules/compiler/spirv-ll/source/builder.cpp
@@ -445,8 +445,10 @@ bool spirv_ll::Builder::replaceBuiltinUsesWithCalls(
       // Make sure our index is a 32 bit integer to match the work item function
       // signatures.
       if (index->getType()->getScalarSizeInBits() != 32) {
-        index = llvm::CastInst::CreateIntegerCast(index, IRBuilder.getInt32Ty(),
-                                                  false, "", useInst);
+        auto *cast = llvm::CastInst::CreateIntegerCast(
+            index, IRBuilder.getInt32Ty(), false);
+        cast->insertBefore(useInst->getIterator());
+        index = cast;
       }
       arg.push_back(index);
     }
@@ -458,8 +460,10 @@ bool spirv_ll::Builder::replaceBuiltinUsesWithCalls(
     // is needed for VK modules sometimes because the GLSL builtin variables are
     // vectors of 32 bit ints whereas the CL work item functions return size_t.
     if (use->getType() != workItemCall->getType()) {
-      workItemCall = llvm::CastInst::CreateIntegerCast(
-          workItemCall, use->getType(), false, "", useInst);
+      auto *cast = llvm::CastInst::CreateIntegerCast(workItemCall,
+                                                     use->getType(), false);
+      cast->insertBefore(useInst->getIterator());
+      workItemCall = cast;
     }
     workItemCall->takeName(useInst);
     useInst->replaceAllUsesWith(workItemCall);

--- a/modules/compiler/targets/host/source/AddFloatingPointControl.cpp
+++ b/modules/compiler/targets/host/source/AddFloatingPointControl.cpp
@@ -27,6 +27,7 @@
 #include <llvm/IR/IntrinsicsX86.h>
 #include <llvm/IR/Module.h>
 #include <llvm/TargetParser/Triple.h>
+#include <multi_llvm/intrinsic.h>
 
 using namespace llvm;
 
@@ -42,11 +43,11 @@ void configX86FP(Function &wrapper, Function &function) {
   // x86 STMXCSR instruction stores the contents of the MXCSR register in the
   // destination operand. MXCSR contains flags for control and status
   // information regarding SSE instructions.
-  Function *const st_mxcsr = Intrinsic::getDeclaration(
+  Function *const st_mxcsr = multi_llvm::GetOrInsertIntrinsicDeclaration(
       wrapper.getParent(), Intrinsic::x86_sse_stmxcsr);
 
   // Loads the source operand into the MXCSR register
-  Function *const ld_mxcsr = Intrinsic::getDeclaration(
+  Function *const ld_mxcsr = multi_llvm::GetOrInsertIntrinsicDeclaration(
       wrapper.getParent(), Intrinsic::x86_sse_ldmxcsr);
 
   // Allocas to store the old and new state
@@ -131,11 +132,11 @@ void configArmFP(Function &wrapper, Function &function) {
   // create an IR builder with a single basic block in our wrapper
   IRBuilder<> ir(BasicBlock::Create(wrapper.getContext(), "", &wrapper));
 
-  Function *const get_fpscr =
-      Intrinsic::getDeclaration(wrapper.getParent(), Intrinsic::arm_get_fpscr);
+  Function *const get_fpscr = multi_llvm::GetOrInsertIntrinsicDeclaration(
+      wrapper.getParent(), Intrinsic::arm_get_fpscr);
 
-  Function *const set_fpscr =
-      Intrinsic::getDeclaration(wrapper.getParent(), Intrinsic::arm_set_fpscr);
+  Function *const set_fpscr = multi_llvm::GetOrInsertIntrinsicDeclaration(
+      wrapper.getParent(), Intrinsic::arm_set_fpscr);
 
   // call fpscr to store the original state
   auto original_fpscr = ir.CreateCall(get_fpscr);

--- a/modules/compiler/vecz/source/include/memory_operations.h
+++ b/modules/compiler/vecz/source/include/memory_operations.h
@@ -70,14 +70,12 @@ llvm::Function *getOrCreateMaskedMemOpFn(VectorizationContext &Ctx,
 /// @param[in] EVL vector length as i32, else null (full width operation).
 /// @param[in] Alignment Alignment
 /// @param[in] Name Name to give to the call instruction.
-/// @param[in] InsertBefore Insertion point for the call instruction.
 ///
 /// @return Call instruction or null on error.
 llvm::CallInst *createMaskedLoad(VectorizationContext &Ctx, llvm::Type *Ty,
                                  llvm::Value *Ptr, llvm::Value *Mask,
                                  llvm::Value *EVL, unsigned Alignment,
-                                 llvm::Twine Name = "",
-                                 llvm::Instruction *InsertBefore = nullptr);
+                                 llvm::Twine Name = "");
 
 /// @brief Create a call to a masked store operation builtin function.
 ///
@@ -88,14 +86,12 @@ llvm::CallInst *createMaskedLoad(VectorizationContext &Ctx, llvm::Type *Ty,
 /// @param[in] EVL vector length as i32, else null (full width operation).
 /// @param[in] Alignment Alignment
 /// @param[in] Name Name to give to the call instruction.
-/// @param[in] InsertBefore Insertion point for the call instruction.
 ///
 /// @return Call instruction or null on error.
 llvm::CallInst *createMaskedStore(VectorizationContext &Ctx, llvm::Value *Data,
                                   llvm::Value *Ptr, llvm::Value *Mask,
                                   llvm::Value *EVL, unsigned Alignment,
-                                  llvm::Twine Name = "",
-                                  llvm::Instruction *InsertBefore = nullptr);
+                                  llvm::Twine Name = "");
 
 /// @brief Return or declare a (masked) interleaved memory operation builtin
 /// function.
@@ -130,14 +126,13 @@ llvm::Function *getOrCreateInterleavedMemOpFn(
 /// case an unmasked builtin is called.
 /// @param[in] Alignment Alignment of the operation.
 /// @param[in] Name Name to give to the call instruction.
-/// @param[in] InsertBefore Insertion point for the call instruction.
 ///
 /// @return Call instruction or null on error.
-llvm::CallInst *createInterleavedLoad(
-    VectorizationContext &Ctx, llvm::Type *Ty, llvm::Value *Ptr,
-    llvm::Value *Stride, llvm::Value *Mask, llvm::Value *EVL,
-    unsigned Alignment, llvm::Twine Name = "",
-    llvm::Instruction *InsertBefore = nullptr);
+llvm::CallInst *createInterleavedLoad(VectorizationContext &Ctx, llvm::Type *Ty,
+                                      llvm::Value *Ptr, llvm::Value *Stride,
+                                      llvm::Value *Mask, llvm::Value *EVL,
+                                      unsigned Alignment,
+                                      llvm::Twine Name = "");
 
 /// @brief Create a call to a (masked) interleaved store builtin function. Also
 /// known as a strided store.
@@ -152,14 +147,13 @@ llvm::CallInst *createInterleavedLoad(
 /// case an unmasked builtin is called.
 /// @param[in] Alignment Alignment of the operation.
 /// @param[in] Name Name to give to the call instruction.
-/// @param[in] InsertBefore Insertion point for the call instruction.
 ///
 /// @return Call instruction or null on error.
-llvm::CallInst *createInterleavedStore(
-    VectorizationContext &Ctx, llvm::Value *Data, llvm::Value *Ptr,
-    llvm::Value *Stride, llvm::Value *Mask, llvm::Value *EVL,
-    unsigned Alignment, llvm::Twine Name = "",
-    llvm::Instruction *InsertBefore = nullptr);
+llvm::CallInst *createInterleavedStore(VectorizationContext &Ctx,
+                                       llvm::Value *Data, llvm::Value *Ptr,
+                                       llvm::Value *Stride, llvm::Value *Mask,
+                                       llvm::Value *EVL, unsigned Alignment,
+                                       llvm::Twine Name = "");
 
 /// @brief Return or declare a (masked) scatter/gather memory operation builtin
 /// function.
@@ -196,14 +190,12 @@ llvm::Function *getOrCreateScatterGatherMemOpFn(vecz::VectorizationContext &Ctx,
 /// @param[in] Alignment Alignment of the operation.
 /// @param[in] EVL vector length as i32, else null (full width operation).
 /// @param[in] Name Name to give to the call instruction.
-/// @param[in] InsertBefore Insertion point for the call instruction.
 ///
 /// @return Call instruction or null on error.
 llvm::CallInst *createGather(VectorizationContext &Ctx, llvm::Type *Ty,
                              llvm::Value *VecPtr, llvm::Value *Mask,
                              llvm::Value *EVL, unsigned Alignment,
-                             llvm::Twine Name = "",
-                             llvm::Instruction *InsertBefore = nullptr);
+                             llvm::Twine Name = "");
 
 /// @brief Create a call to a (masked) scatter memory operation builtin
 /// function.
@@ -218,14 +210,12 @@ llvm::CallInst *createGather(VectorizationContext &Ctx, llvm::Type *Ty,
 /// @param[in] Alignment Alignment of the operation.
 /// @param[in] EVL vector length as i32, else null (full width operation).
 /// @param[in] Name Name to give to the call instruction.
-/// @param[in] InsertBefore Insertion point for the call instruction.
 ///
 /// @return Call instruction or null on error.
 llvm::CallInst *createScatter(VectorizationContext &Ctx, llvm::Value *VecData,
                               llvm::Value *VecPtr, llvm::Value *Mask,
                               llvm::Value *EVL, unsigned Alignment,
-                              llvm::Twine Name = "",
-                              llvm::Instruction *InsertBefore = nullptr);
+                              llvm::Twine Name = "");
 
 /// @brief an enum to distinguish between loads and stores, and between builtin
 /// memop calls and native IR memop instructions.

--- a/modules/compiler/vecz/source/include/transform/control_flow_conversion_pass.h
+++ b/modules/compiler/vecz/source/include/transform/control_flow_conversion_pass.h
@@ -113,7 +113,7 @@ class ControlFlowConversionState {
     llvm::SmallDenseMap<llvm::BasicBlock *, llvm::Value *, 4> exitMasks;
     /// @brief Mask that describes which lanes are active at the start of the
     /// basic block.
-    llvm::Value *entryMask = nullptr;
+    llvm::Instruction *entryMask = nullptr;
   };
   llvm::DenseMap<llvm::BasicBlock *, MaskInfo> MaskInfos;
 

--- a/modules/compiler/vecz/source/transform/basic_mem2reg_pass.cpp
+++ b/modules/compiler/vecz/source/transform/basic_mem2reg_pass.cpp
@@ -22,7 +22,6 @@
 #include <llvm/Support/Debug.h>
 #include <llvm/Support/raw_ostream.h>
 #include <llvm/Transforms/Utils/Local.h>
-#include <multi_llvm/llvm_version.h>
 
 #include "debugging.h"
 #include "transform/passes.h"
@@ -225,8 +224,9 @@ bool BasicMem2RegPass::promoteAlloca(AllocaInst *Alloca) const {
           NewValue->getType()->getPrimitiveSizeInBits()) {
         return false;
       }
-      NewValue = CastInst::CreateBitOrPointerCast(StoredValue, Load->getType(),
-                                                  "", Load);
+      auto *CI = CastInst::CreateBitOrPointerCast(StoredValue, Load->getType());
+      CI->insertBefore(Load->getIterator());
+      NewValue = CI;
     }
     LLVM_DEBUG(dbgs() << "VM2R: Replaced :" << *Load << "\n");
     LLVM_DEBUG(dbgs() << "      |-> with :" << *NewValue << "\n");

--- a/modules/compiler/vecz/source/transform/packetization_helpers.cpp
+++ b/modules/compiler/vecz/source/transform/packetization_helpers.cpp
@@ -30,7 +30,7 @@
 #include <llvm/IR/Instructions.h>
 #include <llvm/IR/Intrinsics.h>
 #include <llvm/Transforms/Utils/LoopUtils.h>
-#include <multi_llvm/multi_llvm.h>
+#include <multi_llvm/intrinsic.h>
 #include <multi_llvm/vector_type_helper.h>
 
 #include "debugging.h"
@@ -322,8 +322,8 @@ Value *createMaybeVPReduction(IRBuilderBase &B, Value *Val, RecurKind Kind,
       break;
   }
 
-  auto *const F = Intrinsic::getDeclaration(B.GetInsertBlock()->getModule(),
-                                            IntrinsicOp, Val->getType());
+  auto *const F = multi_llvm::GetOrInsertIntrinsicDeclaration(
+      B.GetInsertBlock()->getModule(), IntrinsicOp, Val->getType());
   assert(F && "Could not declare vector-predicated reduction intrinsic");
 
   auto *const VecTy = cast<VectorType>(Val->getType());

--- a/modules/compiler/vecz/source/transform/pre_linearize_pass.cpp
+++ b/modules/compiler/vecz/source/transform/pre_linearize_pass.cpp
@@ -51,7 +51,6 @@
 #include <llvm/Pass.h>
 #include <llvm/Support/InstructionCost.h>
 #include <llvm/Transforms/Utils/LoopUtils.h>
-#include <multi_llvm/multi_llvm.h>
 #include <multi_llvm/vector_type_helper.h>
 
 #include "analysis/uniform_value_analysis.h"
@@ -192,15 +191,16 @@ bool hoistInstructions(BasicBlock &BB, BranchInst &Branch, bool exceptions) {
               Value *one = ConstantInt::get(divisor->getType(), 1);
               Value *cond = Branch.getCondition();
 
+              Instruction *SI;
               if (TrueBranch) {
-                masked =
-                    SelectInst::Create(cond, divisor, one,
-                                       divisor->getName() + ".hoist_guard", &I);
+                SI = SelectInst::Create(cond, divisor, one,
+                                        divisor->getName() + ".hoist_guard");
               } else {
-                masked =
-                    SelectInst::Create(cond, one, divisor,
-                                       divisor->getName() + ".hoist_guard", &I);
+                SI = SelectInst::Create(cond, one, divisor,
+                                        divisor->getName() + ".hoist_guard");
               }
+              SI->insertBefore(I.getIterator());
+              masked = SI;
             }
           }
 

--- a/modules/compiler/vecz/source/transform/remove_intptr_pass.cpp
+++ b/modules/compiler/vecz/source/transform/remove_intptr_pass.cpp
@@ -63,7 +63,8 @@ PreservedAnalyses RemoveIntPtrPass::run(Function &F,
         // hopefully be removed later.
         auto num_values = phi->getNumIncomingValues();
         PHINode *new_phi = PHINode::Create(int_ptr->getSrcTy(), num_values,
-                                           phi->getName() + ".intptr", phi);
+                                           phi->getName() + ".intptr");
+        new_phi->insertBefore(phi->getIterator());
 
         Instruction *insert = phi;
         while (isa<PHINode>(insert)) {

--- a/modules/compiler/vecz/source/transform/simplify_infinite_loop_pass.cpp
+++ b/modules/compiler/vecz/source/transform/simplify_infinite_loop_pass.cpp
@@ -20,7 +20,6 @@
 #include <unordered_set>
 
 #include "debugging.h"
-#include "multi_llvm/multi_llvm.h"
 #include "transform/passes.h"
 
 using namespace llvm;
@@ -100,8 +99,8 @@ PreservedAnalyses vecz::SimplifyInfiniteLoopPass::run(
     }
     // Add new phi nodes for instructions computed in `toBlend`.
     for (Instruction *I : toBlend) {
-      PHINode *PHI = PHINode::Create(I->getType(), 2, I->getName() + ".blend",
-                                     &target->front());
+      PHINode *PHI = PHINode::Create(I->getType(), 2, I->getName() + ".blend");
+      PHI->insertBefore(target->begin());
       for (BasicBlock *pred : predecessors(target)) {
         if (pred != virtualExit) {
           PHI->addIncoming(I, pred);

--- a/modules/compiler/vecz/source/transform/uniform_reassociation_pass.cpp
+++ b/modules/compiler/vecz/source/transform/uniform_reassociation_pass.cpp
@@ -166,7 +166,8 @@ bool Reassociator::reassociate(llvm::BinaryOperator &Op) {
       // Transform (Varying Op Uniform) Op Varying
       // into (Varying Op Varying) Op Uniform
       auto *const P = BinaryOperator::Create(Opcode, A->getOperand(0), RHS,
-                                             "varying.reassoc", &Op);
+                                             "varying.reassoc");
+      P->insertBefore(Op.getIterator());
       UVR->setVarying(P);
       Op.setOperand(0, P);
       Op.setOperand(1, A->getOperand(1));
@@ -177,7 +178,8 @@ bool Reassociator::reassociate(llvm::BinaryOperator &Op) {
       // Transform (Varying Op Uniform) Op Uniform
       // into Varying Op (Uniform Op Uniform)
       auto *const P = BinaryOperator::Create(Opcode, A->getOperand(1), RHS,
-                                             "uniform.reassoc", &Op);
+                                             "uniform.reassoc");
+      P->insertBefore(Op.getIterator());
       Op.setOperand(0, A->getOperand(0));
       Op.setOperand(1, P);
       UVR->remove(A);
@@ -192,7 +194,8 @@ bool Reassociator::reassociate(llvm::BinaryOperator &Op) {
     // Transform Varying Op (Varying Op Uniform)
     // into (Varying Op Varying) Op Uniform
     auto *const P = BinaryOperator::Create(Opcode, B->getOperand(0), LHS,
-                                           "varying.reassoc", &Op);
+                                           "varying.reassoc");
+    P->insertBefore(Op.getIterator());
     Op.setOperand(0, P);
     Op.setOperand(1, B->getOperand(1));
     UVR->setVarying(P);

--- a/modules/compiler/vecz/source/vector_target_info_arm.cpp
+++ b/modules/compiler/vecz/source/vector_target_info_arm.cpp
@@ -18,6 +18,7 @@
 #include <llvm/IR/Instructions.h>
 #include <llvm/IR/IntrinsicsAArch64.h>
 #include <llvm/IR/IntrinsicsARM.h>
+#include <multi_llvm/intrinsic.h>
 #include <multi_llvm/vector_type_helper.h>
 
 #include "debugging.h"
@@ -223,8 +224,8 @@ bool TargetInfoArm::optimizeInterleavedGroup(IRBuilder<> &B,
     Tys = {VecTy, PtrTy};
   }
 
-  Function *IntrFn =
-      Intrinsic::getDeclaration(Op0->getModule(), (Intrinsic::ID)IntrID, Tys);
+  Function *IntrFn = multi_llvm::GetOrInsertIntrinsicDeclaration(
+      Op0->getModule(), (Intrinsic::ID)IntrID, Tys);
   if (!IntrFn) {
     return false;
   }
@@ -378,7 +379,7 @@ bool TargetInfoAArch64::optimizeInterleavedGroup(
     VecTy = cast<FixedVectorType>(Op0->getType());
   }
 
-  Function *IntrFn = Intrinsic::getDeclaration(
+  Function *IntrFn = multi_llvm::GetOrInsertIntrinsicDeclaration(
       Op0->getModule(), (Intrinsic::ID)IntrID, {VecTy, PtrTy});
   if (!IntrFn) {
     return false;


### PR DESCRIPTION
# Overview

Fix build with LLVM 20.

# Reason for change

* LLVM 20 renames Intrinsic::getDeclaration to Intrinsic::getOrInsertDeclaration.
* LLVM 20 deprecates instruction creation overloads that take an Instruction * as an insertion point, recommending the ones that take an iterator instead. In LLVM 18, for the most part, those overloads taking iterators do not yet exist.

# Description of change

* Handle the Intrinsic function rename with a multi_llvm::GetOrInsertIntrinsicDeclaration helper function.
* In LLVM 18, Instruction::insertBefore does already take iterators, so rework the code to consistently use that. This removes some bitcast instructions in memory_operations.cpp that could not be updated, but had become unnecessary ever since LLVM switched to opaque pointers.

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-19](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
