### PR TITLE
Add ock artefact building

### DIFF
--- a/.github/actions/build_portDNN_action/action.yml
+++ b/.github/actions/build_portDNN_action/action.yml
@@ -20,7 +20,7 @@ runs:
         sudo apt-get install -y spirv-tools
 
     - name: Install Ninja
-      uses: llvm/actions/install-ninja@main
+      uses: llvm/actions/install-ninja@a1ea791b03c8e61f53a0e66f2f73db283aa0f01e # main branch
 
     - name: Get Intel OneAPI Nightly Release
       shell: bash

--- a/.github/actions/calc_vars/action.yml
+++ b/.github/actions/calc_vars/action.yml
@@ -1,0 +1,46 @@
+name: calc vars
+description: calculate variables based off the target name that may be useful in other steps
+
+inputs:
+  target:
+    description: 'target architecture'
+
+outputs:
+  arch:
+    description: "base architecture - one of x86, x86_64, arm, aarch64 or riscv64"
+    value: ${{ steps.calc_vars_action.outputs.arch }}
+  toolchain:
+    description: "path to toolchain file for architecture"
+    value: ${{ steps.calc_vars_action.outputs.toolchain }}
+  cmake_toolchain:
+    description: "cmake argument to pass to CMAKE_TOOLCHAIN_FILE"    
+    value: ${{ steps.calc_vars_action.outputs.cmake_toolchain }}    
+runs:
+  using: "composite"
+  steps:
+    - shell: bash
+      id: calc_vars_action
+      run: |
+        ARCH=
+        TOOLCHAIN=
+        CMAKE_TOOLCHAIN=
+        if [[ "${{inputs.target}}" = "host_x86_64_linux" ]]; then
+         ARCH=x86_64 >> $GITHUB_OUTPUT
+        elif [[ "${{inputs.target}}" = "host_x86_64_windows" ]]; then
+         ARCH=x86_64 >> $GITHUB_OUTPUT
+        elif [[ "${{inputs.target}}" = "host_aarch64_linux" ]]; then
+         ARCH=aarch64 >> $GITHUB_OUTPUT
+         TOOLCHAIN=$GITHUB_WORKSPACE/platform/arm-linux/aarch64-toolchain.cmake
+         CMAKE_TOOLCHAIN="--toolchain $TOOLCHAIN"
+        elif [[ "${{inputs.target}}" = "host_riscv64_linux" ]]; then
+         ARCH=riscv64 >> $GITHUB_OUTPUT
+         TOOLCHAIN=$GITHUB_WORKSPACE/platform/riscv64-linux/riscv64-toolchain.cmake
+         CMAKE_TOOLCHAIN="--toolchain $TOOLCHAIN"       
+        else
+         echo Unknown target ${{inputs.target}}
+         exit 1
+        fi
+        echo "arch=$ARCH" >> $GITHUB_OUTPUT
+        echo "toolchain=$TOOLCHAIN" >> $GITHUB_OUTPUT
+        echo "cmake_toolchain=$CMAKE_TOOLCHAIN" >> $GITHUB_OUTPUT        
+        cat $GITHUB_OUTPUT

