### PR TITLE
Fix scheduling of pr test workflow

### DIFF
--- a/.github/workflows/run_pr_tests.yml
+++ b/.github/workflows/run_pr_tests.yml
@@ -25,10 +25,6 @@ on:
         default: true
 permissions: {}
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
-
 jobs:
 
   # build and run host x86_64, execute UnitCL and lit tests and build and run offline

--- a/.github/workflows/run_pr_tests_caller.yml
+++ b/.github/workflows/run_pr_tests_caller.yml
@@ -23,21 +23,12 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  run-with-pull:
-    name: Call PR testing on pull request
-    if: ${{ github.event_name == 'pull_request' }}    
-    uses: ./.github/workflows/run_pr_tests.yml
-    with:
-      update_cache: false
-      is_pull_request: true
-
-  # Could have multiple here
-  run-with-cron:
+  run-prs:
     name: Call PR testing on schedule
-    if: ${{ github.event_name == 'schedule' && github.repository == 'uxlfoundation/oneapi-construction-kit'}}
+    if: ${{ (github.event_name == 'schedule' && github.repository == 'uxlfoundation/oneapi-construction-kit') || github.event_name == 'pull_request' }}
     uses: ./.github/workflows/run_pr_tests.yml
     with:
-      update_cache: true
-      is_pull_request: false
+      update_cache: ${{ github.event_name == 'schedule' }}
+      is_pull_request:  ${{ github.event_name != 'schedule' }}
 
 # additional ones here for cron and/or push to main - also can be in different file.


### PR DESCRIPTION
# Overview

Fix scheduling of pr test workflow

# Reason for change

Scheduled pr testing did not run.

# Description of change

Having the same concurrency group in the caller and the callee was causing
issues. This removes the concurrency group setting in run_pr_tests.yml.

It also simplifies the original calling workflow to one job.
