### PR TITLE
Update dockerfiles with baseline content

### DIFF
--- a/.github/dockerfiles/Dockerfile_22.04
+++ b/.github/dockerfiles/Dockerfile_22.04
@@ -5,6 +5,9 @@ RUN apt-get update
 # FROM INFRA UBUNTU BASE
 
 RUN apt-get install -y git git-crypt wget curl jq xz-utils build-essential zlib1g-dev lsb-release libssl-dev
+# Set the timezone, required to avoid hanging on input
+ENV TZ=Europe/London
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
 # FROM 22 OCK BASE - if not already added
 

--- a/.github/dockerfiles/Dockerfile_22.04
+++ b/.github/dockerfiles/Dockerfile_22.04
@@ -6,6 +6,18 @@ RUN apt-get update
 
 RUN apt-get install -y git git-crypt wget curl jq xz-utils build-essential zlib1g-dev lsb-release libssl-dev
 
+# Install recent version of ccache in /usr
+# Redis support requires ccache 4.4 or newer.
+RUN git clone https://github.com/ccache/ccache.git && \
+  cd ccache && \
+  LATEST_TAG=$(git describe --tags `git rev-list --tags --max-count=1`); \
+  git -c advice.detachedHead=false checkout ${LATEST_TAG} && \
+  /usr/local/bin/cmake -Bbuild -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=Release \
+    -DZSTD_FROM_INTERNET=ON -DHIREDIS_FROM_INTERNET=ON \
+    -DCMAKE_C_COMPILER=gcc-9 -DCMAKE_CXX_COMPILER=g++-9 -DENABLE_TESTING=OFF && \
+  /usr/local/bin/cmake --build build --target install && \
+  cd - && rm -rf ccache
+
 # FROM 22 OCK BASE - if not already added
 
 # Enable ability to install foreign packages for cross compilation
@@ -45,8 +57,7 @@ RUN apt-get install --yes qemu-user
 # Install pkg-config for dpc++ builds and locally built spir-v
 RUN apt-get install --yes pkg-config
 
-# Enforce use of python3
-RUN apt-get install --yes python-is-python3
+# Set-up pip
 RUN update-alternatives --install /usr/bin/pip pip `which pip3` 30
 
 # Install python packages
@@ -54,8 +65,7 @@ RUN pip install cmakelint colorama flake8 lit pylint requests virtualenv yapf py
 
 # FROM OUR CURRENT INSTALLS PLUS ANY NEW EXTRAS - if not already added
 
-RUN apt-get -y install sudo
-RUN sudo apt install -y zstd
-RUN sudo apt install -y gnupg
-RUN sudo apt install -y gcc g++
-RUN sudo apt install -y file
+RUN apt install -y zstd
+RUN apt install -y gnupg
+RUN apt install -y gcc g++
+RUN apt install -y file

--- a/.github/dockerfiles/Dockerfile_22.04
+++ b/.github/dockerfiles/Dockerfile_22.04
@@ -21,9 +21,9 @@ RUN git clone https://github.com/ccache/ccache.git && \
 # FROM 22 OCK BASE - if not already added
 
 # Enable ability to install foreign packages for cross compilation
-dpkg --add-architecture i386
-dpkg --add-architecture arm64
-dpkg --add-architecture riscv64
+RUN dpkg --add-architecture i386
+RUN dpkg --add-architecture arm64
+RUN dpkg --add-architecture riscv64
 
 # The main archive only hosts amd64 and i386, we need to add ports for arm64 and riscv64.
 RUN sed -i -e '/^deb /{h;s|deb |&[arch=amd64,i386] |p;g;s|deb http://[^ ]*|deb [arch=arm64,riscv64] http://ports.ubuntu.com/ubuntu-ports|p;d}' /etc/apt/sources.list

--- a/.github/dockerfiles/Dockerfile_22.04
+++ b/.github/dockerfiles/Dockerfile_22.04
@@ -6,18 +6,6 @@ RUN apt-get update
 
 RUN apt-get install -y git git-crypt wget curl jq xz-utils build-essential zlib1g-dev lsb-release libssl-dev
 
