### PR TITLE
[compiler] Avoid out of bounds access.

### DIFF
--- a/modules/compiler/compiler_pipeline/source/work_item_loops_pass.cpp
+++ b/modules/compiler/compiler_pipeline/source/work_item_loops_pass.cpp
@@ -1024,7 +1024,9 @@ struct ScheduleGenerator {
                       mainPreheaderBB = nullptr;
                       mainExitBB = block;
                       nextSubgroupIV = ivs1[0];
-                      nextScanIV = ivs1[1];
+                      if (isScan) {
+                        nextScanIV = ivs1[1];
+                      }
                     }
                   } else {
                     mainPreheaderBB = BasicBlock::Create(


### PR DESCRIPTION
# Overview

[compiler] Avoid out of bounds access.

# Reason for change

If !isScan, ivs1 is not guaranteed to hold at least two items and we could fail trying to retrieve ivs1[1] even if the result would be unused.

# Description of change

*Describe the intended behaviour your changes are meant to introduce to the
project and explain how they resolve the problem stated above. Detail any
relevant changes that may affect other users of the project, such as
compilation options, runtime flags, expected inputs and outputs, API entry
points, etc.*

*If you have added new testing, provide details on what tests you have added
and what the purpose of them is.*

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-19](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
