### PR TITLE
Use cp-ubuntu-24.04 with ubuntu 22.04 image on slow PR job

### DIFF
--- a/.github/actions/setup_build/action.yml
+++ b/.github/actions/setup_build/action.yml
@@ -36,6 +36,11 @@ runs:
       if: ${{ inputs.os == 'ubuntu' }}
       shell: bash
       run: |
+        # required for virtualenv running in docker
+        echo "PATH=$PATH:$HOME/.local/bin" >> $GITHUB_ENV
+        # required due to using non docker to build llvm
+        # If we switch to always using docker we can drop.
+        sudo apt-get install --yes lib32ncurses-dev    
         if [ "${{ inputs.cross_arch }}" = "x86" ]; then sudo dpkg --add-architecture i386 ; fi
         wget -qO - https://packages.lunarg.com/lunarg-signing-key-pub.asc | sudo apt-key add -
         if [ "${{ inputs.ubuntu_version }}" = "20.04" ]; then sudo wget -qO /etc/apt/sources.list.d/lunarg-vulkan-1.3.243-focal.list https://packages.lunarg.com/vulkan/1.3.243/lunarg-vulkan-1.3.243-focal.list; fi
@@ -52,6 +57,8 @@ runs:
         sudo apt-get update
         if [ "${{ inputs.clang_tidy }}" = "true" ]; then sudo apt-get install --yes clang-tidy-19; fi
         pip install lit clang-format==19.1.0 virtualenv
+        # required for gtest-terse-runner running in docker
+        sudo apt-get install --yes python3-colorama
         sudo apt-get install --yes doxygen
         sudo apt-get install --yes vulkan-sdk
         # TODO: Only required if we are running something that requires qemu, not required for building
@@ -64,7 +71,7 @@ runs:
       if: ${{ inputs.os == 'ubuntu' }}
       uses: ./.github/actions/do_install_ubuntu_cross_tools
       with:
-        cross_arch: ${{ inputs.cross_arch }}      
+        cross_arch: ${{ inputs.cross_arch }}
 
     - name: Install windows prerequisites
       if: ${{ inputs.os == 'windows' }}

--- a/.github/workflows/run_pr_tests.yml
+++ b/.github/workflows/run_pr_tests.yml
@@ -354,7 +354,11 @@ jobs:
 
   # Based on: mr-ubuntu-gcc-aarch64-llvm-previous-cl3-0-fp16
   run-ubuntu-gcc-aarch64-llvm-latest-cl3-0-fp16:
-    runs-on: ubuntu-22.04
+    runs-on: cp-ubuntu-24.04
+    container:
+      image: ghcr.io/intel/llvm/ubuntu2204_base:latest
+      volumes:
+        - ${{github.workspace}}:${{github.workspace}}
     timeout-minutes: 90 # aarch64 needs longer timeout
     steps:
     - name: Checkout repo


### PR DESCRIPTION
# Overview

Use cp-ubuntu-24.04 with ubuntu 22.04 image on slow PR job

# Reason for change

Desire to speed up jobs and provide a pathway to use these runners.

# Description of change

Uses cp-ubuntu-24.04, but with ubuntu 22.04 image from intel/llvm. Required a few small additional installs/env vars etc to make it work.
