### PR TITLE
[GITHUB CI] Add support for cross compilation installation for ICD

### DIFF
--- a/.github/actions/do_build_icd/action.yml
+++ b/.github/actions/do_build_icd/action.yml
@@ -17,6 +17,12 @@ runs:
     - name: Install Ninja
       uses: llvm/actions/install-ninja@a1ea791b03c8e61f53a0e66f2f73db283aa0f01e # main branch
 
+    - name: install cross tools
+      if: steps.calc_vars.outputs.arch != 'x86_64'
+      uses: ./.github/actions/do_install_ubuntu_cross_tools
+      with:
+        cross_arch: ${{ steps.calc_vars.outputs.arch }}
+
     - name: clone headers
       uses: actions/checkout@v4
       with:

--- a/.github/actions/do_install_ubuntu_cross_tools/action.yml
+++ b/.github/actions/do_install_ubuntu_cross_tools/action.yml
@@ -1,0 +1,27 @@
+name: install ubuntu cross compilation tools
+description: install ubuntu tools needed for cross compilation
+
+inputs:
+  cross_arch:
+    description: 'target architecture - default is no cross arch'
+    default: ''
+
+runs:
+  using: "composite"
+  steps:
+    - name: Install ubuntu prerequisites
+      shell: bash
+      run: |
+        if [ "${{ inputs.cross_arch }}" = "x86" ]; then \
+            sudo apt-get install --yes gcc-multilib g++-multilib libc6-dev:i386 lib32tinfo-dev; \
+        fi
+        if [ "${{ inputs.cross_arch }}" = "arm" ]; then \
+            sudo apt-get install --yes gcc-arm-linux-gnueabihf g++-arm-linux-gnueabihf; \
+        fi
+        if [ "${{ inputs.cross_arch }}" = "aarch64" ]; then \
+            sudo apt-get install --yes gcc-aarch64-linux-gnu g++-aarch64-linux-gnu; \
+        fi
+        if [ "${{ inputs.cross_arch }}" = "riscv64" ]; then \
+            sudo apt-get install --yes gcc-riscv64-linux-gnu g++-riscv64-linux-gnu; \
+        fi
+

--- a/.github/actions/setup_build/action.yml
+++ b/.github/actions/setup_build/action.yml
@@ -54,22 +54,17 @@ runs:
         pip install lit clang-format==19.1.0 virtualenv
         sudo apt-get install --yes doxygen
         sudo apt-get install --yes vulkan-sdk
-        if [ "${{ inputs.cross_arch }}" = "x86" ]; then \
-           sudo apt-get install --yes gcc-multilib g++-multilib libc6-dev:i386 lib32tinfo-dev; \
-        fi
-        if [ "${{ inputs.cross_arch }}" = "arm" ]; then \
-           sudo apt-get install --yes gcc-arm-linux-gnueabihf g++-arm-linux-gnueabihf; \
-        fi
-        if [ "${{ inputs.cross_arch }}" = "aarch64" ]; then \
-           sudo apt-get install --yes gcc-aarch64-linux-gnu g++-aarch64-linux-gnu; \
-        fi
-        if [ "${{ inputs.cross_arch }}" = "riscv64" ]; then \
-           sudo apt-get install --yes gcc-riscv64-linux-gnu g++-riscv64-linux-gnu; \
-        fi
+        # TODO: Only required if we are running something that requires qemu, not required for building
         if [ "${{ inputs.cross_arch }}" != "none" ] && [ "${{ inputs.cross_arch }}" != "x86" ]; then \
            # Install QEMU for testing cross compilation.
            sudo apt-get install --yes qemu-user; \
         fi
+
+    - name: Install cross arch tools
+      if: ${{ inputs.os == 'ubuntu' }}
+      uses: ./.github/actions/do_install_ubuntu_cross_tools
+      with:
+        cross_arch: ${{ inputs.cross_arch }}      
 
     - name: Install windows prerequisites
       if: ${{ inputs.os == 'windows' }}


### PR DESCRIPTION
# Overview

This fixes the ICD overnight failure for aarch64 by calling a new action do_install_ubuntu_cross_tools which will also be used by setup_build.
