### PR TITLE
Switch over planned testing to use cp-ubuntu-24.04 for ock/OpenCL

### DIFF
--- a/.github/actions/do_build_ock_artefact/action.yml
+++ b/.github/actions/do_build_ock_artefact/action.yml
@@ -33,6 +33,7 @@ runs:
           llvm_version: ${{ inputs.llvm_version }}
           llvm_build_type: RelAssert
           cross_arch: ${{ steps.calc_vars.outputs.arch == 'x86_64' && 'none' || steps.calc_vars.outputs.arch }}
+          os: ${{ contains(inputs.target, 'windows') && 'windows' || 'ubuntu' }}
 
       - name: build ock x86
         if: steps.calc_vars.outputs.arch  == 'x86_64'
@@ -41,6 +42,7 @@ runs:
           build_targets: install
           offline_kernel_tests: OFF
           extra_flags: -DCA_ENABLE_TESTS=OFF -DCA_ENABLE_EXAMPLES=OFF -DCA_ENABLE_DOCUMENTATION=OFF
+          shell_to_use: ${{ contains(inputs.target, 'windows') && 'pwsh' || 'bash' }}
 
       - name: build ock other ${{ matrix.target }}
         if: steps.calc_vars.outputs.arch  != 'x86_64'

--- a/.github/workflows/planned_testing.yml
+++ b/.github/workflows/planned_testing.yml
@@ -51,7 +51,27 @@ jobs:
         cat $GITHUB_OUTPUT    
 
 
-  create_ock_artefacts:
+  create_ock_artefacts_windows:
+    needs: [workflow_vars]
+    # Currently there is only one windows target so we don't bother with the
+    # matrix, just check if it's enabled
+    runs-on: windows-2019
+    if : inputs.ock && contains(inputs.target_list, 'host_x86_64_windows')
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+      # Todo: move to a common place e.g. setup_build
+      - name: Setup Windows llvm base
+        uses: llvm/actions/setup-windows@main
+        with:
+          arch: amd64
+      - name: build ock artefact
+        uses: ./.github/actions/do_build_ock_artefact
+        with:
+          target: host_x86_64_windows
+          llvm_version: ${{ inputs.llvm_version }}
+
+  create_ock_artefacts_ubuntu:
     needs: [workflow_vars]
     strategy:
       matrix:
@@ -59,10 +79,13 @@ jobs:
         exclude: ${{ fromJson(needs.workflow_vars.outputs.matrix_only_linux_x86_64_aarch64) }}
 
     # risc-v needs ubuntu 24.04 so we get the latest qemu as well as how we
-    # build llvm. Otherwise we choose windows or ubuntu-22.04 depending on the
-    # target.
-    runs-on: ${{ (contains(matrix.target, 'host_riscv') && 'ubuntu-24.04') || (contains(matrix.target, 'windows') && 'windows-2019' || 'ubuntu-22.04' ) }}
-    if : inputs.ock
+    # build llvm. Otherwise we choose ubuntu-22.04 (use a container for both for consistency).
+    runs-on: cp-ubuntu-24.04
+    container:
+      image: ${{ contains(matrix.target, 'host_riscv') && 'ghcr.io/intel/llvm/ubuntu2404_base:latest' || 'ghcr.io/intel/llvm/ubuntu2204_base:latest' }}
+      volumes:
+        - ${{github.workspace}}:${{github.workspace}}
+    if : inputs.ock && contains(inputs.target_list, 'linux')
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
@@ -97,7 +120,7 @@ jobs:
   # Currently only builds and runs on x86_64 linux
   build_run_tornado:
     if: inputs.test_tornado
-    needs: [ workflow_vars, build_icd, create_ock_artefacts ]
+    needs: [ workflow_vars, build_icd, create_ock_artefacts_ubuntu ]
     strategy:
       matrix:
         target: ${{ fromJson(inputs.target_list) }}
@@ -125,14 +148,18 @@ jobs:
   # Currently only builds and runs (default: quick) on x86_64 linux
   build_run_opencl_cts:
     if: inputs.test_opencl_cts
-    needs: [ workflow_vars, build_icd, create_ock_artefacts ]
+    needs: [ workflow_vars, build_icd, create_ock_artefacts_ubuntu ]
     strategy:
       matrix:
         target: ${{ fromJson(inputs.target_list) }}
         exclude: ${{ fromJson(needs.workflow_vars.outputs.matrix_only_linux_x86_64) }}
 
     # TODO: host-x86_64-linux only - expand for other targets
-    runs-on: ubuntu-22.04
+    runs-on: cp-ubuntu-24.04
+    container:
+      image: ${{ contains(matrix.target, 'host_riscv') && 'ghcr.io/intel/llvm/ubuntu2404_base:latest' || 'ghcr.io/intel/llvm/ubuntu2204_base:latest' }}
+      volumes:
+        - ${{github.workspace}}:${{github.workspace}}
     steps:
       - name: clone ock
         uses: actions/checkout@v4
@@ -160,7 +187,13 @@ jobs:
         target: ${{ fromJson(inputs.target_list) }}
         exclude: ${{ fromJson(needs.workflow_vars.outputs.matrix_only_linux_x86_64) }}
 
-    runs-on: ${{ contains(matrix.target, 'windows') && 'windows-2019' || 'ubuntu-22.04'  }}
+    # TODO: Extend if we decide to enable for windows or build natively on another target
+    runs-on: cp-ubuntu-24.04
+    container:
+      image: ghcr.io/intel/llvm/ubuntu2204_base:latest
+      volumes:
+        - ${{github.workspace}}:${{github.workspace}}
+
     if : inputs.test_sycl_cts
     steps:
       - name: Checkout repo
@@ -178,7 +211,13 @@ jobs:
         # TODO: For now just linux x86_64
         exclude: ${{ fromJson(needs.workflow_vars.outputs.matrix_only_linux_x86_64) }}
 
-    runs-on: 'ubuntu-22.04'
+    # TODO: Extend if we decide to enable for windows or build natively on another target
+    runs-on: cp-ubuntu-24.04
+    container:
+      image: ghcr.io/intel/llvm/ubuntu2204_base:latest
+      volumes:
+        - ${{github.workspace}}:${{github.workspace}}
+
     if : inputs.test_sycl_cts
     steps:
       - name: Checkout repo
@@ -189,7 +228,7 @@ jobs:
           target: ${{ matrix.target }}
 
   run_sycl_cts:
-    needs: [workflow_vars, create_ock_artefacts, build_dpcpp_native_host, build_sycl_cts]
+    needs: [workflow_vars, create_ock_artefacts_ubuntu, build_dpcpp_native_host, build_sycl_cts]
     strategy:
       matrix:
         target: ${{ fromJson(inputs.target_list) }}

--- a/.github/workflows/planned_testing_caller.yml
+++ b/.github/workflows/planned_testing_caller.yml
@@ -12,6 +12,10 @@ on:
     # Run Mon-Fri at 7pm
     - cron: '00 19 * * 1-5'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   call_planned:
     # This makes the diagram too big if we post much here so S_ for scheduled.


### PR DESCRIPTION
# Overview

Switch over planned testing to use cp-ubuntu-24.04 for ock/OpenCL

# Reason for change

Speed up overnight builds

# Description of change

Switched ock artefact creation and OpenCL build/run to use cp-ubuntu-24.04 (with docker).