--- a/.github/actions/do_build_icd/action.yml
+++ b/.github/actions/do_build_icd/action.yml
@@ -1,0 +1,72 @@
+name: pull and build opencl icd loader
+description: pull icd loader and build with a particular toolchain, uploading opencl header and icd artefacts
+
+inputs:
+  target:
+    description: 'target architecture'
+
+runs:
+  using: "composite"
+  steps:
+    - name: calc vars
+      id: calc_vars
+      uses: ./.github/actions/calc_vars
+      with:
+        target: ${{ inputs.target }}  
+
+    - name: Install Ninja
+      uses: llvm/actions/install-ninja@a1ea791b03c8e61f53a0e66f2f73db283aa0f01e # main branch
+
+    - name: clone headers
+      uses: actions/checkout@v4
+      with:
+        repository: KhronosGroup/OpenCL-Headers
+        path: headers
+
+    - name: cmake headers
+      shell: bash
+      run:
+        cmake headers -Bheaders/build_${{steps.calc_vars.outputs.arch}}
+         -DCMAKE_TOOLCHAIN_FILE=${{ steps.calc_vars.outputs.toolchain }}
+         -DCMAKE_INSTALL_PREFIX=$PWD/headers_install_${{steps.calc_vars.outputs.arch}}
+         -GNinja
+    - name: ninja install headers
+      shell: bash
+      run:
+        ninja -v -C headers/build_${{steps.calc_vars.outputs.arch}} install
+
+    - name: upload header artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: header_${{inputs.target}}
+        path: headers_install_${{steps.calc_vars.outputs.arch}}
+        retention-days: 1
+
+    - name: clone icd 
+      uses: actions/checkout@v4
+      with:
+        repository: KhronosGroup/OpenCL-ICD-Loader
+        path: icd
+
+    - name: icd cmake
+      shell: bash
+      run:
+        cmake icd -B icd/build_${{steps.calc_vars.outputs.arch}}
+        -DCMAKE_TOOLCHAIN_FILE=${{ steps.calc_vars.outputs.toolchain }}
+        -DCMAKE_BUILD_TYPE=${{ inputs.build_type }}
+        -DCMAKE_INSTALL_PREFIX=$GITHUB_WORKSPACE/install_icd_${{steps.calc_vars.outputs.arch}}
+        -DOpenCLHeaders_DIR=$GITHUB_WORKSPACE/headers_install_${{steps.calc_vars.outputs.arch}}/share/cmake/OpenCLHeaders
+        -GNinja
+
+    - name: icd build
+      shell: bash
+      run:
+        ninja -v -C icd/build_${{steps.calc_vars.outputs.arch}} install
+
+    - name: upload icd artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: icd_${{inputs.target}}
+        path: install_icd_${{steps.calc_vars.outputs.arch}}
+        retention-days: 1
+

--- a/.github/actions/do_build_ock_artefact/action.yml
+++ b/.github/actions/do_build_ock_artefact/action.yml
@@ -1,0 +1,71 @@
+name: build-ock-artefacts
+description: Action to build the oneapi-construction-kit as an artefact
+
+# Note we need to support llvm tip at some point
+
+inputs:
+  llvm_version:
+    description: 'llvm version we want to use (18-19)'
+    default: '19'
+  target:
+    description: 'target architecture'
+
+# TODO: This has not been tested yet on windows so would likely need some updating.
+runs:
+  using: "composite"
+  steps:
+      - name: calc vars
+        id: calc_vars
+        uses: ./.github/actions/calc_vars
+        with:
+          target: ${{ inputs.target }}
+
+      - name: print vars
+        shell: bash
+        run: |
+          echo arch = ${{steps.calc_vars.outputs.arch}}
+          echo toolchain = ${{steps.calc_vars.outputs.toolchain}}
+
+      # installs tools, ninja, installs llvm and sets up sccache
+      - name: setup
+        uses:  ./.github/actions/setup_build
+        with:
+          llvm_version: ${{ inputs.llvm_version }}
+          llvm_build_type: RelAssert
+          cross_arch: ${{ steps.calc_vars.outputs.arch == 'x86_64' && 'none' || steps.calc_vars.outputs.arch }}
+
+      - name: build ock x86
+        if: steps.calc_vars.outputs.arch  == 'x86_64'
+        uses: ./.github/actions/do_build_ock
+        with:
+          build_targets: install
+          offline_kernel_tests: OFF
+          extra_flags: -DCA_ENABLE_TESTS=OFF -DCA_ENABLE_EXAMPLES=OFF -DCA_ENABLE_DOCUMENTATION=OFF
+
+      - name: build ock other ${{ matrix.target }}
+        if: steps.calc_vars.outputs.arch  != 'x86_64'
+        uses: ./.github/actions/do_build_ock
+        with:
+          build_targets: install
+          toolchain_file: ${{ steps.calc_vars.outputs.toolchain }}
+          extra_flags: -DCA_BUILTINS_TOOLS_DIR=${{ github.workspace }}/llvm_install_native/bin -DCA_ENABLE_TESTS=OFF -DCA_ENABLE_EXAMPLES=OFF -DCA_ENABLE_DOCUMENTATION=OFF
+          # Do we need the offline kernel as an artefact? If so currently this requires an external clc or qemu to be installed.
+          offline_kernel_tests: OFF
+          host_fp16: ON
+
+      # Prune it as there is too much things in there we don't want to use
+      # Todo: move this logic to cmake settings so that we build only what we
+      # want to install. As time goes on we may want to install more.
+      - name: prune ock artefact
+        shell: bash
+        run: |
+          # delete all but city runner and the python associated file under bin
+          find install/bin -maxdepth 1 -type f  ! -name "*.py"  -delete
+          rm -rf install/share
+
+      - name: upload ock artefact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ock_${{ inputs.target }}
+          path: install
+          retention-days: 1