-# Install recent version of ccache in /usr
-# Redis support requires ccache 4.4 or newer.
-RUN git clone https://github.com/ccache/ccache.git && \
-  cd ccache && \
-  LATEST_TAG=$(git describe --tags `git rev-list --tags --max-count=1`); \
-  git -c advice.detachedHead=false checkout ${LATEST_TAG} && \
-  /usr/local/bin/cmake -Bbuild -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=Release \
-    -DZSTD_FROM_INTERNET=ON -DHIREDIS_FROM_INTERNET=ON \
-    -DCMAKE_C_COMPILER=gcc-9 -DCMAKE_CXX_COMPILER=g++-9 -DENABLE_TESTING=OFF && \
-  /usr/local/bin/cmake --build build --target install && \
-  cd - && rm -rf ccache
-
 # FROM 22 OCK BASE - if not already added
 
 # Enable ability to install foreign packages for cross compilation
@@ -69,3 +57,21 @@ RUN apt install -y zstd
 RUN apt install -y gnupg
 RUN apt install -y gcc g++
 RUN apt install -y file
+
+# DO THIS LAST
+
+# Install recent version of ccache in /usr
+# Redis support requires ccache 4.4 or newer.
+RUN git clone https://github.com/ccache/ccache.git && \
+  cd ccache && \
+  LATEST_TAG=$(git describe --tags `git rev-list --tags --max-count=1`); \
+  git -c advice.detachedHead=false checkout ${LATEST_TAG} && \
+  #/usr/local/bin/cmake -Bbuild -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=Release \
+  #  -DZSTD_FROM_INTERNET=ON -DHIREDIS_FROM_INTERNET=ON \
+  #  -DCMAKE_C_COMPILER=gcc-9 -DCMAKE_CXX_COMPILER=g++-9 -DENABLE_TESTING=OFF && \
+  #/usr/local/bin/cmake --build build --target install && \
+  cmake -Bbuild -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=Release \
+    -DZSTD_FROM_INTERNET=ON -DHIREDIS_FROM_INTERNET=ON \
+    -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -DENABLE_TESTING=OFF && \
+  cmake --build build --target install && \
+  cd - && rm -rf ccache

--- a/.github/dockerfiles/Dockerfile_22.04
+++ b/.github/dockerfiles/Dockerfile_22.04
@@ -53,6 +53,7 @@ RUN update-alternatives --install /usr/bin/pip pip `which pip3` 30
 RUN pip install cmakelint colorama flake8 lit pylint requests virtualenv yapf python-gitlab distro clang-format==19.1.0
 
 # FROM OUR CURRENT INSTALLS PLUS ANY NEW EXTRAS - if not already added
+
 RUN apt-get -y install sudo
 RUN sudo apt install -y zstd
 RUN sudo apt install -y gnupg

--- a/.github/dockerfiles/Dockerfile_22.04
+++ b/.github/dockerfiles/Dockerfile_22.04
@@ -1,9 +1,60 @@
 FROM ubuntu:22.04
 
 RUN apt-get update 
