### PR TITLE
fix riscv64/aarch64 mismatch

### DIFF
--- a/.github/workflows/create_llvm.yml
+++ b/.github/workflows/create_llvm.yml
@@ -64,7 +64,7 @@ jobs:
             arch: aarch64
           - arch_flags: -DCMAKE_TOOLCHAIN_FILE="$GITHUB_WORKSPACE/ock/platform/riscv64-linux/riscv64-gcc-toolchain.cmake"
                         -DLLVM_HOST_TRIPLE=riscv64-unknown-linux-gnu
-            arch: aarch64
+            arch: riscv64
           - arch_flags: -DLLVM_BUILD_32_BITS=ON -DLIBXML2_LIBRARIES=IGNORE -DLLVM_ENABLE_TERMINFO=OFF
                         -DLLVM_HOST_TRIPLE=i686-unknown-linux-gnu
             arch: x86


### PR DESCRIPTION
# Overview

fix llvm cache riscv64/aarch64 mismatch

# Reason for change

cut'n'paste issue unearthed by aarch64 rebuild

# Description of change

use riscv64