--- a/.github/actions/do_build_tornado/action.yml
+++ b/.github/actions/do_build_tornado/action.yml
@@ -1,0 +1,69 @@
+name: build tornado
+description: build tornado
+
+inputs:
+  target:
+    description: 'target architecture'
+
+runs:
+  # We don't want a new docker just a list of steps, so mark as composite
+  using: "composite"
+  steps:
+    - name: calc vars
+      id: calc_vars
+      uses: ./.github/actions/calc_vars
+      with:
+        target: ${{ inputs.target }}
+
+    - name: Install Ninja
+      uses: llvm/actions/install-ninja@a1ea791b03c8e61f53a0e66f2f73db283aa0f01e # main branch
+    
+    - name: download icd artifact
+      uses: actions/download-artifact@v4
+      with:
+        name: icd_${{inputs.target}}
+        path: install_icd
+
+    # Get maven
+    - name: fetch maven
+      shell: bash    
+      run: |
+        wget https://archive.apache.org/dist/maven/maven-3/3.9.3/binaries/apache-maven-3.9.3-bin.tar.gz
+        tar xf apache-maven-3.9.3-bin.tar.gz
+
+    # TODO: setup correctly for our aarch64 runner
+    - name: select jdk21
+      if: steps.calc_vars.outputs.arch == 'x86_64'
+      shell: bash      
+      run: |
+        sudo update-java-alternatives -s temurin-21-jdk-amd64
+        pip install tqdm
+
+    - name: clone TornadoVM
+      uses: actions/checkout@v4
+      with:
+        repository: beehive-lab/TornadoVM
+        path: TornadoVM_build
+        ref: develop
+
+    - name: build tornadovm
+      shell: bash    
+      run: |
+        export JAVA_HOME=`readlink -f $(command -v java) | sed 's/\/bin\/java//'`
+        export TORNADO_SDK=$GITHUB_WORKSPACE/TornadoVM_build/bin/sdk
+        export PATH=$PWD/apache-maven-3.9.3/bin:$PATH
+        mvn -v
+        java --version
+        cd TornadoVM_build
+        # The tornado build system links in OpenCL assuming it's in a known place. This gets around
+        # this by pass CXX as an environment variable as it's difficult to change the build system
+        # even if we don't use this script.
+        CXX="g++ -L$GITHUB_WORKSPACE/install_icd/lib" make -j8 jdk21 BACKEND=opencl
+        cp -r -L $TORNADO_SDK $GITHUB_WORKSPACE/TornadoVM_SDK
+
+    - name: upload tornado artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: tornado_${{inputs.target}}
+        path: TornadoVM_SDK
+        retention-days: 1

--- a/.github/actions/run_tornado/action.yml
+++ b/.github/actions/run_tornado/action.yml
@@ -1,0 +1,34 @@
+name: run tornado
+description: run tornado
+
+# This action is not standalone and assumes it has been run after the build_tornado action
+# and that the icd is already installed at install_icd
+inputs:
+  target:
+    description: 'target architecture'
+
+runs:
+  using: "composite"
+  steps:
+    - name: Download ock artefact
+      uses: actions/download-artifact@v4
+      with:
+        name: ock_${{inputs.target}}
+        path: install_ock
+
+    - name: Run tornado example
+      shell: bash
+      run: |
+        export ARTEFACT_CHECKOUT_PATH=$GITHUB_WORKSPACE/install_ock
+        export ICD_LOADER_INSTALL_PATH=$GITHUB_WORKSPACE/install_icd
+
+        export LD_LIBRARY_PATH=$ICD_LOADER_INSTALL_PATH/lib:$LD_LIBRARY_PATH
+        echo $LD_LIBRARY_PATH
+        export OCL_ICD_FILENAMES=$ARTEFACT_CHECKOUT_PATH/lib/libCL.so
+        export JAVA_HOME=`readlink -f $(command -v java) | sed 's/\/bin\/java//'`
+        export TORNADO_SDK=$GITHUB_WORKSPACE/TornadoVM_build/bin/sdk
+        export PATH=$TORNADO_SDK/bin:$PATH
+        
+        git clone https://github.com/beehive-lab/TornadoVM.git -b develop --depth 1
+        cd TornadoVM
+        CA_HOST_DUMP_ASM=1 tornado --printKernel --threadInfo -m tornado.examples/uk.ac.manchester.tornado.examples.compute.MatrixMultiplication2D 256

