### PR TITLE
Add missing reference for threads.

### DIFF
--- a/source/cl/test/FuzzCL/CMakeLists.txt
+++ b/source/cl/test/FuzzCL/CMakeLists.txt
@@ -17,6 +17,7 @@
 add_ca_cl_library(Fuzz STATIC
   ${CMAKE_CURRENT_SOURCE_DIR}/source/context.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/include/FuzzCL/context.h)
+target_link_libraries(Fuzz PRIVATE Threads::Threads)
 
 target_include_directories(Fuzz
   PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)


### PR DESCRIPTION
# Overview

Add missing reference for threads.

# Reason for change

After the bump to OpenCL ICD Loader, on Ubuntu 20, linking FuzzCL fails with an undefined reference to pthread_create. It appears that the older version of OpenCL ICD Loader implicitly referenced libpthread, whereas the newer version does not.

# Description of change

Explicitly add the reference instead.

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-19](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
