### PR TITLE
[vecz] Handle vectors of size 1.

### DIFF
--- a/modules/compiler/vecz/source/transform/packetization_helpers.cpp
+++ b/modules/compiler/vecz/source/transform/packetization_helpers.cpp
@@ -486,7 +486,7 @@ PacketRange Packetizer::Result::getAsPacket(unsigned width) const {
   if (auto *const vecTy = dyn_cast<FixedVectorType>(vec->getType())) {
     assert(isa<FixedVectorType>(vecTy) && "Must be a fixed vector type here!");
     const unsigned scalarWidth = vecTy->getNumElements() / width;
-    if (scalarWidth > 1) {
+    if (scalarWidth > 1 || scalar->getType()->isVectorTy()) {
       auto *const undef = UndefValue::get(vec->getType());
 
       // Build shuffle mask to perform the subvector extracts.

--- a/modules/compiler/vecz/test/lit/llvm/vector_size_1.ll
+++ b/modules/compiler/vecz/test/lit/llvm/vector_size_1.ll
@@ -1,0 +1,38 @@
+; Copyright (C) Codeplay Software Limited
+;
+; Licensed under the Apache License, Version 2.0 (the "License") with LLVM
+; Exceptions; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/LICENSE.txt
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+; WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+; License for the specific language governing permissions and limitations
+; under the License.
+;
+; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+; RUN: veczc -k test -vecz-simd-width=4 -S < %s | FileCheck %s
+
+; ModuleID = 'kernel.opencl'
+target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "spir64-unknown-unknown"
+
+define spir_kernel void @test(ptr %src, ptr %dst) {
+entry:
+  %lid = tail call i32 @__mux_get_sub_group_local_id()
+  %lid.i64 = zext i32 %lid to i64
+  %src.i = getelementptr i64, ptr %src, i64 %lid.i64
+  %val = load <1 x i64>, ptr %src.i, align 8
+  %vec = shufflevector <1 x i64> %val, <1 x i64> zeroinitializer, <8 x i32> zeroinitializer
+  %dst.i = getelementptr <8 x i64>, ptr %dst, i64 %lid.i64
+  store <8 x i64> %vec, ptr %dst.i, align 16
+  ret void
+}
+
+; CHECK-LABEL: define spir_kernel void @test
+; CHECK-LABEL: define spir_kernel void @__vecz_v4_test
+
+declare i32 @__mux_get_sub_group_local_id()


### PR DESCRIPTION
# Overview

[vecz] Handle vectors of size 1.

# Reason for change

Vectors of size 1 are valid, but were internally getting mishandled by the packetization treating them as scalars.

# Description of change

Check whether the vecz source instruction was using vectors and if so, keep it using vectors.

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-19](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