--- a/.github/actions/setup_build/action.yml
+++ b/.github/actions/setup_build/action.yml
@@ -21,9 +21,8 @@ inputs:
     description: 'Save the build cache at the end - not for PR testing'
     default: false
   cross_arch:
-    description: 'Cross compilation architecture from: x86, arm, aarch64, riscv64. Default: "" (no cross compile)'
-    default: ""
-    # Note: runner architectures from: x86_64 (aka runner.arch: X64), aarch64 (aka runner.arch: ARM64)
+    description: 'Cross compilation architecture from: x86, arm, aarch64, riscv64. Default: "none" (no cross compile), will auto fetch native arch'
+    default: "none"
   clang_tidy:
     description: 'Enable installing of clang-tidy (currently 19)'
     type: boolean
@@ -67,7 +66,7 @@ runs:
         if [ "${{ inputs.cross_arch }}" = "riscv64" ]; then \
            sudo apt-get install --yes gcc-11-riscv64-linux-gnu g++-11-riscv64-linux-gnu; \
         fi
-        if [ "${{ inputs.cross_arch }}" != "" ] && [ "${{ inputs.cross_arch }}" != "x86" ]; then \
+        if [ "${{ inputs.cross_arch }}" != "none" ] && [ "${{ inputs.cross_arch }}" != "x86" ]; then \
            # Install QEMU for testing cross compilation.
            sudo apt-get install --yes qemu-user; \
         fi
@@ -84,27 +83,40 @@ runs:
         pip install lit
 
     - name: Install Ninja
-      uses: llvm/actions/install-ninja@main
+      uses: llvm/actions/install-ninja@a1ea791b03c8e61f53a0e66f2f73db283aa0f01e # main branch
 
     - name: set llvm key
       id: set_llvm_key
       shell: bash
       run: |
         KEY_VERSION="${{ inputs.ubuntu_version }}"
-        if [ "${{ inputs.os }}" = "windows" ]; then \
-           KEY_VERSION="${{ inputs.windows_version }}" ; \
+        if [ "${{ inputs.os }}" = "windows" ]; then
+           KEY_VERSION="${{ inputs.windows_version }}"
         fi
         echo "key_version=$KEY_VERSION" >> "$GITHUB_OUTPUT"
         KEY_ARCH="x86_64"
-        if [ "${{ runner.arch }}" = "ARM64" ]; then \
-           KEY_ARCH="aarch64" ; \
+        KEY_NATIVE_ARCH="x86_64"
+        if [ "${{ runner.arch }}" = "ARM64" ]; then
+           KEY_ARCH="aarch64" ;
+           KEY_NATIVE_ARCH="aarch64"
         fi
-        if [ "${{ inputs.cross_arch }}" != "" ]; then \
-           KEY_ARCH="${{ inputs.cross_arch }}" ; \
+        if [ "${{ inputs.cross_arch }}" != "none" ]; then
+           KEY_ARCH="${{ inputs.cross_arch }}"
         fi
         echo "key_arch=$KEY_ARCH" >> "$GITHUB_OUTPUT"
