### PR TITLE
Fix sycl cts building on self-hosted runner

### DIFF
--- a/.github/actions/do_build_sycl_cts/action.yml
+++ b/.github/actions/do_build_sycl_cts/action.yml
@@ -49,22 +49,6 @@ runs:
         path: SYCL-CTS.src
         submodules: true
 
-    - name: expand runner swap
-      # Needed to allow building - else current default memory restrictions lead to the runner being killed
-      shell: bash
-      run: |
-        set -x
-        df -h
-        sudo swapon --show
-        sudo swapoff -a
-        sudo fallocate -l 8G /mnt/swapfilenew
-        sudo chmod 600 /mnt/swapfilenew
-        sudo mkswap /mnt/swapfilenew
-        sudo swapon /mnt/swapfilenew
-        sudo swapon --show
-        df -h
-        set +x
-
     - name: build SYCL CTS
       shell: bash
       run: |


### PR DESCRIPTION
# Overview

Fix sycl cts building on self-hosted runner

# Reason for change

The runner was failing to run as it could not run swapoff which is not needed on the self-hosted runner.

# Description of change

Deleted section which did the swapoff in ci.