### PR TITLE
[NFC] Avoid deprecated Type::getPointerTo.

### DIFF
--- a/modules/compiler/compiler_pipeline/source/add_kernel_wrapper_pass.cpp
+++ b/modules/compiler/compiler_pipeline/source/add_kernel_wrapper_pass.cpp
@@ -43,7 +43,7 @@ void compiler::utils::AddKernelWrapperPass::createNewFunctionArgTypes(
     StructType *structTy, SmallVectorImpl<KernelArgMapping> &argMappings,
     SmallVectorImpl<Type *> &argTypes) {
   // the first element is our new packed argument struct
-  argTypes.push_back(structTy->getPointerTo());
+  argTypes.push_back(PointerType::get(structTy, /*AddressSpace=*/0));
 
   uint32_t index = 0;
   // Track which arguments are *not* packed, and which index each corresponds

--- a/modules/compiler/compiler_pipeline/source/cl_builtin_info.cpp
+++ b/modules/compiler/compiler_pipeline/source/cl_builtin_info.cpp
@@ -2190,8 +2190,7 @@ Value *CLBuiltinInfo::emitBuiltinInlineVLoad(Function *F, unsigned Width,
       Data = B.CreateInsertElement(Data, Lane, Index, "vload_insert");
     }
   } else {
-    PointerType *VecPtrTy = DataTy->getPointerTo(PtrTy->getAddressSpace());
-    Value *VecBase = B.CreateBitCast(GEPBase, VecPtrTy, "vload_ptr");
+    Value *VecBase = B.CreateBitCast(GEPBase, PtrTy, "vload_ptr");
     auto *Load = B.CreateLoad(DataTy, VecBase, false, "vload");
 
     const unsigned Align = DataTy->getScalarSizeInBits() / 8;
@@ -2251,8 +2250,7 @@ Value *CLBuiltinInfo::emitBuiltinInlineVStore(Function *F, unsigned Width,
       Store = B.CreateStore(Lane, GEP, false);
     }
   } else {
-    PointerType *VecPtrTy = VecDataTy->getPointerTo(PtrTy->getAddressSpace());
-    Value *VecBase = B.CreateBitCast(GEPBase, VecPtrTy, "vstore_ptr");
+    Value *VecBase = B.CreateBitCast(GEPBase, PtrTy, "vstore_ptr");
     Store = B.CreateStore(Data, VecBase, false);
 
     const unsigned Align = VecDataTy->getScalarSizeInBits() / 8;

--- a/modules/compiler/compiler_pipeline/source/mux_builtin_info.cpp
+++ b/modules/compiler/compiler_pipeline/source/mux_builtin_info.cpp
@@ -1208,7 +1208,7 @@ BIMuxInfoConcept::getMuxSchedulingParameters(Module &M) {
     auto *const WIInfoS = getWorkItemInfoStructTy(M);
     WIInfo.ID = SchedParamIndices::WI;
     WIInfo.ParamPointeeTy = WIInfoS;
-    WIInfo.ParamTy = WIInfoS->getPointerTo();
+    WIInfo.ParamTy = PointerType::get(WIInfoS, /*AddressSpace=*/0);
     WIInfo.ParamName = "wi-info";
     WIInfo.ParamDebugName = WIInfoS->getStructName().str();
     WIInfo.PassedExternally = false;
@@ -1224,7 +1224,7 @@ BIMuxInfoConcept::getMuxSchedulingParameters(Module &M) {
     auto *const WGInfoS = getWorkGroupInfoStructTy(M);
     WGInfo.ID = SchedParamIndices::WG;
     WGInfo.ParamPointeeTy = WGInfoS;
-    WGInfo.ParamTy = WGInfoS->getPointerTo();
+    WGInfo.ParamTy = PointerType::get(WGInfoS, /*AddressSpace=*/0);
     WGInfo.ParamName = "wg-info";
     WGInfo.ParamDebugName = WGInfoS->getStructName().str();
     WGInfo.PassedExternally = true;

--- a/modules/compiler/compiler_pipeline/source/replace_atomic_funcs_pass.cpp
+++ b/modules/compiler/compiler_pipeline/source/replace_atomic_funcs_pass.cpp
@@ -367,12 +367,6 @@ bool RunOnInstruction(CallInst &call) {
                      ? builder.getIntN(call.getType()->getIntegerBitWidth(), 1)
                      : call.getArgOperand(1);
 
-      if (call.getType()->isFloatingPointTy()) {
-        auto ptr = builder.getIntNTy(call.getType()->getPrimitiveSizeInBits())
-                       ->getPointerTo(op0->getType()->getPointerAddressSpace());
-        op0 = builder.CreateBitCast(op0, ptr);
-      }
-
       if (op1->getType()->isFloatingPointTy()) {
         op1 = builder.CreateBitCast(
             op1, builder.getIntNTy(call.getType()->getPrimitiveSizeInBits()));

--- a/modules/compiler/compiler_pipeline/source/replace_local_module_scope_variables_pass.cpp
+++ b/modules/compiler/compiler_pipeline/source/replace_local_module_scope_variables_pass.cpp
@@ -354,7 +354,8 @@ PreservedAnalyses compiler::utils::ReplaceLocalModuleScopeVariablesPass::run(
 
   // change all our functions to take a pointer to the new structTy we created
   const AttributeSet defaultAttrs;
-  addParamToAllRequiredFunctions(M, structTy->getPointerTo(), defaultAttrs);
+  addParamToAllRequiredFunctions(
+      M, PointerType::get(structTy, /*AddressSpace=*/0), defaultAttrs);
 
   // Check if we have debug info, if so we need to fix it up to turn global
   // variable entries into local variable ones.

--- a/modules/compiler/source/base/source/printf_replacement_pass.cpp
+++ b/modules/compiler/source/base/source/printf_replacement_pass.cpp
@@ -716,7 +716,7 @@ void compiler::PrintfReplacementPass::rewritePrintfCall(
   // later when we know how much we need to add
   auto call_offset = ir.CreateAtomicRMW(
       AtomicRMWInst::Add,
-      ir.CreatePointerCast(buffer, ir.getInt32Ty()->getPointerTo(1)),
+      ir.CreatePointerCast(buffer, ir.getPtrTy(/*AddrSpace=*/1)),
       ir.getInt32(0), MaybeAlign(), ordering, SyncScope::System);
 
   // store block
@@ -727,7 +727,7 @@ void compiler::PrintfReplacementPass::rewritePrintfCall(
   ir.CreateAlignedStore(
       ir.getInt32(printf_calls.size() - 1),
       ir.CreatePointerCast(ir.CreateGEP(buffer_elt_ty, buffer, call_offset),
-                           ir.getInt32Ty()->getPointerTo(1)),
+                           ir.getPtrTy(/*AddrSpace=*/1)),
       Align(1));
   // argument offset, starts at 4 to account for the printf call's id
   size_t offset = 4;
@@ -753,8 +753,8 @@ void compiler::PrintfReplacementPass::rewritePrintfCall(
     offset += size / 8;
 
     // cast the pointer to the larger type and store the value
-    ir.CreateAlignedStore(arg, ir.CreatePointerCast(gep, type->getPointerTo(1)),
-                          Align(1));
+    ir.CreateAlignedStore(
+        arg, ir.CreatePointerCast(gep, ir.getPtrTy(/*AddrSpace=*/1)), Align(1));
   }
 
   // and return 0;
@@ -767,7 +767,7 @@ void compiler::PrintfReplacementPass::rewritePrintfCall(
   // store
   auto correct_add = ir.CreateAtomicRMW(
       AtomicRMWInst::Add,
-      ir.CreatePointerCast(buffer, ir.getInt32Ty()->getPointerTo(1)),
+      ir.CreatePointerCast(buffer, ir.getPtrTy(/*AddrSpace=*/1)),
       ir.getInt32(offset), MaybeAlign(), ordering, SyncScope::System);
   call_offset->replaceAllUsesWith(correct_add);
 
@@ -790,7 +790,7 @@ void compiler::PrintfReplacementPass::rewritePrintfCall(
   // write how much data was not written to the buffer but is accounted for by
   // the length because of the first atomic add
   //
-  auto *cast = ir.CreatePointerCast(buffer, ir.getInt32Ty()->getPointerTo(1));
+  auto *cast = ir.CreatePointerCast(buffer, ir.getPtrTy(/*AddrSpace=*/1));
 
   ir.CreateAtomicRMW(
       AtomicRMWInst::Add, ir.CreateGEP(ir.getInt32Ty(), cast, ir.getInt32(1)),

--- a/modules/compiler/targets/host/source/HostMuxBuiltinInfo.cpp
+++ b/modules/compiler/targets/host/source/HostMuxBuiltinInfo.cpp
@@ -88,7 +88,7 @@ HostBIMuxInfo::getMuxSchedulingParameters(Module &M) {
   {
     auto *const WIInfoS = compiler::utils::getWorkItemInfoStructTy(M);
     WIInfo.ID = SchedParamIndices::WI;
-    WIInfo.ParamTy = WIInfoS->getPointerTo();
+    WIInfo.ParamTy = PointerType::get(WIInfoS, /*AddressSpace=*/0);
     WIInfo.ParamPointeeTy = WIInfoS;
     WIInfo.ParamName = "wi-info";
     WIInfo.ParamDebugName = WIInfoS->getStructName().str();
@@ -104,7 +104,7 @@ HostBIMuxInfo::getMuxSchedulingParameters(Module &M) {
   {
     auto *const SchedInfoS = getScheduleInfoStruct(M);
     SchedInfo.ID = SchedParamIndices::SCHED;
-    SchedInfo.ParamTy = SchedInfoS->getPointerTo();
+    SchedInfo.ParamTy = PointerType::get(SchedInfoS, /*AddressSpace=*/0);
     SchedInfo.ParamPointeeTy = SchedInfoS;
     SchedInfo.ParamName = "sched-info";
     SchedInfo.ParamDebugName = SchedInfoS->getStructName().str();
@@ -120,7 +120,7 @@ HostBIMuxInfo::getMuxSchedulingParameters(Module &M) {
   {
     auto *const WGInfoS = getMiniWGInfoStruct(M);
     WGInfo.ID = SchedParamIndices::MINIWG;
-    WGInfo.ParamTy = WGInfoS->getPointerTo();
+    WGInfo.ParamTy = PointerType::get(WGInfoS, /*AddressSpace=*/0);
     WGInfo.ParamPointeeTy = WGInfoS;
     WGInfo.ParamName = "mini-wg-info";
     WGInfo.ParamDebugName = WGInfoS->getStructName().str();

--- a/modules/compiler/vecz/source/transform/builtin_inlining_pass.cpp
+++ b/modules/compiler/vecz/source/transform/builtin_inlining_pass.cpp
@@ -153,14 +153,10 @@ static Value *emitBuiltinMemSet(Function *F, IRBuilder<> &B,
   int64_t byte = 0;
   // Initially we use 64bit loads and stores, in order to avoid emitting too
   // many instructions.
-  // We can't just get an Int64PtrTy because we need the correct address space
-  Type *DstInt64PtrTy = B.getInt64Ty()->getPointerTo(
-      cast<PointerType>(DstPtr->getType())->getAddressSpace());
 
   for (; byte <= Bytes - 8; byte += 8) {
     Value *Idx = B.getIntN(PtrBits, byte);
-    Value *OffsetDstPtr = B.CreateBitCast(
-        B.CreateInBoundsGEP(Int8Ty, DstPtr, Idx), DstInt64PtrTy, DstName);
+    Value *OffsetDstPtr = B.CreateInBoundsGEP(Int8Ty, DstPtr, Idx);
     MS = B.CreateStore(StoredValue64, OffsetDstPtr, IsVolatile);
 
     // Set alignments for store to be minimum of that from
@@ -223,19 +219,12 @@ static Value *emitBuiltinMemCpy(Function *F, IRBuilder<> &B,
   int64_t byte = 0;
   // Initially we use 64bit loads and stores, in order to avoid emitting too
   // many instructions...
-  // We can't just get an Int64PtrTy because we need the correct address space
   Type *Int64Ty = B.getInt64Ty();
-  Type *SrcInt64PtrTy = Int64Ty->getPointerTo(
-      cast<PointerType>(SrcPtr->getType())->getAddressSpace());
-  Type *DstInt64PtrTy = Int64Ty->getPointerTo(
-      cast<PointerType>(DstPtr->getType())->getAddressSpace());
 
   for (; byte <= Length - 8; byte += 8) {
     Value *Idx = B.getIntN(PtrBits, byte);
-    Value *OffsetSrcPtr = B.CreateBitCast(
-        B.CreateInBoundsGEP(Int8Ty, SrcPtr, Idx), SrcInt64PtrTy);
-    Value *OffsetDstPtr = B.CreateBitCast(
-        B.CreateInBoundsGEP(Int8Ty, DstPtr, Idx), DstInt64PtrTy, DstName);
+    Value *OffsetSrcPtr = B.CreateInBoundsGEP(Int8Ty, SrcPtr, Idx);
+    Value *OffsetDstPtr = B.CreateInBoundsGEP(Int8Ty, DstPtr, Idx);
     LoadInst *LoadValue =
         B.CreateLoad(Int64Ty, OffsetSrcPtr, IsVolatile, SrcName);
     MC = B.CreateStore(LoadValue, OffsetDstPtr, IsVolatile);

--- a/modules/compiler/vecz/source/transform/remove_intptr_pass.cpp
+++ b/modules/compiler/vecz/source/transform/remove_intptr_pass.cpp
@@ -105,10 +105,7 @@ PreservedAnalyses RemoveIntPtrPass::run(Function &F,
 
         if (index) {
           Value *operand = int_ptr->getOperand(0);
-          Value *cast_operand = B.CreateBitCast(
-              operand, i8_ty->getPointerTo(
-                           operand->getType()->getPointerAddressSpace()));
-          Value *new_gep = B.CreateGEP(i8_ty, cast_operand, index, name);
+          Value *new_gep = B.CreateGEP(i8_ty, operand, index, name);
           Value *new_cast = B.CreatePtrToInt(new_gep, bin_op->getType(), name);
           bin_op->replaceAllUsesWith(new_cast);
           bin_op->eraseFromParent();


### PR DESCRIPTION
# Overview

[NFC] Avoid deprecated Type::getPointerTo.

# Reason for change

Type::getPointerTo has been deprecated in favour of PointerType::get.

# Description of change

This commit updates the calls accordingly.

# Anything else we should know?

Exceptions:
- Some uses were to perform bitcasts between pointer types. These bitcasts did nothing ever since LLVM moved to opaque pointers, and are removed instead.
- Some uses were in a context where an IRBuilder was available, in which case IRBuilder::getPtrTy provides a simpler alternative.

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-19](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
