### PR TITLE
clang-format: fix output.

### DIFF
--- a/.github/workflows/run_pr_tests.yml
+++ b/.github/workflows/run_pr_tests.yml
@@ -110,16 +110,9 @@ jobs:
 
       - name: run clang-format
         run: |
-          # we've installed clang-format-16 in the docker via pip, which just installs it as clang-format,
+          # we've installed clang-format-19 in the docker via pip, which just installs it as clang-format,
           # so just use clang-format-diff and -b clang-format directly
           git fetch origin ${{ github.base_ref }}
           git diff --no-color origin/${{ github.base_ref }} | \
             clang-format-diff.py -p1 -regex \
-            "^(?!(.+\\/)*(external|cookie)\\/).*\\.(c|cc|cxx|cpp|h|hh|hxx|hpp)$" -b clang-format \
-            > clang-format.diff
-          if [ `wc -l < clang-format.diff` = 0 ]; then
-            echo 'success: clang-format did not generate a diff'
-            exit 0
-          fi
-          cat clang-format.diff
-          exit 1
+            "^(?!(.+\\/)*(external|cookie)\\/).*\\.(c|cc|cxx|cpp|h|hh|hxx|hpp)$" -b clang-format


### PR DESCRIPTION
# Overview

clang-format: fix output.

# Reason for change

Now that we have upgraded to clang-format-19, its exit status already indicates whether any changes were suggested. We no longer need to save it to a file and count the lines, and our efforts were causing the output to be hidden.

# Description of change

*Describe the intended behaviour your changes are meant to introduce to the
project and explain how they resolve the problem stated above. Detail any
relevant changes that may affect other users of the project, such as
compilation options, runtime flags, expected inputs and outputs, API entry
points, etc.*

*If you have added new testing, provide details on what tests you have added
and what the purpose of them is.*

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-19](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
