### PR TITLE
Builder::create<OpBranchConditional>: Fix access to destroyed array.

### DIFF
--- a/modules/compiler/spirv-ll/source/builder_core.cpp
+++ b/modules/compiler/spirv-ll/source/builder_core.cpp
@@ -6042,11 +6042,11 @@ llvm::Error Builder::create<OpBranchConditional>(
       branch_inst->setMetadata(md_nodes.front().second, md_nodes.front().first);
     } else {
       // if both possible nodes are needed create an `MDTuple` out of them
-      const llvm::ArrayRef<llvm::Metadata *> md_arr = {md_nodes[0].first,
-                                                       md_nodes[1].first};
+      llvm::Metadata *md_arr[] = {md_nodes[0].first, md_nodes[1].first};
 
       branch_inst->setMetadata(
-          "MDTuple", llvm::MDTuple::get(*context.llvmContext, md_arr));
+          "MDTuple",
+          llvm::MDTuple::get(*context.llvmContext, llvm::ArrayRef(md_arr)));
     }
   }
 


### PR DESCRIPTION
# Overview

Builder::create<OpBranchConditional>: Fix access to destroyed array.

# Reason for change

Previously, md_arr was a named ArrayRef variable constructed from an initializer list. This initializer list causes a temporary array to be created, the ArrayRef is then bound to that temporary array, and then the temporary array gets destroyed. In the subsequent call to llvm::MDTuple::get(*context.llvmContext, md_arr) then, md_arr no longer referenced any array still in existence.

# Description of change

Make md_arr an array instead, like its name implies, to ensure it lives long enough to still be valid during MDTuple::get.

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-19](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
