### PR TITLE
Reduce PR testing overheads

### DIFF
--- a/.github/actions/do_build_ock/action.yml
+++ b/.github/actions/do_build_ock/action.yml
@@ -76,6 +76,10 @@ inputs:
   enable_rvv_scalable_vp_vecz_check:
     description: "Enable RVV scalable vecz VP check (default OFF)"
     default: OFF
+  enable_unitcl_expensive:
+    description: "UnitCL expensive tests enabled (default ON)"
+    required: false
+    default: ON
   install_dir:
     description: "Install directory for OCK"
     default: install
@@ -154,6 +158,7 @@ runs:
               -DCA_RISCV_ENABLED=${{ inputs.riscv_enabled }}
               -DCA_CL_ENABLE_RVV_SCALABLE_VECZ_CHECK=${{ inputs.enable_rvv_scalable_vecz_check }}
               -DCA_CL_ENABLE_RVV_SCALABLE_VP_VECZ_CHECK=${{ inputs.enable_rvv_scalable_vp_vecz_check }}
+              -DCA_CL_ENABLE_UNITCL_EXPENSIVE_CHECK=${{ inputs.enable_unitcl_expensive }}
               -DCMAKE_INSTALL_PREFIX=${{ inputs.install_dir }}
               -DCA_USE_LINKER=${{ inputs.use_linker }}
               -DCA_RUNTIME_COMPILER_ENABLED=${{ inputs.runtime_compiler_enabled }}

--- a/.github/workflows/run_pr_tests.yml
+++ b/.github/workflows/run_pr_tests.yml
@@ -7,15 +7,22 @@ on:
         required: false
         type: boolean
         default: false
+      is_pull_request:
+        required: false
+        type: boolean
+        default: true
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
     inputs:
       update_cache:
-        required: false      
-        default: false
+        required: false
         type: boolean
-  
+        default: false
+      is_pull_request:
+        required: false
+        type: bool
+        default: true
 permissions: {}
 
 concurrency:
@@ -211,6 +218,7 @@ jobs:
           shell_to_use: pwsh
           gtest_launcher: "python3;-u;${{ github.workspace }}/scripts/gtest-terse-runner.py"
           debug_support: ON
+          enable_unitcl_expensive: ${{ !inputs.is_pull_request && 'ON' || 'OFF' }}
 
       - name: build ock x86_64 offline
         uses: ./.github/actions/do_build_ock

--- a/.github/workflows/run_pr_tests_caller.yml
+++ b/.github/workflows/run_pr_tests_caller.yml
@@ -12,10 +12,15 @@ on:
       - '.github/actions/do_build_ock/**'
       - '.github/actions/setup_build/**'
       - '.github/workflows/run_pr_tests.yml'
+      - '.github/workflows/run_pr_tests_caller.yml'
       - 'CMakeLists.txt'
   schedule:
     # Run Mon-Fri at 7pm
     - cron: '00 19 * * 1-5'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   run-with-pull:
@@ -24,6 +29,7 @@ jobs:
     uses: ./.github/workflows/run_pr_tests.yml
     with:
       update_cache: false
+      is_pull_request: true
 
   # Could have multiple here
   run-with-cron:
@@ -32,5 +38,6 @@ jobs:
     uses: ./.github/workflows/run_pr_tests.yml
     with:
       update_cache: true
+      is_pull_request: false
 
 # additional ones here for cron and/or push to main - also can be in different file.

