### PR TITLE
Use GitHub Discussions instead of Slack.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,41 +37,6 @@ where it's unclear if your behaviour would violate the code. Please report
 unacceptable behaviour to
 [oneapi.construction.kit@codeplay.com](mailto:oneapi.construction.kit@codeplay.com).
 
-# I have a question
-
-Before asking a question, it is best to search through the available resources
-in case your question has already been answered.
-
-* We assume that you have read through the relevant
-  [Documentation](https://developer.codeplay.com/products/oneapi/construction-kit/guides).
-* There may be existing
-  [issues](https://github.com/codeplaysoftware/oneapi-construction-kit/issues)
-  that might help you.
-* An answer may have been provided elsewhere on the internet.
-
-In case you have found a suitable
-[issue](https://github.com/codeplaysoftware/oneapi-construction-kit/issues) and
-still need clarification, you can feel free to write your question in the
-existing issue.
-
-If your question has not been answered or you still feel that you need
-clarification, we ask that you follow these steps.
-
-* Open an
-  [issue](https://github.com/codeplaysoftware/oneapi-construction-kit/issues/new/choose).
-* Select the **Question** issue template and fill in the requested details.
-* Provide as much context as you can about the problem or question you have.
-* Provide project version and any relevant system details (e.g. operating
-  system).
-* You can contact oneapi Construction Kit developers via [UXL Foundation Slack] using
-  [#oneck] channel.
-
-
-Once your issue has been opened, we will take a look and try to help you as
-soon as possible.
-
-[#oneck]: https://uxlfoundation.slack.com/channels/oneck
-
 # I want to contribute
 
 ## Legal notice

--- a/README.md
+++ b/README.md
@@ -370,15 +370,30 @@ The results are correct!
 
 # Support
 
-Submit questions, feature requests, and bug reports on the
-[GitHub issues] page.
+Questions can be submitted on [GitHub Discussions Q&A] or on [GitHub Issues].
 
-You can also contact oneapi Construction Kit developers via [UXL Foundation Slack] using
-[#oneck] channel.
+Before submitting a question, please make sure to read through the relevant
+[documentation] and any existing discussions or issues.
 
-[Github issues]: https://github.com/uxlfoundation/oneapi-construction-kit/issues
-[UXL Foundation Slack]: https://slack-invite.uxlfoundation.org/
-[#oneck]: https://uxlfoundation.slack.com/channels/oneck
+If you find that your question has been previously asked but you are in need of
+further clarification, feel free to write your question on the existing
+discussion or issue.
+
+If you would like to open a new question, we ask that you follow these steps:
+
+* [Open a new question](https://github.com/uxlfoundation/oneapi-construction-kit/discussions/new?category=q-a)
+* Alternatively, [open a new issue](https://github.com/codeplaysoftware/oneapi-construction-kit/issues/new/choose).
+  * Select the **Question** issue template and fill in the requested details.
+* Provide as much context as you can about the problem or question you have.
+* Provide project version and any relevant system details (e.g. operating
+  system).
+
+Once your question has been opened, we will take a look and try to help you as
+soon as possible.
+
+[Documentation]: https://developer.codeplay.com/products/oneapi/construction-kit/guides
+[GitHub Discussions Q&A]: https://github.com/uxlfoundation/oneapi-construction-kit/discussions/categories/q-a
+[GitHub Issues]: https://github.com/uxlfoundation/oneapi-construction-kit/issues
 
 # Governance
 The oneAPI Construction Kit project is governed by the [UXL Foundation] and you can get involved in


### PR DESCRIPTION
# Overview

Use GitHub Discussions instead of Slack.

# Reason for change

#612 updated the documentation to refer to a new Slack channel, but after some more discussion, that turns out to not be what we want to be using since we have GitHub Discussions already.

Additionally, the CONTRIBUTING page is not where I would expect to find the instructions on how to ask questions.

# Description of change

- Change references to Slack to reference GitHub Discussions instead
- Move support section of CONTRIBUTING to README

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-19](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
