### PR TITLE
DRAFT: Switch over planned testing to use cp-ubuntu-24.04 where it helps

### DIFF
--- a/.github/actions/do_build_ock_artefact/action.yml
+++ b/.github/actions/do_build_ock_artefact/action.yml
@@ -33,6 +33,7 @@ runs:
           llvm_version: ${{ inputs.llvm_version }}
           llvm_build_type: RelAssert
           cross_arch: ${{ steps.calc_vars.outputs.arch == 'x86_64' && 'none' || steps.calc_vars.outputs.arch }}
+          save: true
 
       - name: build ock x86
         if: steps.calc_vars.outputs.arch  == 'x86_64'

--- a/.github/actions/do_build_sycl_cts/action.yml
+++ b/.github/actions/do_build_sycl_cts/action.yml
@@ -49,21 +49,21 @@ runs:
         path: SYCL-CTS.src
         submodules: true
 
-    - name: expand runner swap
-      # Needed to allow building - else current default memory restrictions lead to the runner being killed
-      shell: bash
-      run: |
-        set -x
-        df -h
-        sudo swapon --show
-        sudo swapoff -a
-        sudo fallocate -l 8G /mnt/swapfilenew
-        sudo chmod 600 /mnt/swapfilenew
-        sudo mkswap /mnt/swapfilenew
-        sudo swapon /mnt/swapfilenew
-        sudo swapon --show
-        df -h
-        set +x
+    # - name: expand runner swap
+    #   # Needed to allow building - else current default memory restrictions lead to the runner being killed
+    #   shell: bash
+    #   run: |
+    #     set -x
+    #     df -h
+    #     sudo swapon --show
+    #     sudo swapoff -a
+    #     sudo fallocate -l 8G /mnt/swapfilenew
+    #     sudo chmod 600 /mnt/swapfilenew
+    #     sudo mkswap /mnt/swapfilenew
+    #     sudo swapon /mnt/swapfilenew
+    #     sudo swapon --show
+    #     df -h
+    #     set +x
 
     - name: build SYCL CTS
       shell: bash

--- a/.github/actions/run_opencl_cts/action.yml
+++ b/.github/actions/run_opencl_cts/action.yml
@@ -38,4 +38,5 @@ runs:
                -e "OCL_ICD_FILENAMES=$GITHUB_WORKSPACE/install_ock/lib/libCL.so" \
                -e "CL_PLATFORM_INDEX=0" \
                -s "$GITHUB_WORKSPACE/test_conformance/$CTS_CSV_FILE" \
-               -i "$GITHUB_WORKSPACE/source/cl/scripts/$CTS_FILTER"
+               -i "$GITHUB_WORKSPACE/source/cl/scripts/$CTS_FILTER" \
+               -j 8

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -4,20 +4,20 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    branches:
-      - main
-    paths:
-      - 'source/**'
-      - 'clik/**'
-      - 'modules/**'
-      - 'examples/**'
-      - 'cmake/**'
-      - 'hal/**'
-      - '.github/actions/do_build_ock/**'
-      - '.github/actions/setup_build/**'
-      - '.github/workflows/codeql.yml'
-      - 'CMakeLists.txt'
+  # pull_request:
+  #   branches:
+  #     - main
+  #   paths:
+  #     - 'source/**'
+  #     - 'clik/**'
+  #     - 'modules/**'
+  #     - 'examples/**'
+  #     - 'cmake/**'
+  #     - 'hal/**'
+  #     - '.github/actions/do_build_ock/**'
+  #     - '.github/actions/setup_build/**'
+  #     - '.github/workflows/codeql.yml'
+  #     - 'CMakeLists.txt'
   schedule:
     - cron: '19 9 * * 3'
 

--- a/.github/workflows/planned_testing.yml
+++ b/.github/workflows/planned_testing.yml
@@ -51,7 +51,22 @@ jobs:
         cat $GITHUB_OUTPUT    
 
 