+
+# FROM INFRA UBUNTU BASE
+
+RUN apt-get install -y git git-crypt wget curl jq xz-utils build-essential zlib1g-dev lsb-release libssl-dev
+
+# FROM 22 OCK BASE - if not already added
+
+# Enable ability to install foreign packages for cross compilation
+dpkg --add-architecture i386
+dpkg --add-architecture arm64
+dpkg --add-architecture riscv64
+
+# The main archive only hosts amd64 and i386, we need to add ports for arm64 and riscv64.
+RUN sed -i -e '/^deb /{h;s|deb |&[arch=amd64,i386] |p;g;s|deb http://[^ ]*|deb [arch=arm64,riscv64] http://ports.ubuntu.com/ubuntu-ports|p;d}' /etc/apt/sources.list
+
+# Add VulkanSDK latest package repository
+RUN wget -qO - https://packages.lunarg.com/lunarg-signing-key-pub.asc | apt-key add -
+RUN wget -qO /etc/apt/sources.list.d/lunarg-vulkan-1.3.243-jammy.list https://packages.lunarg.com/vulkan/1.3.243/lunarg-vulkan-1.3.243-jammy.list
+# Sync the two above package repositories
+RUN apt-get update
+
+# Install minimum requirements
+RUN apt-get install --yes cmake libtinfo-dev
+# Install vulkan-sdk
+RUN apt-get install --yes vulkan-sdk
+# Install 32-bit requirements
+RUN apt-get install --yes gcc-multilib g++-multilib libc6-dev:i386 lib32tinfo-dev
+# Install Arm requirements
+RUN apt-get install --yes gcc-arm-linux-gnueabihf g++-arm-linux-gnueabihf
+# Install AArch64 requirements
+RUN apt-get install --yes gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
+# Install RISC-V requirements
+RUN apt-get install --yes gcc-riscv64-linux-gnu g++-riscv64-linux-gnu
+# Install recommended packages
+RUN apt-get install --yes python3 python3-pip ninja-build doxygen
+# Install documentation packages
+RUN apt-get install --yes graphviz latexmk texlive-xetex xindy texlive-fonts-extra
+# Install CI utility packages
+RUN apt-get install --yes parallel
+# Install QEMU for testing cross compilation.
+RUN apt-get install --yes qemu-user
+# Install pkg-config for dpc++ builds and locally built spir-v
+RUN apt-get install --yes pkg-config
+
+# Enforce use of python3
+RUN apt-get install --yes python-is-python3
+RUN update-alternatives --install /usr/bin/pip pip `which pip3` 30
+
+# Install python packages
+RUN pip install cmakelint colorama flake8 lit pylint requests virtualenv yapf python-gitlab distro clang-format==19.1.0
+
+# FROM OUR CURRENT INSTALLS PLUS ANY NEW EXTRAS - if not already added
 RUN apt-get -y install sudo
 RUN sudo apt install -y zstd
 RUN sudo apt install -y gnupg
-RUN sudo apt install -y wget gcc g++ cmake ninja-build python3 git curl
-RUN sudo apt install -y python3-pip cmake
+RUN sudo apt install -y gcc g++
 RUN sudo apt install -y file

--- a/.github/dockerfiles/Dockerfile_24.04
+++ b/.github/dockerfiles/Dockerfile_24.04
@@ -6,18 +6,6 @@ RUN apt-get update
 
 RUN apt-get install -y git git-crypt wget curl jq xz-utils build-essential zlib1g-dev lsb-release libssl-dev
 
-# Install recent version of ccache in /usr
-# Redis support requires ccache 4.4 or newer.
-RUN git clone https://github.com/ccache/ccache.git && \
-  cd ccache && \
-  LATEST_TAG=$(git describe --tags `git rev-list --tags --max-count=1`); \
-  git -c advice.detachedHead=false checkout ${LATEST_TAG} && \
-  /usr/local/bin/cmake -Bbuild -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=Release \
-    -DZSTD_FROM_INTERNET=ON -DHIREDIS_FROM_INTERNET=ON \
-    -DCMAKE_C_COMPILER=gcc-9 -DCMAKE_CXX_COMPILER=g++-9 -DENABLE_TESTING=OFF && \
-  /usr/local/bin/cmake --build build --target install && \
-  cd - && rm -rf ccache
-
 # FROM 24 OCK BASE - if not already added
 
 # Enable ability to install foreign packages for cross compilation
@@ -69,3 +57,21 @@ RUN apt install -y zstd
 RUN apt install -y gnupg
 RUN apt install -y gcc g++
 RUN apt install -y file
