### PR TITLE
[compiler] Do not mix kernels with different sub-group sizes.

### DIFF
--- a/modules/compiler/compiler_pipeline/source/pass_functions.cpp
+++ b/modules/compiler/compiler_pipeline/source/pass_functions.cpp
@@ -519,6 +519,9 @@ llvm::BasicBlock *createLoop(llvm::BasicBlock *entry, llvm::BasicBlock *exit,
 
   // Set up all of our user PHIs
   for (unsigned i = 0, e = currIVs.size(); i != e; i++) {
+    // For convenience to callers, permit nullptr and skip over it.
+    if (!currIVs[i]) continue;
+
     auto *const phi = loopIR.CreatePHI(currIVs[i]->getType(), 2);
     llvm::cast<llvm::PHINode>(phi)->addIncoming(currIVs[i],
                                                 entryIR.GetInsertBlock());
@@ -542,6 +545,7 @@ llvm::BasicBlock *createLoop(llvm::BasicBlock *entry, llvm::BasicBlock *exit,
 
   // Update all of our PHIs
   for (unsigned i = 0, e = currIVs.size(); i != e; i++) {
+    if (!currIVs[i]) continue;
     llvm::cast<llvm::PHINode>(currIVs[i])->addIncoming(nextIVs[i], latch);
   }
 

--- a/modules/compiler/test/lit/passes/barriers-cfg-reduce.ll
+++ b/modules/compiler/test/lit/passes/barriers-cfg-reduce.ll
@@ -33,11 +33,11 @@ target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:
 ; CHECK:  %[[LD:.+]] = load i32, ptr %[[VAL]], align 4
 ; CHECK:  %[[ACCUM_NEXT]] = add i32 %[[ACCUM]], %[[LD]]
 ; CHECK:  %[[IDX_NEXT]] = add i64 %[[IDX]], 1
-; CHECK:  %[[LOOP_COND:.+]] = icmp ult i64 %24, 262144
+; CHECK:  %[[LOOP_COND:.+]] = icmp ult i64 %[[IDX_NEXT]], 262144
 ; CHECK:  br i1 %[[LOOP_COND]], label %[[REDUCE_LOOP]], label %[[REDUCE_EXIT:[^,]+]]
 
 ; CHECK: [[REDUCE_EXIT]]:
-; CHECK:  %reduce = phi i32 [ %23, %[[REDUCE_LOOP]] ]
+; CHECK:  %reduce = phi i32 [ %[[ACCUM_NEXT]], %[[REDUCE_LOOP]] ]
 
 declare i64 @__mux_get_global_id(i32 %x)
 declare i32 @__mux_work_group_reduce_add_i32(i32 %id, i32 %x)

--- a/modules/compiler/test/lit/passes/subgroup-loop-unroll.ll
+++ b/modules/compiler/test/lit/passes/subgroup-loop-unroll.ll
@@ -65,18 +65,6 @@ attributes #4 = { alwaysinline norecurse nounwind  }
 !13 = !{i32 32, i32 0, i32 0, i32 0}
 !20 = !{!13, ptr @sub_group_all_builtin}
 
-; CHECK-LABEL: sw.bb2:
-; CHECK: br label %loopIR13
-
-; CHECK-LABEL: loopIR13:
-; CHECK: %[[PHI:.+]] = phi i64 [ 0, %sw.bb2 ], [ %[[INC:.+]], %loopIR13 ]
-; CHECK: %[[PHI_ACCUM:.+]] = phi i1 [ true, %sw.bb2 ], [ %[[ACCUM:.+]], %loopIR13 ]
-; CHECK: %[[BARRIER:.+]] = getelementptr inbounds %__vecz_v32_sub_group_all_builtin_live_mem_info, ptr %live_variables, i64 %[[PHI]]
-; CHECK: %[[ITEM:.+]] = getelementptr inbounds %__vecz_v32_sub_group_all_builtin_live_mem_info, ptr %[[BARRIER]], i32 0, i32 0
-; CHECK: %[[LD:.+]] = load i1, ptr %[[ITEM]], align 1
-; CHECK: %[[ACCUM]] = and i1 %[[PHI_ACCUM]], %[[LD]]
-; CHECK: %[[CMP:.+]] = icmp ult i64 %[[INC]], 2
-; CHECK: br i1 %[[CMP]], label %loopIR13, label %exitIR14
-
-; CHECK-LABEL: exitIR14:
-; CHECK: %WGC_reduce = phi i1 [ %[[ACCUM]], %loopIR13 ]
+; The vectorization factor does not divide the required workgroup size so we
+; must fall back to using the scalar kernel.
+; CHECK-NOT: call i32 @__vecz_v

--- a/modules/compiler/vecz/source/transform/control_flow_conversion_pass.cpp
+++ b/modules/compiler/vecz/source/transform/control_flow_conversion_pass.cpp
@@ -1302,9 +1302,10 @@ bool ControlFlowConversionState::Impl::tryApplyMaskToMemOp(
           Ctx, memOp.getDataOperand(), memOp.getPointerOperand(), wideMask,
           /*VL*/ nullptr, memOp.getAlignment(), I->getName());
     }
+    VECZ_FAIL_IF(!newVal);
+
     newVal->insertBefore(I->getIterator());
 
-    VECZ_FAIL_IF(!newVal);
     if (!I->getType()->isVoidTy()) {
       I->replaceAllUsesWith(newVal);
     }

--- a/source/cl/test/UnitCL/cmake/CompileKernelToBin.cmake
+++ b/source/cl/test/UnitCL/cmake/CompileKernelToBin.cmake
@@ -239,18 +239,13 @@ if(NOT clc_result EQUAL 0)
     file(WRITE ${OUTPUT_FILE} "// clc could not compile optional 'mayfail' "
          "requirement kernel for '${DEVICE_NAME}' - stderr:\n${clc_error}")
   else()
-    # execute_process() doesn't print the failing command, so attempt to
-    # reconstruct it here
-    message(FATAL_ERROR
-      "clc failed with status '${clc_result}':
-      ${CLC_EXECUTABLE}
-        -d '${DEVICE_NAME}'
-        -cl-kernel-arg-info
-        -cl-std=CL${CLC_CL_STD}
-        ${CLC_OPTIONS_LIST}
-        ${DEFS_LIST}
-        -o '${OUTPUT_FILE}'
-        -- '${INPUT_FILE}'
-      ${clc_error}")
+    # execute_process() doesn't print the command, so attempt to reconstruct it here
+    set(clc_command ${CLC_EXECUTABLE} -d '${DEVICE_NAME}' -cl-kernel-arg-info
+      -cl-std=CL${CLC_CL_STD} ${CLC_OPTIONS_LIST} ${DEFS_LIST}
+      -o '${OUTPUT_FILE}' -- '${INPUT_FILE}')
+    list(JOIN clc_command " " clc_command)
+    message(NOTICE "${clc_command}")
+    message(NOTICE "${clc_error}")
+    message(FATAL_ERROR "clc returned error code ${clc_result}")
   endif()
 endif()


### PR DESCRIPTION
# Overview

[compiler] Do not mix kernels with different sub-group sizes.

# Reason for change

Per OpenCL 3.0 API 3.2.1 Mapping Work-items Onto an Nd-range, all sub-groups within a work-group will be the same size, apart from the sub-group with the maximum index which may be smaller if the size of the work-group is not evenly divisible by the size of the sub-groups. We were not meeting this requirement: in cases where we would not or could not generate a predicated vectorized kernel, we would execute the scalar kernel in a loop for any remaining work items, possibly resulting in multiple sub-groups that are smaller than the maximum sub-group size.

# Description of change

To avoid this situation, we need to avoid mixing vector and scalar kernels if those kernels use different sub-group sizes. If we can handle all items with vector kernels, possibly with predication, continue to do so. If the vector and scalar kernels do not depend on the sub-group size, also continue to handle this as before. If the vector and scalar kernels do depend on the sub-group size, and the vector kernel cannot handle all work items, we need to switch to the scalar kernel for all work items.

# Anything else we should know?

This includes a small optimization where if we know the kernel does not use sub-group information, we avoid setting sub-group IDs.

This includes one change to createLoop which permits nullptr PHIs. They will be skipped over, and are useful since PHIs must be referred to by index in the callback function. This allows indices to be constant even when the caller has multiple optional PHIs.

This also includes one bugfix to ControlFlowConversionPass to fix a crash seen now, where we use the result of createMasked{Load,Store} before checking whether it succeeded.

This also includes one improvement to CompileKernelToBin.cmake. If the executed command fails, it will now be printed in a format that can be copied and pasted.

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-19](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
