### PR TITLE
Update for LLVM 20.

### DIFF
--- a/modules/compiler/compiler_pipeline/source/work_item_loops_pass.cpp
+++ b/modules/compiler/compiler_pipeline/source/work_item_loops_pass.cpp
@@ -292,9 +292,8 @@ struct ScheduleGenerator {
       // Create intrinsic
 #if LLVM_VERSION_GREATER_EQUAL(19, 0)
       if (!module.IsNewDbgInfoFormat) {
-        auto *const DII = DIB.insertDeclare(barrier.getDebugAddr(), new_var,
-                                            expr, wrapperDbgLoc, block)
-                              .get<Instruction *>();
+        auto *const DII = cast<Instruction *>(DIB.insertDeclare(
+            barrier.getDebugAddr(), new_var, expr, wrapperDbgLoc, block));
 
         // Bit of a HACK to produce the same debug output as the Mem2Reg
         // pass used to do.
@@ -302,9 +301,8 @@ struct ScheduleGenerator {
         ConvertDebugDeclareToDebugValue(DVIntrinsic, SI, DIB);
       } else {
         auto *const DVR = static_cast<DbgVariableRecord *>(
-            DIB.insertDeclare(barrier.getDebugAddr(), new_var, expr,
-                              wrapperDbgLoc, block)
-                .get<DbgRecord *>());
+            cast<DbgRecord *>(DIB.insertDeclare(barrier.getDebugAddr(), new_var,
+                                                expr, wrapperDbgLoc, block)));
 
         // This is nasty, but LLVM errors out on trailing debug info, we need a
         // subsequent instruction even if we delete it immediately afterwards.

--- a/modules/compiler/spirv-ll/source/builder_debug_info.cpp
+++ b/modules/compiler/spirv-ll/source/builder_debug_info.cpp
@@ -527,7 +527,12 @@ llvm::Expected<llvm::MDNode *> DebugInfoBuilder::translate(
   }
 
   if (flags & OpenCLDebugInfo100FlagObjectPointer) {
+#if LLVM_VERSION_GREATER_EQUAL(20, 0)
+    const bool implicit = flags & OpenCLDebugInfo100FlagArtificial;
+    type = dib.createObjectPointerType(type, implicit);
+#else
     type = dib.createObjectPointerType(type);
+#endif
   } else if (flags & OpenCLDebugInfo100FlagArtificial) {
     type = dib.createArtificialType(type);
   }
@@ -1927,7 +1932,8 @@ llvm::Error DebugInfoBuilder::create<DebugDeclare>(const OpExtInst &opc) {
   }
 
 #if LLVM_VERSION_GREATER_EQUAL(19, 0)
-  module.addID(opc.IdResult(), op, dbg_declare.get<llvm::Instruction *>());
+  module.addID(opc.IdResult(), op,
+               llvm::cast<llvm::Instruction *>(dbg_declare));
 #else
   module.addID(opc.IdResult(), op, dbg_declare);
 #endif
@@ -2002,7 +2008,7 @@ llvm::Error DebugInfoBuilder::create<DebugValue>(const OpExtInst &opc) {
   }
 
 #if LLVM_VERSION_GREATER_EQUAL(19, 0)
-  module.addID(opc.IdResult(), op, dbg_value.get<llvm::Instruction *>());
+  module.addID(opc.IdResult(), op, llvm::cast<llvm::Instruction *>(dbg_value));
 #else
   module.addID(opc.IdResult(), op, dbg_value);
 #endif


### PR DESCRIPTION
# Overview

Update for LLVM 20.

# Reason for change

*Describe how the current behaviour of the project is causing problems for you
or is otherwise unsatisfactory for your use case.*

# Description of change

* dib.createObjectPointerType now takes an extra argument indicating whether we have an implicit or an explicit 'this'. Pass this along.
* PointerUnion::get has been deprecated in favor of llvm::cast. Since this works on LLVM 19 too, just use this unconditionally.

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-19](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