+
+# DO THIS LAST
+
+# Install recent version of ccache in /usr
+# Redis support requires ccache 4.4 or newer.
+RUN git clone https://github.com/ccache/ccache.git && \
+  cd ccache && \
+  LATEST_TAG=$(git describe --tags `git rev-list --tags --max-count=1`); \
+  git -c advice.detachedHead=false checkout ${LATEST_TAG} && \
+  #/usr/local/bin/cmake -Bbuild -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=Release \
+  #  -DZSTD_FROM_INTERNET=ON -DHIREDIS_FROM_INTERNET=ON \
+  #  -DCMAKE_C_COMPILER=gcc-9 -DCMAKE_CXX_COMPILER=g++-9 -DENABLE_TESTING=OFF && \
+  #/usr/local/bin/cmake --build build --target install && \
+  cmake -Bbuild -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=Release \
+    -DZSTD_FROM_INTERNET=ON -DHIREDIS_FROM_INTERNET=ON \
+    -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -DENABLE_TESTING=OFF && \
+  cmake --build build --target install && \
+  cd - && rm -rf ccache

--- a/.github/dockerfiles/Dockerfile_24.04
+++ b/.github/dockerfiles/Dockerfile_24.04
@@ -6,6 +6,18 @@ RUN apt-get update
 
 RUN apt-get install -y git git-crypt wget curl jq xz-utils build-essential zlib1g-dev lsb-release libssl-dev
 
+# Install recent version of ccache in /usr
+# Redis support requires ccache 4.4 or newer.
+RUN git clone https://github.com/ccache/ccache.git && \
+  cd ccache && \
+  LATEST_TAG=$(git describe --tags `git rev-list --tags --max-count=1`); \
+  git -c advice.detachedHead=false checkout ${LATEST_TAG} && \
+  /usr/local/bin/cmake -Bbuild -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=Release \
+    -DZSTD_FROM_INTERNET=ON -DHIREDIS_FROM_INTERNET=ON \
+    -DCMAKE_C_COMPILER=gcc-9 -DCMAKE_CXX_COMPILER=g++-9 -DENABLE_TESTING=OFF && \
+  /usr/local/bin/cmake --build build --target install && \
+  cd - && rm -rf ccache
+
 # FROM 24 OCK BASE - if not already added
 
 # Enable ability to install foreign packages for cross compilation
@@ -44,8 +56,7 @@ RUN apt-get install --yes qemu-user
 # Install pkgconf for dpc++ builds and locally built spir-v
 RUN apt-get install --yes pkgconf:amd64 pkgconf:arm64 pkgconf:i386 pkgconf:riscv64
 
-# Enforce use of python3
-RUN apt-get install --yes python-is-python3
+# Set-up pip
 RUN update-alternatives --install /usr/bin/pip pip `which pip3` 30
 
 # Install python packages
@@ -53,8 +64,8 @@ RUN apt-get install --yes python3-colorama python3-distro python3-flake8 python3
 RUN PIPX_HOME=/usr/local/share/pipx PIPX_BIN_DIR=/usr/local/bin PIPX_MAN_DIR=/usr/local/share/man pipx install cmakelint lit pylint clang-format==19.1.0
 
 # FROM OUR CURRENT INSTALLS PLUS ANY NEW EXTRAS - if not already added
-RUN apt-get -y install sudo
-RUN sudo apt install -y zstd
-RUN sudo apt install -y gnupg
-RUN sudo apt install -y gcc g++
-RUN sudo apt install -y file
+
+RUN apt install -y zstd
+RUN apt install -y gnupg
+RUN apt install -y gcc g++
+RUN apt install -y file

--- a/.github/dockerfiles/Dockerfile_24.04
+++ b/.github/dockerfiles/Dockerfile_24.04
@@ -1,6 +1,13 @@
 FROM ubuntu:24.04
 
 RUN apt-get update 
+
+# from infra ubuntu base
+RUN apt-get install -y git git-crypt wget curl jq xz-utils build-essential zlib1g-dev lsb-release libssl-dev
+
+# from 24 ock base
+
+# from our current installs plus any new extras
 RUN apt-get -y install sudo
 RUN sudo apt install -y zstd
 RUN sudo apt install -y gnupg

