### PR TITLE
Fix logic to query the number of available devices

### DIFF
--- a/modules/mux/targets/riscv/source/device_info.cpp
+++ b/modules/mux/targets/riscv/source/device_info.cpp
@@ -199,15 +199,11 @@ static mux_result_t GetDeviceInfos(uint32_t device_types,
     }
 
     // copy out the device info pointer
-    if (out_device_infos) {
+    if (out_device_infos && (num_infos_out < device_infos_length)) {
       out_device_infos[num_infos_out] = static_cast<mux_device_info_t>(&info);
     }
     // advance to next device info
     ++num_infos_out;
-    if (num_infos_out >= device_infos_length) {
-      // no more space so terminate
-      break;
-    }
   }
   // return the number of infos that we have
   if (out_device_infos_length) {


### PR DESCRIPTION
For the riscv mux target, GetDeviceInfos always returned 1 when called with device_infos_length = 0 and out_device_infos = nullptr to query the number of available devices, regardless of the actual number of devices detected in the system.

This fixes it by always returning the number of available devices in the system, but still only filling the provided vector up to its own capacity.