-  create_ock_artefacts:
+  create_ock_artefacts_windows:
+    needs: [workflow_vars]
+    # Currently there is only one windows target so we don't bother with the
+    # matrix, just check if it's enabled
+    runs-on: windows-2019
+    if : inputs.ock && contains(inputs.target_list, 'host_x86_64_windows')
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+      - name: build ock artefact
+        uses: ./.github/actions/do_build_ock_artefact
+        with:
+          target: host_x86_64_windows
+          llvm_version: ${{ inputs.llvm_version }}
+
+  create_ock_artefacts_ubuntu:
     needs: [workflow_vars]
     strategy:
       matrix:
@@ -59,9 +74,12 @@ jobs:
         exclude: ${{ fromJson(needs.workflow_vars.outputs.matrix_only_linux_x86_64_aarch64) }}
 
     # risc-v needs ubuntu 24.04 so we get the latest qemu as well as how we
-    # build llvm. Otherwise we choose windows or ubuntu-22.04 depending on the
-    # target.
-    runs-on: ${{ (contains(matrix.target, 'host_riscv') && 'ubuntu-24.04') || (contains(matrix.target, 'windows') && 'windows-2019' || 'ubuntu-22.04' ) }}
+    # build llvm. Otherwise we choose ubuntu-22.04 (use a container for both for consistency).
+    runs-on: cp-ubuntu-24.04
+    container:
+      image: ${{ contains(matrix.target, 'host_riscv') && 'ghcr.io/intel/llvm/ubuntu2404_base:latest' || 'ghcr.io/intel/llvm/ubuntu2204_base:latest' }}
+      volumes:
+        - ${{github.workspace}}:${{github.workspace}}
     if : inputs.ock
     steps:
       - name: Checkout repo
@@ -97,7 +115,7 @@ jobs:
   # Currently only builds and runs on x86_64 linux
   build_run_tornado:
     if: inputs.test_tornado
-    needs: [ workflow_vars, build_icd, create_ock_artefacts ]
+    needs: [ workflow_vars, build_icd, create_ock_artefacts_ubuntu ]
     strategy:
       matrix:
         target: ${{ fromJson(inputs.target_list) }}
@@ -125,14 +143,18 @@ jobs:
   # Currently only builds and runs (default: quick) on x86_64 linux
   build_run_opencl_cts:
     if: inputs.test_opencl_cts
-    needs: [ workflow_vars, build_icd, create_ock_artefacts ]
+    needs: [ workflow_vars, build_icd, create_ock_artefacts_ubuntu ]
     strategy:
       matrix:
         target: ${{ fromJson(inputs.target_list) }}
         exclude: ${{ fromJson(needs.workflow_vars.outputs.matrix_only_linux_x86_64) }}
 
     # TODO: host-x86_64-linux only - expand for other targets
-    runs-on: ubuntu-22.04
+    runs-on: cp-ubuntu-24.04
+    container:
+      image: ${{ contains(matrix.target, 'host_riscv') && 'ghcr.io/intel/llvm/ubuntu2404_base:latest' || 'ghcr.io/intel/llvm/ubuntu2204_base:latest' }}
+      volumes:
+        - ${{github.workspace}}:${{github.workspace}}
     steps:
       - name: clone ock
         uses: actions/checkout@v4
@@ -160,7 +182,13 @@ jobs:
         target: ${{ fromJson(inputs.target_list) }}
         exclude: ${{ fromJson(needs.workflow_vars.outputs.matrix_only_linux_x86_64) }}
 
-    runs-on: ${{ contains(matrix.target, 'windows') && 'windows-2019' || 'ubuntu-22.04'  }}
+    # TODO: Extend if we decide to enable for windows or build natively on another target
+    runs-on: cp-ubuntu-24.04
+    container:
+      image: ghcr.io/intel/llvm/ubuntu2204_base:latest
+      volumes:
+        - ${{github.workspace}}:${{github.workspace}}
+
     if : inputs.test_sycl_cts
     steps:
       - name: Checkout repo
@@ -178,7 +206,13 @@ jobs:
         # TODO: For now just linux x86_64
         exclude: ${{ fromJson(needs.workflow_vars.outputs.matrix_only_linux_x86_64) }}
 