--- a/.github/dockerfiles/Dockerfile_24.04
+++ b/.github/dockerfiles/Dockerfile_24.04
@@ -17,7 +17,7 @@ RUN dpkg --add-architecture arm64
 RUN dpkg --add-architecture riscv64
 
 # The main archive only hosts amd64 and i386, we need to add ports for arm64 and riscv64.
-RUN then sed -i -e '/^Types:/,/^Signed-By:/{/Types:/{h;d};H;/^Signed-By:/{g;s|$|\nArchitectures: amd64,i386\n|p;g;s|URIs: [^\n]*|URIs: http://ports.ubuntu.com/ubuntu-ports|;s|$|\nArchitectures: arm64,riscv64|p;};d}' /etc/apt/sources.list.d/ubuntu.sources
+RUN sed -i -e '/^Types:/,/^Signed-By:/{/Types:/{h;d};H;/^Signed-By:/{g;s|$|\nArchitectures: amd64,i386\n|p;g;s|URIs: [^\n]*|URIs: http://ports.ubuntu.com/ubuntu-ports|;s|$|\nArchitectures: arm64,riscv64|p;};d}' /etc/apt/sources.list.d/ubuntu.sources
 
 # Add VulkanSDK latest package repository
 RUN wget -qO - https://packages.lunarg.com/lunarg-signing-key-pub.asc | apt-key add -; fi

--- a/.github/dockerfiles/Dockerfile_24.04
+++ b/.github/dockerfiles/Dockerfile_24.04
@@ -21,9 +21,9 @@ RUN git clone https://github.com/ccache/ccache.git && \
 # FROM 24 OCK BASE - if not already added
 
 # Enable ability to install foreign packages for cross compilation
-dpkg --add-architecture i386
-dpkg --add-architecture arm64
-dpkg --add-architecture riscv64
+RUN dpkg --add-architecture i386
+RUN dpkg --add-architecture arm64
+RUN dpkg --add-architecture riscv64
 
 # The main archive only hosts amd64 and i386, we need to add ports for arm64 and riscv64.
 RUN then sed -i -e '/^Types:/,/^Signed-By:/{/Types:/{h;d};H;/^Signed-By:/{g;s|$|\nArchitectures: amd64,i386\n|p;g;s|URIs: [^\n]*|URIs: http://ports.ubuntu.com/ubuntu-ports|;s|$|\nArchitectures: arm64,riscv64|p;};d}' /etc/apt/sources.list.d/ubuntu.sources

--- a/.github/dockerfiles/Dockerfile_24.04
+++ b/.github/dockerfiles/Dockerfile_24.04
@@ -20,7 +20,7 @@ RUN dpkg --add-architecture riscv64
 RUN sed -i -e '/^Types:/,/^Signed-By:/{/Types:/{h;d};H;/^Signed-By:/{g;s|$|\nArchitectures: amd64,i386\n|p;g;s|URIs: [^\n]*|URIs: http://ports.ubuntu.com/ubuntu-ports|;s|$|\nArchitectures: arm64,riscv64|p;};d}' /etc/apt/sources.list.d/ubuntu.sources
 
 # Add VulkanSDK latest package repository
-RUN wget -qO - https://packages.lunarg.com/lunarg-signing-key-pub.asc | apt-key add -; fi
+RUN wget -qO - https://packages.lunarg.com/lunarg-signing-key-pub.asc | apt-key add -
 RUN wget -qO /etc/apt/sources.list.d/lunarg-vulkan-noble.list https://packages.lunarg.com/vulkan/lunarg-vulkan-noble.list
 # Sync the two above package repositories
 RUN apt-get update

--- a/.github/dockerfiles/Dockerfile_24.04
+++ b/.github/dockerfiles/Dockerfile_24.04
@@ -5,6 +5,9 @@ RUN apt-get update
 # FROM INFRA UBUNTU BASE
 
 RUN apt-get install -y git git-crypt wget curl jq xz-utils build-essential zlib1g-dev lsb-release libssl-dev
