### PR TITLE
Remove max_device_infos limit in riscv mux target

### DIFF
--- a/modules/mux/targets/riscv/include/riscv/device_info.h
+++ b/modules/mux/targets/riscv/include/riscv/device_info.h
@@ -54,9 +54,6 @@ struct device_info_s final : public mux_device_info_s {
 /// devices.
 bool enumerate_device_infos();
 
-static const size_t max_device_infos = 1;
-extern std::array<device_info_s, max_device_infos> device_infos;
-
 typedef device_info_s *device_info_t;
 /// @}
 }  // namespace riscv


### PR DESCRIPTION
There was a harcoded maximum of devices used as static size for a std::array.

This removes the limit and uses a dynamically sized std::vector instead.