### PR TITLE
Enable vfp4 for ARM.

### DIFF
--- a/modules/compiler/targets/host/source/target.cpp
+++ b/modules/compiler/targets/host/source/target.cpp
@@ -256,14 +256,13 @@ compiler::Result HostTarget::initWithBuiltins(
       // for single precision floating points.
       Features.AddFeature("strict-align", true);
       Features.AddFeature("neonfp", true);
-      Features.AddFeature("neon", true);
+      // We need hardware FMA support which is only available as of VFP4.
+      // VFP4 also includes FP16.
+      Features.AddFeature("vfp4", true);
       // Hardware division instructions might not exist on all ARMv7 CPUs, but
       // they probably exist on all the ones we might care about.
       Features.AddFeature("hwdiv", true);
       Features.AddFeature("hwdiv-arm", true);
-      if (host_device_info.half_capabilities) {
-        Features.AddFeature("fp16", true);
-      }
       break;
 #endif
 #ifdef HOST_LLVM_RISCV


### PR DESCRIPTION
# Overview

Enable vfp4 for ARM.

# Reason for change

We made the decision at the start of the year to only support targets that have hardware FMA support. This is available on 32-bit ARM, but only as of VFPv4.

# Description of change

Make sure to enable this.

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-19](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