+# Set the timezone, required to avoid hanging on input
+ENV TZ=Europe/London
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
 # FROM 24 OCK BASE - if not already added
 

--- a/.github/dockerfiles/Dockerfile_24.04
+++ b/.github/dockerfiles/Dockerfile_24.04
@@ -2,15 +2,59 @@ FROM ubuntu:24.04
 
 RUN apt-get update 
 
-# from infra ubuntu base
+# FROM INFRA UBUNTU BASE
+
 RUN apt-get install -y git git-crypt wget curl jq xz-utils build-essential zlib1g-dev lsb-release libssl-dev
 
-# from 24 ock base
+# FROM 24 OCK BASE - if not already added
 
-# from our current installs plus any new extras
+# Enable ability to install foreign packages for cross compilation
+dpkg --add-architecture i386
+dpkg --add-architecture arm64
+dpkg --add-architecture riscv64
+
+# The main archive only hosts amd64 and i386, we need to add ports for arm64 and riscv64.
+RUN then sed -i -e '/^Types:/,/^Signed-By:/{/Types:/{h;d};H;/^Signed-By:/{g;s|$|\nArchitectures: amd64,i386\n|p;g;s|URIs: [^\n]*|URIs: http://ports.ubuntu.com/ubuntu-ports|;s|$|\nArchitectures: arm64,riscv64|p;};d}' /etc/apt/sources.list.d/ubuntu.sources
+
+# Add VulkanSDK latest package repository
+RUN wget -qO - https://packages.lunarg.com/lunarg-signing-key-pub.asc | apt-key add -; fi
+RUN wget -qO /etc/apt/sources.list.d/lunarg-vulkan-noble.list https://packages.lunarg.com/vulkan/lunarg-vulkan-noble.list
+# Sync the two above package repositories
+RUN apt-get update
+
+# Install minimum requirements
+RUN apt-get install --yes cmake libtinfo-dev
+RUN apt-get install --yes vulkan-sdk
+# Install 32-bit requirements
+RUN apt-get install --yes gcc-multilib g++-multilib libc6-dev:i386 lib32ncurses-dev
+# Install Arm requirements
+RUN apt-get install --yes gcc-arm-linux-gnueabihf g++-arm-linux-gnueabihf
+# Install AArch64 requirements
+RUN apt-get install --yes gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
+# Install RISC-V requirements
+RUN apt-get install --yes gcc-riscv64-linux-gnu g++-riscv64-linux-gnu
+# Install recommended packages
+RUN apt-get install --yes python3 python3-pip ninja-build doxygen
+# Install documentation packages
+RUN apt-get install --yes graphviz latexmk texlive-xetex xindy texlive-fonts-extra
+# Install CI utility packages
+RUN apt-get install --yes parallel
+# Install QEMU for testing cross compilation.
+RUN apt-get install --yes qemu-user
+# Install pkgconf for dpc++ builds and locally built spir-v
+RUN apt-get install --yes pkgconf:amd64 pkgconf:arm64 pkgconf:i386 pkgconf:riscv64
+
+# Enforce use of python3
+RUN apt-get install --yes python-is-python3
+RUN update-alternatives --install /usr/bin/pip pip `which pip3` 30
+
+# Install python packages
+RUN apt-get install --yes python3-colorama python3-distro python3-flake8 python3-gitlab python3-requests python3-virtualenv python3-yapf pipx
+RUN PIPX_HOME=/usr/local/share/pipx PIPX_BIN_DIR=/usr/local/bin PIPX_MAN_DIR=/usr/local/share/man pipx install cmakelint lit pylint clang-format==19.1.0
+
+# FROM OUR CURRENT INSTALLS PLUS ANY NEW EXTRAS - if not already added
 RUN apt-get -y install sudo
 RUN sudo apt install -y zstd
 RUN sudo apt install -y gnupg
