### PR TITLE
Remove uxlfoundation/security-managers as dependabot reviewers

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,5 +15,3 @@ updates:
       github-actions:
         patterns:
           - "*"
-    reviewers:
-      - "codeplaysoftware/security-managers"


### PR DESCRIPTION
# Overview

Remove reviewers for depedabot PRs. 

# Reason for change

Dependabot PRs were configured to request review from a team not present in current organization. security-managers  team on UXL foundation is not in charge of updating workflow dependencies. 

# Description of change

Remove reviewers configuration. 

# Anything else we should know?

N/A

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-19](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
