### PR TITLE
Do not save PR build cache in codeql

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -30,7 +30,6 @@ jobs:
       - name: setup-ubuntu
         uses:  ./.github/actions/setup_build
         with:
-          save: true
           llvm_version: 18
           llvm_build_type: RelAssert
 


### PR DESCRIPTION
# Overview

Do not save PR build cache in codeql

# Reason for change

This unnecessarily floods the system with caches which can breech our limit

# Description of change

Remove save cache flag.
