### PR TITLE
[LLVM 20] Update tests.

### DIFF
--- a/modules/compiler/vecz/test/lit/llvm/loop_call_instantiation.ll
+++ b/modules/compiler/vecz/test/lit/llvm/loop_call_instantiation.ll
@@ -39,7 +39,7 @@ declare extern_weak spir_func i32 @printf(i8 addrspace(2)*, ...)
 
 ; CHECK: [[LOOPHEADER1:instloop.header.*]]:
 ; CHECK: %[[INSTANCE1:instance.*]] = phi i32 [ 0, {{.+}} ], [ %[[V7:[0-9]+]], %[[LOOPBODY1:instloop.body.*]] ]
-; CHECK: %[[V3:[0-9]+]] = icmp ult i32 %[[INSTANCE1]], 4
+; CHECK: %[[V3:[0-9]+]] = icmp {{(samesign )?}}ult i32 %[[INSTANCE1]], 4
 ; CHECK: br i1 %[[V3]], label %[[LOOPBODY1]], label {{.+}}
 
 ; CHECK: [[LOOPBODY1]]:
@@ -51,7 +51,7 @@ declare extern_weak spir_func i32 @printf(i8 addrspace(2)*, ...)
 
 ; CHECK: [[LOOPHEADER2:instloop.header.*]]:
 ; CHECK: %[[INSTANCE3:.+]] = phi i32 [ %[[V11:[0-9]+]], %[[LOOPBODY2:instloop.body.*]] ], [ 0, {{.+}} ]
-; CHECK: %[[V8:[0-9]+]] = icmp ult i32 %[[INSTANCE3]], 4
+; CHECK: %[[V8:[0-9]+]] = icmp {{(samesign )?}}ult i32 %[[INSTANCE3]], 4
 ; CHECK: br i1 %[[V8]], label %[[LOOPBODY2]], label {{.+}}
 
 ; CHECK: [[LOOPBODY2]]:

--- a/modules/compiler/vecz/test/lit/llvm/struct_select.ll
+++ b/modules/compiler/vecz/test/lit/llvm/struct_select.ll
@@ -19,7 +19,7 @@
 target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "spir64-unknown-unknown"
 
-%struct_type = type { i32, i32 }
+%struct_type = type { i32, i64 }
 
 define spir_kernel void @test(%struct_type* %in1, %struct_type* %in2, %struct_type* %out) {
 entry:


### PR DESCRIPTION
# Overview

[LLVM 20] Update tests.

# Reason for change

*Describe how the current behaviour of the project is causing problems for you
or is otherwise unsatisfactory for your use case.*

# Description of change

loop_call_instantiation sees an extra flag added to icmp. Allow that.

struct_select hits a new optimization that happens because both structure elements are the same type. Use different types to get the same IR we got before.

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-19](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
