### PR TITLE
Updated CONTRIBUTING and README.md to refer to the slack channel.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,9 +63,14 @@ clarification, we ask that you follow these steps.
 * Provide as much context as you can about the problem or question you have.
 * Provide project version and any relevant system details (e.g. operating
   system).
+* You can contact oneapi Construction Kit developers via [UXL Foundation Slack] using
+  [#oneck] channel.
+
 
 Once your issue has been opened, we will take a look and try to help you as
 soon as possible.
+
+[#oneck]: https://uxlfoundation.slack.com/channels/oneck
 
 # I want to contribute
 
@@ -168,6 +173,7 @@ in preparation for your suggestion.
 Once you have prepared to submit your enhancement suggestion, we ask that you
 follow these steps.
 
+* Consider using the slack channel [#oneck] to discuss the idea.
 * Open an
   [issue](https://github.com/codeplaysoftware/oneapi-construction-kit/issues/new/choose).
 * Select the **Enhancement** issue template and fill in the requested details.

--- a/README.md
+++ b/README.md
@@ -368,6 +368,18 @@ refsi_hal_device::mem_free(address=0x9ff0ff80)
 The results are correct!
 ```
 
+# Support
+
+Submit questions, feature requests, and bug reports on the
+[GitHub issues] page.
+
+You can also contact oneapi Construction Kit developers via [UXL Foundation Slack] using
+[#oneck] channel.
+
+[Github issues]: https://github.com/uxlfoundation/oneapi-construction-kit/issues
+[UXL Foundation Slack]: https://slack-invite.uxlfoundation.org/
+[#oneck]: https://uxlfoundation.slack.com/channels/oneck
+
 # Governance
 The oneAPI Construction Kit project is governed by the [UXL Foundation] and you can get involved in
 this project in the following ways:


### PR DESCRIPTION
# Overview

Updated CONTRIBUTING and README.md to refer to the slack channel.

# Reason for change

Make it easier for users to see that as an option. Fits with uxlfoundation.

# Description of change

Added some references to readme and contributing guides.
