### PR TITLE
Fix build with LLVM 20.

### DIFF
--- a/modules/compiler/source/base/source/pass_pipelines.cpp
+++ b/modules/compiler/source/base/source/pass_pipelines.cpp
@@ -118,8 +118,7 @@ void addLLVMDefaultPerModulePipeline(ModulePassManager &PM, PassBuilder &PB,
   if (!options.opt_disable) {
     PM.addPass(PB.buildPerModuleDefaultPipeline(OptimizationLevel::O3));
   } else {
-    PM.addPass(PB.buildO0DefaultPipeline(OptimizationLevel::O0,
-                                         /*LTOPreLink*/ false));
+    PM.addPass(PB.buildO0DefaultPipeline(OptimizationLevel::O0));
     // LLVM's new inliners do less than the legacy ones, so run a round of
     // global optimization to remove any dead functions.
     // FIXME: This isn't just optimization: we have internal functions without


### PR DESCRIPTION
# Overview

Fix build with LLVM 20.

# Reason for change

LLVM 20 changes buildO0DefaultPipeline's second parameter from bool LTOPreLink to ThinOrFullLTOPhase Phase, so we can no longer explicitly pass false.

# Description of change

In both cases, the parameter has a default value and that default value is what we want to pass, so just drop the argument.

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-19](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
