### PR TITLE
Update to use dockers built for OCK

### DIFF
--- a/.github/actions/do_build_ock/action.yml
+++ b/.github/actions/do_build_ock/action.yml
@@ -100,7 +100,7 @@ inputs:
     default: OFF
   gtest_launcher:
     description: "Googletest suite launcher command (default launcher used for ubuntu)"
-    default: "/usr/bin/python;-u;${{ github.workspace }}/scripts/gtest-terse-runner.py"
+    default: "/usr/bin/python3;-u;${{ github.workspace }}/scripts/gtest-terse-runner.py"
   build_32_bit:
     description: "32-bit building"
     default: OFF

--- a/.github/actions/setup_build/action.yml
+++ b/.github/actions/setup_build/action.yml
@@ -43,7 +43,7 @@ runs:
         echo "PATH=$PATH:$HOME/.local/bin" >> $GITHUB_ENV
         # required due to using non docker to build llvm
         # If we switch to always using docker we can drop.
-        sudo apt-get install --yes lib32ncurses-dev    
+        sudo apt-get install --yes lib32ncurses-dev
         if [ "${{ inputs.cross_arch }}" = "x86" ]; then sudo dpkg --add-architecture i386 ; fi
         wget -qO - https://packages.lunarg.com/lunarg-signing-key-pub.asc | sudo apt-key add -
         if [ "${{ inputs.ubuntu_version }}" = "20.04" ]; then sudo wget -qO /etc/apt/sources.list.d/lunarg-vulkan-1.3.243-focal.list https://packages.lunarg.com/vulkan/1.3.243/lunarg-vulkan-1.3.243-focal.list; fi

--- a/.github/workflows/planned_testing.yml
+++ b/.github/workflows/planned_testing.yml
@@ -31,6 +31,9 @@ on:
         type: boolean
         default: false
 
+permissions:
+  packages: read
+
 jobs:
 
   # Calculate some useful variables that can be used through the workflow
@@ -82,7 +85,7 @@ jobs:
     # build llvm. Otherwise we choose ubuntu-22.04 (use a container for both for consistency).
     runs-on: cp-ubuntu-24.04
     container:
-      image: ${{ contains(matrix.target, 'host_riscv') && 'ghcr.io/intel/llvm/ubuntu2404_base:latest' || 'ghcr.io/intel/llvm/ubuntu2204_base:latest' }}
+      image: ${{ contains(matrix.target, 'host_riscv') && 'ghcr.io/uxlfoundation/ock_ubuntu_24.04:latest' || 'ghcr.io/uxlfoundation/ock_ubuntu_24.04:latest' }}
       volumes:
         - ${{github.workspace}}:${{github.workspace}}
     if : inputs.ock && contains(inputs.target_list, 'linux')
@@ -159,7 +162,7 @@ jobs:
     # TODO: host-x86_64-linux only - expand for other targets
     runs-on: cp-ubuntu-24.04
     container:
-      image: ${{ contains(matrix.target, 'host_riscv') && 'ghcr.io/intel/llvm/ubuntu2404_base:latest' || 'ghcr.io/intel/llvm/ubuntu2204_base:latest' }}
+      image: ${{ contains(matrix.target, 'host_riscv') && 'ghcr.io/uxlfoundation/ock_ubuntu_24.04:latest' || 'ghcr.io/uxlfoundation/ock_ubuntu_22.04:latest' }}
       volumes:
         - ${{github.workspace}}:${{github.workspace}}
     steps:
@@ -194,7 +197,7 @@ jobs:
     # TODO: Extend if we decide to enable for windows or build natively on another target
     runs-on: cp-ubuntu-24.04
     container:
-      image: ghcr.io/intel/llvm/ubuntu2204_base:latest
+      image: 'ghcr.io/uxlfoundation/ock_ubuntu_22.04:latest'
       volumes:
         - ${{github.workspace}}:${{github.workspace}}
 
@@ -218,7 +221,7 @@ jobs:
     # TODO: Extend if we decide to enable for windows or build natively on another target
     runs-on: cp-ubuntu-24.04
     container:
-      image: ghcr.io/intel/llvm/ubuntu2204_base:latest
+      image: 'ghcr.io/uxlfoundation/ock_ubuntu_22.04:latest'
       volumes:
         - ${{github.workspace}}:${{github.workspace}}
 

--- a/.github/workflows/run_pr_tests.yml
+++ b/.github/workflows/run_pr_tests.yml
@@ -23,14 +23,19 @@ on:
         required: false
         type: bool
         default: true
-permissions: {}
+
+permissions:
+  packages: read
 
 jobs:
 
   # build and run host x86_64, execute UnitCL and lit tests and build and run offline
   run_host_x86_64:
     runs-on: ubuntu-22.04
-
+    container:
+      image: ghcr.io/uxlfoundation/ock_ubuntu_22.04:latest
+      volumes:
+        - ${{github.workspace}}:${{github.workspace}}    
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4.1.0
@@ -75,7 +80,10 @@ jobs:
   run_riscv_m1:
 
     runs-on: ubuntu-22.04