-RUN sudo apt install -y wget gcc g++ cmake ninja-build python3 git curl
-RUN sudo apt install -y python3-pip cmake
+RUN sudo apt install -y gcc g++
 RUN sudo apt install -y file

--- a/.github/workflows/publish_docker_images.yml
+++ b/.github/workflows/publish_docker_images.yml
@@ -31,7 +31,8 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
     - name: Build and push the Docker images
       run: |
-        for dockerfile in ${{ github.workspace }}/.github/dockerfiles/Dockerfile_* ; do
+        #for dockerfile in ${{ github.workspace }}/.github/dockerfiles/Dockerfile_* ; do
+        for dockerfile in ${{ github.workspace }}/.github/dockerfiles/Dockerfile_24.04 ; do
           VERSION=${dockerfile##*_}
           docker build . -f $dockerfile --tag $REGISTRY/ock_test_ubuntu_$VERSION:latest
           docker push $REGISTRY/ock_test_ubuntu_$VERSION:latest

--- a/.github/workflows/publish_docker_images.yml
+++ b/.github/workflows/publish_docker_images.yml
@@ -1,10 +1,9 @@
 name: publish docker images
 
 on:
-  #push:
-    #branches:
-    #- main
-  pull_request:
+  push:
+    branches:
+    - main
     paths:
     - '.github/workflows/publish_docker_images.yml'
     - '.github/dockerfiles/**'
@@ -31,8 +30,7 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
     - name: Build and push the Docker images
       run: |
-        #for dockerfile in ${{ github.workspace }}/.github/dockerfiles/Dockerfile_* ; do
-        for dockerfile in ${{ github.workspace }}/.github/dockerfiles/Dockerfile_24.04 ; do
+        for dockerfile in ${{ github.workspace }}/.github/dockerfiles/Dockerfile_* ; do
           VERSION=${dockerfile##*_}
           docker build . -f $dockerfile --tag $REGISTRY/ock_test_ubuntu_$VERSION:latest
           docker push $REGISTRY/ock_test_ubuntu_$VERSION:latest

--- a/.github/workflows/publish_docker_images.yml
+++ b/.github/workflows/publish_docker_images.yml
@@ -1,9 +1,10 @@
 name: publish docker images
 
 on:
-  push:
+  #push:
     #branches:
     #- main
+  pull_request:
     paths:
     - '.github/workflows/publish_docker_images.yml'
     - '.github/dockerfiles/**'

--- a/.github/workflows/publish_docker_images.yml
+++ b/.github/workflows/publish_docker_images.yml
@@ -2,8 +2,8 @@ name: publish docker images
 
 on:
   push:
-    branches:
-    - main
+    #branches:
+    #- main
     paths:
     - '.github/workflows/publish_docker_images.yml'
     - '.github/dockerfiles/**'
@@ -32,6 +32,6 @@ jobs:
       run: |
         for dockerfile in ${{ github.workspace }}/.github/dockerfiles/Dockerfile_* ; do
           VERSION=${dockerfile##*_}
-          docker build . -f $dockerfile --tag $REGISTRY/ock_ubuntu_$VERSION:latest
-          docker push $REGISTRY/ock_ubuntu_$VERSION:latest
+          docker build . -f $dockerfile --tag $REGISTRY/ock_test_ubuntu_$VERSION:latest
+          docker push $REGISTRY/ock_test_ubuntu_$VERSION:latest
         done


### PR DESCRIPTION
# Overview

Add more baseline content to the dockerfiles. Most of this comes from existing Gitlab dockers - a little from additional settings included in the Github scripts (A forthcoming PR will complete the migration from the scripts). New "test" images will be created.

# Reason for change

On-going migration to containers in Github.

# Description of change

Misc updates to both 22.04 and 24.04 dockerfiles and creation of corresponding "test" images.

# Anything else we should know?

Image filenames include the string `_test_` to distinguish the new images from existing "official" images. The intention is to make test images available for read/write from dev branches without standing on the toes of the official set. The official images will be updated with latest content in due course.