--- a/source/cl/test/UnitCL/CMakeLists.txt
+++ b/source/cl/test/UnitCL/CMakeLists.txt
@@ -14,6 +14,10 @@
 #
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+option(CA_CL_ENABLE_RVV_SCALABLE_VECZ_CHECK "Enable RVV scalable vecz checking" OFF)
+option(CA_CL_ENABLE_RVV_SCALABLE_VP_VECZ_CHECK "Enable RVV scalable VP vecz checking" OFF)
+option(CA_CL_ENABLE_UNITCL_EXPENSIVE_CHECK "Enable UnitCL expensive tests" ON)
+
 if(CA_CL_ENABLE_OFFLINE_KERNEL_TESTS AND
     NOT CA_RUNTIME_COMPILER_ENABLED AND NOT CA_EXTERNAL_CLC)
   message(FATAL_ERROR "CA_CL_ENABLE_OFFLINE_KERNEL_TESTS is set, but "
@@ -455,110 +459,118 @@ function(add_ca_vecz_unitcl_check name)
 endfunction()
 
 
+# Always run these tests
+
 # Note that this is the vanilla UnitCL configuration, i.e. it should not have
 # any tests filtered out or any special flags set. `-cl-wfv` defaults to `auto`
 # now, but we don't "--vecz-check" here since it may bail out by design.
 add_ca_default_unitcl_check(UnitCL)
 
-# This only provides minimal additional coverage over the `-cl-opt-disable
-# -g` test, so only include this in the extended set.
-add_ca_default_unitcl_check(UnitCL-opt-disable COMPILER EXTENDED
-  ENVIRONMENT "CA_EXTRA_COMPILE_OPTS=-cl-opt-disable -cl-wfv=never")
-
-# This only provides minimal additional coverage over the `-cl-wfv=always
-# -g` test, so only include this in the extended set.
-add_ca_default_unitcl_check(UnitCL-debug COMPILER EXTENDED
-  ENVIRONMENT "CA_EXTRA_COMPILE_OPTS=-g -cl-wfv=never")
-
-add_ca_default_unitcl_check(UnitCL-prevec COMPILER EXTENDED
-  ENVIRONMENT "CA_EXTRA_COMPILE_OPTS=-cl-vec=all -cl-wfv=never")
-
-# Running without optimizations but with VECZ provides additional testing of
-# VECZ by essentially testing a different set of inputs.  Note that unlike
-# other VECZ UnitCL checks these do not use `--vecz-check`, that is because
-# we don't expect VECZ to successfully vectorize all kernels in this
-# circumstance as optimizations perform canonicalizations that we rely upon.
-# However, VECZ should never crash or generate wrong code without the
-# canonicalizations.
-add_ca_default_unitcl_check(UnitCL-opt-disable-vecz COMPILER EXTENDED
-  ENVIRONMENT "CA_EXTRA_COMPILE_OPTS=-cl-opt-disable -cl-wfv=always")
-
-add_ca_default_unitcl_check(UnitCL-opt-disable-vecz-boscc COMPILER EXTENDED
-  ENVIRONMENT "CODEPLAY_VECZ_CHOICES=LinearizeBOSCC"
-              "CA_EXTRA_COMPILE_OPTS=-cl-opt-disable -cl-wfv=always")
-
-# Test VECZ Full Scalarization in combination with SLP and loop vectorization,
-# because it stresses the scalarizer.
-add_ca_default_unitcl_check(UnitCL-prevec-vecz-full-scalarization COMPILER
-  ENVIRONMENT "CODEPLAY_VECZ_CHOICES=FullScalarization"
-              "CA_EXTRA_COMPILE_OPTS=-cl-vec=all -cl-wfv=always"
-  ARGS --vecz-check)
-
-# Test auto-vectorization.
-# At least one kernel is known not to vectorize in this config.
-add_ca_default_unitcl_check(UnitCL-prevec-opt-disable COMPILER
-  ENVIRONMENT "CA_EXTRA_COMPILE_OPTS=-cl-vec=all -cl-opt-disable")
-
+add_ca_vecz_unitcl_check(UnitCL-vecz-never COMPILER
+ENVIRONMENT "CA_EXTRA_COMPILE_OPTS=-cl-wfv=never")
 if(NOT CA_CL_DISABLE_UNITCL_VECZ_CHECKS)
   add_ca_vecz_unitcl_check(UnitCL-vecz COMPILER
     ENVIRONMENT "CA_EXTRA_COMPILE_OPTS=-cl-wfv=always"
     ARGS --vecz-check)
+endif()
 
-  # Test VECZ in combination with the loop vectorizer.
-  add_ca_vecz_unitcl_check(UnitCL-prevec-vecz COMPILER EXTENDED
-    ENVIRONMENT "CA_EXTRA_COMPILE_OPTS=-cl-vec=all -cl-wfv=always"
-    ARGS --vecz-check)
+# Only run if expensive flag is on
+if (CA_CL_ENABLE_UNITCL_EXPENSIVE_CHECK)
 
-  # BOSCC specific debug info failures are quite specific, so only test that in
-  # the extended test set.
-  add_ca_vecz_unitcl_check(UnitCL-vecz-boscc-debug COMPILER EXTENDED
+  # This only provides minimal additional coverage over the `-cl-opt-disable
+  # -g` test, so only include this in the extended set.
+  add_ca_default_unitcl_check(UnitCL-opt-disable COMPILER EXTENDED
+    ENVIRONMENT "CA_EXTRA_COMPILE_OPTS=-cl-opt-disable -cl-wfv=never")
+
+  # This only provides minimal additional coverage over the `-cl-wfv=always
+  # -g` test, so only include this in the extended set.
+  add_ca_default_unitcl_check(UnitCL-debug COMPILER EXTENDED
+    ENVIRONMENT "CA_EXTRA_COMPILE_OPTS=-g -cl-wfv=never")
+
+  add_ca_default_unitcl_check(UnitCL-prevec COMPILER EXTENDED
+    ENVIRONMENT "CA_EXTRA_COMPILE_OPTS=-cl-vec=all -cl-wfv=never")
+
+  # Running without optimizations but with VECZ provides additional testing of
+  # VECZ by essentially testing a different set of inputs.  Note that unlike
+  # other VECZ UnitCL checks these do not use `--vecz-check`, that is because
+  # we don't expect VECZ to successfully vectorize all kernels in this
+  # circumstance as optimizations perform canonicalizations that we rely upon.
+  # However, VECZ should never crash or generate wrong code without the
+  # canonicalizations.
+  add_ca_default_unitcl_check(UnitCL-opt-disable-vecz COMPILER EXTENDED
+    ENVIRONMENT "CA_EXTRA_COMPILE_OPTS=-cl-opt-disable -cl-wfv=always")
+
+  add_ca_default_unitcl_check(UnitCL-opt-disable-vecz-boscc COMPILER EXTENDED
     ENVIRONMENT "CODEPLAY_VECZ_CHOICES=LinearizeBOSCC"
-                "CA_EXTRA_COMPILE_OPTS=-cl-wfv=always -g"
-    ARGS --vecz-check)
+                "CA_EXTRA_COMPILE_OPTS=-cl-opt-disable -cl-wfv=always")
 
-  add_ca_vecz_unitcl_check(UnitCL-vecz-boscc COMPILER
-    ENVIRONMENT "CODEPLAY_VECZ_CHOICES=LinearizeBOSCC"
-                "CA_EXTRA_COMPILE_OPTS=-cl-wfv=always"
-    ARGS --vecz-check)
-
-  # Test scalable vectorization on RVV.
-  if(CA_CL_ENABLE_RVV_SCALABLE_VECZ_CHECK)
-    # A RISCV-specific check which relies on the CA_RISCV_VF environment variable
-    # to select a specific scalable vectorization factor. Perhaps if/when -cl-wfv
-    # allows us to do the same we can make it a more general test.
-    add_ca_vecz_unitcl_check(UnitCL-riscv-vecz-vf-nxv1 COMPILER
-      ENVIRONMENT "CA_RISCV_VF=1,S")
-  endif()
-
-  # Test scalable vectorization in combination with vector predication
-  if(CA_CL_ENABLE_RVV_SCALABLE_VP_VECZ_CHECK)
-    # A RISCV-specific check which relies on the CA_RISCV_VF environment variable
-    # to select a specific scalable vectorization factor in combination with
-    # vector predication. Perhaps if/when -cl-wfv allows us to do the same we can
-    # make it a more general test.
-    add_ca_vecz_unitcl_check(UnitCL-riscv-vecz-vf-nxv1-vp COMPILER
-      ENVIRONMENT "CA_RISCV_VF=1,S,VP")
-
-    add_ca_vecz_unitcl_check(UnitCL-riscv-vecz-vf-nxv1-vvp COMPILER
-      ENVIRONMENT "CA_RISCV_VF=1,S,VVP")
-  endif()
-
-  add_ca_vecz_unitcl_check(UnitCL-vecz-debug COMPILER
-    ENVIRONMENT "CA_EXTRA_COMPILE_OPTS=-cl-wfv=always -g"
-    ARGS --vecz-check)
-
-  # Test without wfv vectorization.
-  add_ca_vecz_unitcl_check(UnitCL-vecz-never-opt-disable-debug COMPILER
-    ENVIRONMENT "CA_EXTRA_COMPILE_OPTS=-cl-opt-disable -g -cl-wfv=never")
-
-  add_ca_vecz_unitcl_check(UnitCL-vecz-never COMPILER
-    ENVIRONMENT "CA_EXTRA_COMPILE_OPTS=-cl-wfv=never")
-
-  # Let's throw the kitchen sink at it, since that found at least one bug already..
-  add_ca_vecz_unitcl_check(UnitCL-vecz-everything COMPILER
-    ENVIRONMENT "CODEPLAY_VECZ_CHOICES=LinearizeBOSCC"
+  # Test VECZ Full Scalarization in combination with SLP and loop vectorization,
+  # because it stresses the scalarizer.
+  add_ca_default_unitcl_check(UnitCL-prevec-vecz-full-scalarization COMPILER
+    ENVIRONMENT "CODEPLAY_VECZ_CHOICES=FullScalarization"
                 "CA_EXTRA_COMPILE_OPTS=-cl-vec=all -cl-wfv=always"
     ARGS --vecz-check)
+
+  # Test auto-vectorization.
+  # At least one kernel is known not to vectorize in this config.
+  add_ca_default_unitcl_check(UnitCL-prevec-opt-disable COMPILER
+    ENVIRONMENT "CA_EXTRA_COMPILE_OPTS=-cl-vec=all -cl-opt-disable")
+
+  if(NOT CA_CL_DISABLE_UNITCL_VECZ_CHECKS)
+
+    # Test VECZ in combination with the loop vectorizer.
+    add_ca_vecz_unitcl_check(UnitCL-prevec-vecz COMPILER EXTENDED
+      ENVIRONMENT "CA_EXTRA_COMPILE_OPTS=-cl-vec=all -cl-wfv=always"
+      ARGS --vecz-check)
+
+    # BOSCC specific debug info failures are quite specific, so only test that in
+    # the extended test set.
+    add_ca_vecz_unitcl_check(UnitCL-vecz-boscc-debug COMPILER EXTENDED
+      ENVIRONMENT "CODEPLAY_VECZ_CHOICES=LinearizeBOSCC"
+                  "CA_EXTRA_COMPILE_OPTS=-cl-wfv=always -g"
+      ARGS --vecz-check)
+
+    add_ca_vecz_unitcl_check(UnitCL-vecz-boscc COMPILER
+      ENVIRONMENT "CODEPLAY_VECZ_CHOICES=LinearizeBOSCC"
+                  "CA_EXTRA_COMPILE_OPTS=-cl-wfv=always"
+      ARGS --vecz-check)
+
+    # Test scalable vectorization on RVV.
+    if(CA_CL_ENABLE_RVV_SCALABLE_VECZ_CHECK)
+      # A RISCV-specific check which relies on the CA_RISCV_VF environment variable
+      # to select a specific scalable vectorization factor. Perhaps if/when -cl-wfv
+      # allows us to do the same we can make it a more general test.
+      add_ca_vecz_unitcl_check(UnitCL-riscv-vecz-vf-nxv1 COMPILER
+        ENVIRONMENT "CA_RISCV_VF=1,S")
+    endif()
+
+    # Test scalable vectorization in combination with vector predication
+    if(CA_CL_ENABLE_RVV_SCALABLE_VP_VECZ_CHECK)
+      # A RISCV-specific check which relies on the CA_RISCV_VF environment variable
+      # to select a specific scalable vectorization factor in combination with
+      # vector predication. Perhaps if/when -cl-wfv allows us to do the same we can
+      # make it a more general test.
+      add_ca_vecz_unitcl_check(UnitCL-riscv-vecz-vf-nxv1-vp COMPILER
+        ENVIRONMENT "CA_RISCV_VF=1,S,VP")
+
+      add_ca_vecz_unitcl_check(UnitCL-riscv-vecz-vf-nxv1-vvp COMPILER
+        ENVIRONMENT "CA_RISCV_VF=1,S,VVP")
+    endif()
+
+    add_ca_vecz_unitcl_check(UnitCL-vecz-debug COMPILER
+      ENVIRONMENT "CA_EXTRA_COMPILE_OPTS=-cl-wfv=always -g"
+      ARGS --vecz-check)
+
+    # Test without wfv vectorization.
+    add_ca_vecz_unitcl_check(UnitCL-vecz-never-opt-disable-debug COMPILER
+      ENVIRONMENT "CA_EXTRA_COMPILE_OPTS=-cl-opt-disable -g -cl-wfv=never")
+
+    # Let's throw the kitchen sink at it, since that found at least one bug already..
+    add_ca_vecz_unitcl_check(UnitCL-vecz-everything COMPILER
+      ENVIRONMENT "CODEPLAY_VECZ_CHOICES=LinearizeBOSCC"
+                  "CA_EXTRA_COMPILE_OPTS=-cl-vec=all -cl-wfv=always"
+      ARGS --vecz-check)
+  endif()
 endif()
 
 if(OCL_EXTENSION_cl_intel_unified_shared_memory)
@@ -599,7 +611,10 @@ if(CMAKE_CROSSCOMPILING)
     NOEMULATE NOGLOBAL)
 else()
   # Convenvenience to only run half tests to assist with a quick run
-  add_ca_unitcl_check(UnitCL-half FILTER "*Half*")
+  # Tested anyway as part of standard testing, so only provide as part of full testing
+  if (CA_CL_ENABLE_UNITCL_EXPENSIVE_CHECK)
+    add_ca_unitcl_check(UnitCL-half FILTER "*Half*")
+  endif()
 endif()
 
 install(DIRECTORY


### PR DESCRIPTION
# Overview

Reduce PR testing overheads

# Reason for change

PR testing is taking too long

# Description of change

  Add CMake option  CA_CL_ENABLE_UNITCL_EXPENSIVE_CHECK to disable full
  unitcl testing for some cases. Per job we can enable/disable per job
  with the pull_request flag. Currently only apply the expensive flag to a long running windows job.
