### PR TITLE
Switch off codeql cache build save for PR jobs

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -16,7 +16,7 @@ on:
       - 'hal/**'
       - '.github/actions/do_build_ock/**'
       - '.github/actions/setup_build/**'
-      - '.github/workflows/run_pr_tests.yml'
+      - '.github/workflows/codeql.yml'
       - 'CMakeLists.txt'
   schedule:
     - cron: '19 9 * * 3'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -7,6 +7,17 @@ on:
   pull_request:
     branches:
       - main
+    paths:
+      - 'source/**'
+      - 'clik/**'
+      - 'modules/**'
+      - 'examples/**'
+      - 'cmake/**'
+      - 'hal/**'
+      - '.github/actions/do_build_ock/**'
+      - '.github/actions/setup_build/**'
+      - '.github/workflows/run_pr_tests.yml'
+      - 'CMakeLists.txt'
   schedule:
     - cron: '19 9 * * 3'
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -77,7 +77,6 @@ jobs:
       - name: setup-ubuntu
         uses:  ./.github/actions/setup_build
         with:
-          save: true
           llvm_version: 18
           llvm_build_type: RelAssert
 


### PR DESCRIPTION
# Overview

Switch off cache build save with CodeQL PR jobs - and make them use the standard PR "changed files" set.

# Reason for change

Cache build save not needed.

# Description of change

Set CodeQL's setup_build action params correctly and update its `on:pull_request:` settings.
