### PR TITLE
Fix clang-tidy job

### DIFF
--- a/.github/workflows/run_pr_tests.yml
+++ b/.github/workflows/run_pr_tests.yml
@@ -111,8 +111,6 @@ jobs:
   run_clang_tidy_changes:
 
     runs-on: ubuntu-22.04
-    # Disable until the awk line works on the container
-    if: false
     container:
       image: ghcr.io/uxlfoundation/ock_ubuntu_22.04:latest
       volumes:
@@ -136,34 +134,16 @@ jobs:
           host_image: ON
           build_targets: build.ninja
 
-      # Here we compute the set difference between the output of the two
-      # temporary file descriptors using `awk`. Awk processes both files line by
-      # line, going through the first file, then the second file. The NR==FNR
-      # predicate executes its block only on the records of the first file,
-      # ensuring to call `next` (equivalent to `return`) to avoid running the
-      # second block on each line in the first file.
-      #
-      # The first input to `awk` lists all targets reported by ninja.
-      #
-      # The second input to awk collects all targets on which `tidy-` targets
-      # depend. This may include targets which are guarded by if() statements in
-      # CMake, hence why we need to compute a set difference with the targets that
-      # ninja reports.
+      # Assume all clang-tidy prerequisites are files ending in '.cpp' or '.h'.
       - name: build actual targets needed
         run:
-         ninja -C build
-          $(
-            awk -F':' 'NR==FNR { targets[$1] = 1; next } $1 in targets { print $1 }'
-              <(ninja -C build -t targets)
-              <(
-                find modules source -type f -name CMakeLists.txt -exec
-                awk -F"[()]" '/add_dependencies\(tidy-/ {sub(/[^ ]*/, "", $2);print $2}'
-                {} \+ | tr ' ' '\n'
-              )
-           )
-
+          ninja -C build $(ninja -C build -t targets all | sed -nE 's/(\.cpp|\.h):.*/\1/p')
+ 
       - name: run clang-tidy
         run: |
+          # TODO: Move to docker
+          sudo apt-get -y install parallel
+          git config --global --add safe.directory $PWD
           git fetch origin ${{ github.base_ref }}
           ./scripts/compute-dependants.py \
             --exclude-filter='(/build/.*\.s$)|(.*/(external|cookie)/.*)' \
@@ -173,6 +153,8 @@ jobs:
               grep -P '\.(c|cc|cxx|cpp|h|hh|hpp|hxx)$'` | \
             tee /dev/stderr | \
             parallel --verbose -- clang-tidy-19 --quiet -p "$PWD/build/" "{}"
+          # ^ When updating the clang-tidy version, the version used by the cmake
+          # target should match updated c.f. the `tidy` target
 
   # run clang-format-diff on the repo
   run_clang_format:


### PR DESCRIPTION

# Overview

Fix clang-tidy job

# Reason for change

This was both incorrect and did not work with the new dockers.

# Description of change

This replicates our original code in our previous internal CI.  We cannot reliably get dependencies of clang-tidy targets by grepping for add_dependencies. Luckily, we do not need to: we can simply look for all targets ending in '.cpp' or '.h' instead.