-        echo "key_version=$KEY_VERSION"
-        echo "key_arch=$KEY_ARCH"
+        echo "key_native_arch=$KEY_NATIVE_ARCH" >> "$GITHUB_OUTPUT"
+        cat $GITHUB_OUTPUT
+
+    - name: load llvm native
+      if: inputs.cross_arch != 'none'
+      uses: actions/cache/restore@v4
+      with:
+        path: llvm_install/**
+        key: llvm-${{ inputs.os }}-${{ steps.set_llvm_key.outputs.key_version }}-${{ steps.set_llvm_key.outputs.key_native_arch }}-v${{ inputs.llvm_version }}-${{ inputs.llvm_build_type }}
+        fail-on-cache-miss: true
+    - shell: bash
+      if: inputs.cross_arch != 'none'    
+      run: mv llvm_install llvm_install_native
 
     - name: load llvm
       uses: actions/cache/restore@v4

--- a/.github/workflows/create_llvm.yml
+++ b/.github/workflows/create_llvm.yml
@@ -96,7 +96,7 @@ jobs:
 
       - name: Install Ninja
         if: steps.cache.outputs.cache-hit != 'true'
-        uses: llvm/actions/install-ninja@main
+        uses: llvm/actions/install-ninja@a1ea791b03c8e61f53a0e66f2f73db283aa0f01e # main branch
 
       - name: install aarch64 build tools
         if: ${{ steps.cache.outputs.cache-hit != 'true' && matrix.arch == 'aarch64' }}

--- a/.github/workflows/planned_testing.yml
+++ b/.github/workflows/planned_testing.yml
@@ -1,0 +1,116 @@
+# Simple workflow for running planned testing
+name: Run planned tests
+on:
+  workflow_call:
+    inputs:
+      ock:
+        required: false
+        type: boolean
+        default: true
+      test_tornado:
+        required: false
+        type: boolean
+        default: true        
+      target_list:
+        required: false
+        type: string
+      llvm_version:
+        required: false
+        type: string
+        default: 19
+      pull_request:
+        required: false
+        type: boolean
+        default: false
+
+jobs:
+
+  # Calculate some useful variables that can be used through the workflow
+  # Currently this can be used to exclude all but certain targets in matrices
+  workflow_vars:
+    runs-on: ubuntu-22.04
+    outputs:
+      matrix_only_linux_x86_64_aarch64: ${{ steps.vars.outputs.matrix_only_linux_x86_64_aarch64 }}
+      matrix_only_linux_x86_64: ${{ steps.vars.outputs.matrix_only_linux_x86_64 }}
+    steps:
+    - id: vars
+      # TODO: If we expand on this, come up with a more programmatical way of doing only certain targets.
+      # These variables are for excluding certain targets from the total list, which is why just including
+      # two targets is a long list of excludes
+      run: |
+        echo matrix_only_linux_x86_64_aarch64="[ {\"target\": \"host_arm_linux\"}, {\"target\": \"host_riscv64_linux\"}, {\"target\": \"host_refsi_linux\"}, {\"target\": \"host_i686_linux\"}, {\"target\": \"host_x86_64_windows\"}]" >> $GITHUB_OUTPUT
+        echo matrix_only_linux_x86_64="[ {\"target\": \"host_aarch64_linux\"}, {\"target\": \"host_riscv64_linux\"}, {\"target\": \"host_arm_linux\"}, {\"target\": \"host_refsi_linux\"}, {\"target\": \"host_i686_linux\"}, {\"target\": \"host_x86_64_windows\"}]" >> $GITHUB_OUTPUT
+        cat $GITHUB_OUTPUT    
+
+
+  create_ock_artefacts:
+    needs: [workflow_vars]
+    strategy:
+      matrix:
+        target: ${{ fromJson(inputs.target_list) }}
+        exclude: ${{ fromJson(needs.workflow_vars.outputs.matrix_only_linux_x86_64_aarch64) }}
+
+    # risc-v needs ubuntu 24.04 so we get the latest qemu as well as how we
+    # build llvm. Otherwise we choose windows or ubuntu-22.04 depending on the
+    # target.
+    runs-on: ${{ (contains(matrix.target, 'host_riscv') && 'ubuntu-24.04') || (contains(matrix.target, 'windows') && 'windows-2019' || 'ubuntu-22.04' ) }}
+    if : inputs.ock
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+      - name: build ock artefact
+        uses: ./.github/actions/do_build_ock_artefact
+        with:
+          target: ${{ matrix.target }}
+          llvm_version: ${{ inputs.llvm_version }}
+
+  build_icd:
+    # Will also be required for opencl
+    if: inputs.test_tornado
+    needs: [workflow_vars]
+    strategy:
+      matrix:
+        target: ${{ fromJson(inputs.target_list) }}
+        exclude: ${{ fromJson(needs.workflow_vars.outputs.matrix_only_linux_x86_64_aarch64) }}
+
+    runs-on: ubuntu-22.04
+    steps:
+      - name: clone ock platform
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            platform
+            .github
+      - name : build and upload icd ${{matrix.target}}
+        uses: ./.github/actions/do_build_icd
+        with:
+          target: ${{matrix.target}}
+
+  
+  # Currently only builds and runs on x86_64 linux
+  build_run_tornado:
+    if: inputs.test_tornado
+    needs: [ workflow_vars, build_icd, create_ock_artefacts ]
+    strategy:
+      matrix:
+        target: ${{ fromJson(inputs.target_list) }}
+        exclude: ${{ fromJson(needs.workflow_vars.outputs.matrix_only_linux_x86_64) }}
+
+    # Todo: expand for aarch64
+    runs-on: ubuntu-22.04
+    steps:
+      - name: clone ock platform
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            platform
+            .github
+      # TODO: Consider separating out tornado build and run in the future
+      - name : build and upload tornado
+        uses: ./.github/actions/do_build_tornado
+        with:
+          target: ${{ matrix.target }}
+      - name : run tornado
+        uses: ./.github/actions/run_tornado
+        with:
+          target: ${{ matrix.target }}

--- a/.github/workflows/planned_testing_caller.yml
+++ b/.github/workflows/planned_testing_caller.yml
@@ -1,0 +1,25 @@
+# Calling workflow for running planned style tests
+name: Run planned testing
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/planned_testing.yml'
+      - '.github/workflows/planned_testing_caller.yml'      
+    branches:
+      - main      
+  schedule:
+    # Run Mon-Fri at 7pm
+    - cron: '00 19 * * 1-5'
+
+jobs:
+  call_planned:
+    # This makes the diagram too big if we post much here so S_ for scheduled.
+    name: S_
+    if: github.repository == 'uxlfoundation/oneapi-construction-kit' || github.event_name != 'schedule'
+    uses: ./.github/workflows/planned_testing.yml
+    with:
+      target_list: '["host_x86_64_linux", "host_aarch64_linux", "host_riscv64_linux", "host_i686_linux", "host_refsi_linux", "host_x86_64_windows" ]'
+      test_tornado: true
+      # Have a pull request setting which can be used to test the flow as best as possible
+      # in a reasonable time
+      pull_request: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/run_pr_tests.yml
+++ b/.github/workflows/run_pr_tests.yml
@@ -363,13 +363,6 @@ jobs:
     steps:
     - name: Checkout repo
       uses: actions/checkout@v4.1.0
-    - name: load native llvm
-      uses: actions/cache/restore@v4
-      with:
-        path: llvm_install/**
-        key: llvm-ubuntu-22.04-x86_64-v19-RelAssert
-        fail-on-cache-miss: true
-    - run: mv llvm_install llvm_install_native
     - name: setup-ubuntu
       uses: ./.github/actions/setup_build
       with:

--- a/.github/workflows/run_pr_tests_caller.yml
+++ b/.github/workflows/run_pr_tests_caller.yml
@@ -34,7 +34,7 @@ jobs:
   # Could have multiple here
   run-with-cron:
     name: Call PR testing on schedule
-    if: ${{ github.event_name == 'schedule' }}    
+    if: ${{ github.event_name == 'schedule' && github.repository == 'uxlfoundation/oneapi-construction-kit'}}
     uses: ./.github/workflows/run_pr_tests.yml
     with:
       update_cache: true


### PR DESCRIPTION
# Overview

Add ock artefact building, icd building and tornado run for planned testing
  
# Reason for change

Need to port some of our local testing to planned to improve public level of testing.

# Description of change

Added planned testing which is intended to run long running scheduled
tests. Added a base which they can all use which allows all jobs to
follow a similar method of using a matrix, a named target and a flag
which dictates what tests are enabled.

icd, ock artefacts and tornado are done as part of this.
