### PR TITLE
LLVM 20: Update for getFirstNonPHIOrDbg.

### DIFF
--- a/modules/compiler/compiler_pipeline/source/barrier_regions.cpp
+++ b/modules/compiler/compiler_pipeline/source/barrier_regions.cpp
@@ -1185,7 +1185,7 @@ Function *compiler::utils::Barrier::GenerateNewKernel(BarrierRegion &region) {
   }
 
   BasicBlock *new_kernel_entry_block = &(new_kernel->getEntryBlock());
-  Instruction *insert_point = new_kernel_entry_block->getFirstNonPHIOrDbg();
+  Instruction *insert_point = &*new_kernel_entry_block->getFirstNonPHIOrDbg();
   auto *const cloned_barrier_call =
       region.barrier_inst ? insert_point : nullptr;
 
@@ -1290,7 +1290,7 @@ Function *compiler::utils::Barrier::GenerateNewKernel(BarrierRegion &region) {
   }
 
   // Iterate instruction from insert point at entry basic block.
-  insert_point = new_kernel_entry_block->getFirstNonPHIOrDbg();
+  insert_point = &*new_kernel_entry_block->getFirstNonPHIOrDbg();
   const RemapFlags remapFlags =
       RF_IgnoreMissingLocals | llvm::RF_ReuseAndMutateDistinctMDs;
   BasicBlock::iterator b_iter = insert_point->getIterator();


### PR DESCRIPTION
# Overview

LLVM 20: Update for getFirstNonPHIOrDbg.

# Reason for change

LLVM 20 updates getFirstNonPHIOrDbg() to return an iterator rather than an Instruction *.

# Description of change

We can use &* to reliably get an Instruction * across LLVM versions.

# Anything else we should know?

The variable name insert_point suggests that we should instead change the type of the variable to be an iterator, but despite the name, it is not used merely as an insert point. This should be revisited in the future but may result in changes in behavior that should probably be kept separate from any compatibility fixes.

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-19](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