-
+    container:
+      image: ghcr.io/uxlfoundation/ock_ubuntu_22.04:latest
+      volumes:
+        - ${{github.workspace}}:${{github.workspace}}    
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4.1.0
@@ -103,7 +111,12 @@ jobs:
   run_clang_tidy_changes:
 
     runs-on: ubuntu-22.04
-
+    # Disable until the awk line works on the container
+    if: false
+    container:
+      image: ghcr.io/uxlfoundation/ock_ubuntu_22.04:latest
+      volumes:
+        - ${{github.workspace}}:${{github.workspace}}    
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4.1.0
@@ -232,6 +245,10 @@ jobs:
   # Based on: mr-ubuntu-gcc-x86_64-riscv-fp16-cl3.0-unitcl_vecz
   run_ubuntu_gcc_x86_64_riscv_fp16_cl3_0_unitcl_vecz:
     runs-on: ubuntu-22.04
+    container:
+      image: ghcr.io/uxlfoundation/ock_ubuntu_22.04:latest
+      volumes:
+        - ${{github.workspace}}:${{github.workspace}}
     timeout-minutes: 60
     steps:
     - name: Checkout repo
@@ -261,6 +278,10 @@ jobs:
   # Based on: mr-ubuntu-clang-x86-llvm-previous-cl3-0-offline
   run-ubuntu-clang-x86-llvm-latest-cl3-0-offline:
     runs-on: ubuntu-22.04
+    container:
+      image: ghcr.io/uxlfoundation/ock_ubuntu_22.04:latest
+      volumes:
+        - ${{github.workspace}}:${{github.workspace}}    
     timeout-minutes: 90 # offline needs longer timeout
     steps:
     - name: Checkout repo
@@ -300,6 +321,10 @@ jobs:
   # Based on: mr-ubuntu-gcc-x86_64-riscv-fp16-cl3-0
   run-ubuntu-gcc-x86_64-riscv-fp16-cl3-0:
     runs-on: ubuntu-22.04
+    container:
+      image: ghcr.io/uxlfoundation/ock_ubuntu_22.04:latest
+      volumes:
+        - ${{github.workspace}}:${{github.workspace}}    
     timeout-minutes: 60
     steps:
     - name: Checkout repo
@@ -331,6 +356,10 @@ jobs:
   # Based on: mr-ubuntu-gcc-x86-llvm-latest-x86_64-images-cl3-0-release
   run-ubuntu-gcc-x86-llvm-latest-x86_64-images-cl3-0-release:
     runs-on: ubuntu-22.04
+    container:
+      image: ghcr.io/uxlfoundation/ock_ubuntu_22.04:latest
+      volumes:
+        - ${{github.workspace}}:${{github.workspace}}    
     timeout-minutes: 60
     steps:
     - name: Checkout repo
@@ -356,7 +385,7 @@ jobs:
   run-ubuntu-gcc-aarch64-llvm-latest-cl3-0-fp16:
     runs-on: cp-ubuntu-24.04
     container:
-      image: ghcr.io/intel/llvm/ubuntu2204_base:latest
+      image: ghcr.io/uxlfoundation/ock_ubuntu_22.04:latest
       volumes:
         - ${{github.workspace}}:${{github.workspace}}
     timeout-minutes: 90 # aarch64 needs longer timeout
@@ -387,12 +416,19 @@ jobs:
   #                       and: mr-ubuntu-gcc-x86_64-clik-refsi
   run-ubuntu-gcc-x86_64-clik-refsi:
     runs-on: ubuntu-22.04
+    container:
+      image: ghcr.io/uxlfoundation/ock_ubuntu_22.04:latest
+      volumes:
+        - ${{github.workspace}}:${{github.workspace}}    
     timeout-minutes: 60
     steps:
     - name: Checkout repo
       uses: actions/checkout@v4.1.0
     - name: Install Ninja
       uses: llvm/actions/install-ninja@main
+    - name: install risc-v toolchain
+      run:
+        sudo apt-get install --yes gcc-riscv64-linux-gnu g++-riscv64-linux-gnu
     - run: echo WORKSPACE is $GITHUB_WORKSPACE && echo PWD is `pwd` && ls -al
     - name: Run Clik
       run: |
@@ -407,6 +443,10 @@ jobs:
   run-ubuntu-gcc-x86_64-refsi-g1-wi-cl3-0:
     if: ${{ !inputs.is_pull_request }}  # do not run as PR job for now to avoid flooding the concurrency
     runs-on: ubuntu-22.04
+    container:
+      image: ghcr.io/uxlfoundation/ock_ubuntu_22.04:latest
+      volumes:
+        - ${{github.workspace}}:${{github.workspace}}    
     timeout-minutes: 60
     steps:
     - name: Checkout repo


### PR DESCRIPTION
# Overview

Update to use dockers built for OCK
# Reason for change

Using different runners is causing issues with not always using the same dockers. This also allows us to move more setup into the dockers.

# Description of change

Added container:/image: to most jobs

# Anything else we should know?

Note  run_clang_tidy_changes is currently disabled until we can resolve the errors brought up
