### PR TITLE
Roll-back inclusion of llvm cache riscv

### DIFF
--- a/.github/workflows/create_llvm.yml
+++ b/.github/workflows/create_llvm.yml
@@ -23,17 +23,13 @@ jobs:
         version: [18, 19]
         os: [ubuntu-22.04, windows-2019]
         build_type: [Release, RelAssert]
-        arch : [x86, x86_64, aarch64, riscv64]
+        arch : [x86, x86_64, aarch64]
         exclude:
-          # Reduce the versions of llvm for aarch64, riscv64 & x86 architectures and windows, as
+          # Reduce the versions of llvm for aarch64 & x86 architectures and windows, as
           # well as any windows os variants to reduce cache usage.
           - arch: aarch64
             version: 18
           - arch: aarch64
-            build_type: Release
-          - arch: riscv64
-            version: 18
-          - arch: riscv64
             build_type: Release
           - arch: x86
             version: 18
@@ -45,8 +41,6 @@ jobs:
             build_type: Release
           - os: windows-2019
             arch: aarch64
-          - os: windows-2019
-            arch: riscv64
           - os: windows-2019
             arch: x86
         include:
@@ -62,9 +56,6 @@ jobs:
           - arch_flags: -DCMAKE_TOOLCHAIN_FILE="$GITHUB_WORKSPACE/ock/platform/arm-linux/aarch64-toolchain.cmake"
                         -DLLVM_HOST_TRIPLE=aarch64-unknown-linux-gnu
             arch: aarch64
-          - arch_flags: -DCMAKE_TOOLCHAIN_FILE="$GITHUB_WORKSPACE/ock/platform/riscv64-linux/riscv64-gcc-toolchain.cmake"
-                        -DLLVM_HOST_TRIPLE=riscv64-unknown-linux-gnu
-            arch: riscv64
           - arch_flags: -DLLVM_BUILD_32_BITS=ON -DLIBXML2_LIBRARIES=IGNORE -DLLVM_ENABLE_TERMINFO=OFF
                         -DLLVM_HOST_TRIPLE=i686-unknown-linux-gnu
             arch: x86
@@ -114,11 +105,6 @@ jobs:
         if: ${{ steps.cache.outputs.cache-hit != 'true' && matrix.arch == 'aarch64' }}
         run:
           sudo apt-get install --yes g++-aarch64-linux-gnu
-
-      - name: install riscv64 build tools
-        if: ${{ steps.cache.outputs.cache-hit != 'true' && matrix.arch == 'riscv64' }}
-        run:
-          sudo apt-get install --yes g++-riscv64-linux-gnu
 
       - name: install x86 build tools
         if: ${{ steps.cache.outputs.cache-hit != 'true' && matrix.arch == 'x86' }}


### PR DESCRIPTION
# Overview

Roll-back inclusion of llvm cache riscv64

# Reason for change

Issues associated with riscv64 llvm cache build need fuller consideration prior to inclusion.

# Description of change

Exclude riscv64

# Anything else we should know?

Note: removal of `g++-11-aarch64-linux-gnu` version number has been retained. (this was unintentionally omitted when other similar version numbers were removed)