-    runs-on: 'ubuntu-22.04'
+    # TODO: Extend if we decide to enable for windows or build natively on another target
+    runs-on: cp-ubuntu-24.04
+    container:
+      image: ghcr.io/intel/llvm/ubuntu2204_base:latest
+      volumes:
+        - ${{github.workspace}}:${{github.workspace}}
+
     if : inputs.test_sycl_cts
     steps:
       - name: Checkout repo
@@ -189,14 +223,20 @@ jobs:
           target: ${{ matrix.target }}
 
   run_sycl_cts:
-    needs: [workflow_vars, create_ock_artefacts, build_dpcpp_native_host, build_sycl_cts]
+    needs: [workflow_vars, create_ock_artefacts_ubuntu, build_dpcpp_native_host, build_sycl_cts]
     strategy:
       matrix:
         target: ${{ fromJson(inputs.target_list) }}
         # TODO: For now just linux x86_64
         exclude: ${{ fromJson(needs.workflow_vars.outputs.matrix_only_linux_x86_64) }}
 
-    runs-on: 'ubuntu-22.04'
+    # TODO: Extend if we decide to enable for windows or build natively on another target
+    runs-on: cp-ubuntu-24.04
+    container:
+      image: ghcr.io/intel/llvm/ubuntu2204_base:latest
+      volumes:
+        - ${{github.workspace}}:${{github.workspace}}
+
     if : inputs.test_sycl_cts
     steps:
       - name: Checkout repo

--- a/.github/workflows/planned_testing_caller.yml
+++ b/.github/workflows/planned_testing_caller.yml
@@ -12,6 +12,10 @@ on:
     # Run Mon-Fri at 7pm
     - cron: '00 19 * * 1-5'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   call_planned:
     # This makes the diagram too big if we post much here so S_ for scheduled.

--- a/.github/workflows/planned_testing_caller.yml
+++ b/.github/workflows/planned_testing_caller.yml
@@ -2,12 +2,12 @@
 name: Run planned testing
 on:
   # Note: use pull_request: for localized testing only
-  #pull_request:
-  #  paths:
-  #    - '.github/workflows/planned_testing.yml'
-  #    - '.github/workflows/planned_testing_caller.yml'
-  #  branches:
-  #    - main
+  pull_request:
+   paths:
+     - '.github/workflows/planned_testing.yml'
+     - '.github/workflows/planned_testing_caller.yml'
+   branches:
+     - main
   schedule:
     # Run Mon-Fri at 7pm
     - cron: '00 19 * * 1-5'

--- a/.github/workflows/run_pr_tests_caller.yml
+++ b/.github/workflows/run_pr_tests_caller.yml
@@ -1,19 +1,19 @@
 # Calling workflow for running PR style tests
 name: Run ock tests for PR style testing
 on:
-  pull_request:
-    paths:
-      - 'source/**'
-      - 'clik/**'
-      - 'modules/**'
-      - 'examples/**'
-      - 'cmake/**'
-      - 'hal/**'
-      - '.github/actions/do_build_ock/**'
-      - '.github/actions/setup_build/**'
-      - '.github/workflows/run_pr_tests.yml'
-      - '.github/workflows/run_pr_tests_caller.yml'
-      - 'CMakeLists.txt'
+  # pull_request:
+  #   paths:
+  #     - 'source/**'
+  #     - 'clik/**'
+  #     - 'modules/**'
+  #     - 'examples/**'
+  #     - 'cmake/**'
+  #     - 'hal/**'
+  #     - '.github/actions/do_build_ock/**'
+  #     - '.github/actions/setup_build/**'
+  #     - '.github/workflows/run_pr_tests.yml'
+  #     - '.github/workflows/run_pr_tests_caller.yml'
+  #     - 'CMakeLists.txt'
   schedule:
     # Run Mon-Fri at 7pm
     - cron: '00 19 * * 1-5'


### PR DESCRIPTION
# Overview

Switch over planned testing to use cp-ubuntu-24.04 where it helps

# Reason for change

Speed up overnight, stop flooding all the runners.

# Description of change

Switched ock artefact building to use cp-ubuntu2-24.04
