### PR TITLE
Builder::create<OpVariable>: Set address space of builtins.

### DIFF
--- a/modules/compiler/spirv-ll/include/spirv-ll/builder.h
+++ b/modules/compiler/spirv-ll/include/spirv-ll/builder.h
@@ -329,8 +329,10 @@ class Builder {
   ///
   /// @param builtin SPIR-V builtin enum denoting which builtin to initialize.
   /// @param builtinType LLVM `Type` of the builtin variable.
+  /// @param builtinAddrSpace LLVM address space of the builtin variable.
   /// @param initBlock Basic block to generate the init code in.
   void generateBuiltinInitBlock(spv::BuiltIn builtin, llvm::Type *builtinType,
+                                unsigned builtinAddrSpace,
                                 llvm::BasicBlock *initBlock);
 
   /// @brief Attempts to replace uses of a builtin global variable with calls to


### PR DESCRIPTION
# Overview

Builder::create<OpVariable>: Set address space of builtins.

# Reason for change

Builtins are supposed to be declared with the Input storage class, but are not. We were working around this by ignoring the storage class and forcibly overriding how the builtin got declared, but this breaks now that DPC++ generates different SPIR-V, which puts it in a different storage class, resulting in us seeing address space casts where there should be none.

# Description of change

Work around this by putting globals in whatever address space is implied by the storage class.

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-19](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
