### PR TITLE
[NFC] Remove unused CMake variables.

### DIFF
--- a/doc/modules.md
+++ b/doc/modules.md
@@ -95,14 +95,3 @@ options, and link libraries.
 target_include_directories(<name> PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
 target_link_libraries(<name> PUBLIC <lib0> <lib2> ...)
 ```
-
-Header only modules may populate the CMake variable `MODULES_INCLUDE_DIRS` to
-enabling dependency tracking. This approach is only suggested as a backup when
-the suggested approach above is intractable.
-
-```cmake
-# Append to the list of module include directories, the cache MUST be updated.
-list(APPEND MODULES_INCLUDE_DIRS ${CARGO_INCLUDE_DIR})
-set(MODULES_INCLUDE_DIRS ${MODULES_INCLUDE_DIRS}
-  CACHE INTERNAL "List of module include directories")
-```

--- a/modules/CMakeLists.txt
+++ b/modules/CMakeLists.txt
@@ -14,19 +14,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-# Create an internally cached variable to store a list of include directories
-# for modules which do not export a target, such as header only libraries.
-# These modules must append to this string so that the include directories can
-# be propagated throughout the project.
-set(MODULES_INCLUDE_DIRS # No default value
-  CACHE INTERNAL "List of module include directories.")
-
-# Create an internally cached variable to store all module libraries. Modules
-# must append to this list so that the libraries can be propagated throughout
-# the project.
-set(MODULES_LIBRARIES # No default value
-  CACHE INTERNAL "List of module libraries.")
-
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/cargo)
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/loader)
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/tracer)
@@ -63,7 +50,3 @@ if(CA_ENABLE_TESTS)
   add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/kts)
 endif()
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/lit)
-
-foreach(LIBRARY ${MODULES_LIBRARIES})
-  target_include_directories(${LIBRARY} PUBLIC ${MODULES_INCLUDE_DIRS})
-endforeach()

--- a/modules/cargo/CMakeLists.txt
+++ b/modules/cargo/CMakeLists.txt
@@ -83,11 +83,6 @@ target_compile_definitions(cargo PUBLIC
   $<$<BOOL:${CA_ENABLE_CARGO_INSTRUMENTATION}>:
   CA_CARGO_INSTRUMENTATION_ENABLED>)
 
-# Append to the list of module libraries, the cache MUST be updated.
-list(APPEND MODULES_LIBRARIES cargo)
-set(MODULES_LIBRARIES ${MODULES_LIBRARIES}
-  CACHE INTERNAL "List of module libraries.")
-
 if(CA_ENABLE_TESTS)
   add_ca_executable(UnitCargo
     ${CMAKE_CURRENT_SOURCE_DIR}/test/allocator.cpp

--- a/modules/compiler/builtins/CMakeLists.txt
+++ b/modules/compiler/builtins/CMakeLists.txt
@@ -657,11 +657,6 @@ target_compile_definitions(builtins PRIVATE CL_VERSION_3_0)
 
 target_link_libraries(builtins PUBLIC cargo abacus_static image_library_host)
 
-# Append to the list of module libraries, the cache MUST be updated.
-list(APPEND MODULES_LIBRARIES builtins)
-set(MODULES_LIBRARIES ${MODULES_LIBRARIES}
-  CACHE INTERNAL "List of module libraries.")
-
 set(BUILTINS_NAMESPACES builtins CACHE INTERNAL
   "List of builtins resource compiler namespaces" FORCE)
 

--- a/modules/compiler/multi_llvm/CMakeLists.txt
+++ b/modules/compiler/multi_llvm/CMakeLists.txt
@@ -18,5 +18,3 @@ add_ca_interface_library(multi_llvm)
 
 target_include_directories(multi_llvm INTERFACE
 $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>)
-
-# No need to append interface libraries to MODULES_LIBRARIES variable

--- a/modules/compiler/spirv-ll/CMakeLists.txt
+++ b/modules/compiler/spirv-ll/CMakeLists.txt
@@ -75,8 +75,3 @@ add_subdirectory(tools)
 if(CA_ENABLE_TESTS)
   add_subdirectory(test)
 endif()
-
-# Append to the list of module libraries, the cache MUST be updated.
-list(APPEND MODULES_LIBRARIES spirv-ll)
-set(MODULES_LIBRARIES ${MODULES_LIBRARIES}
-  CACHE INTERNAL "List of module libraries.")

--- a/modules/compiler/vecz/CMakeLists.txt
+++ b/modules/compiler/vecz/CMakeLists.txt
@@ -201,8 +201,3 @@ if(NOT CA_VECZ_ONLY)
     add_subdirectory(test)
   endif()
 endif()
-
-# Append to the list of module libraries, the cache MUST be updated.
-list(APPEND MODULES_LIBRARIES vecz)
-set(MODULES_LIBRARIES ${MODULES_LIBRARIES}
-  CACHE INTERNAL "List of module libraries.")

--- a/modules/kts/CMakeLists.txt
+++ b/modules/kts/CMakeLists.txt
@@ -31,8 +31,3 @@ target_compile_options(kts PRIVATE
 
 target_include_directories(kts PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>)
 target_link_libraries(kts PUBLIC ca_gtest)
-
-# Append to the list of module libraries, the cache MUST be updated.
-list(APPEND MODULES_LIBRARIES kts)
-set(MODULES_LIBRARIES ${MODULES_LIBRARIES}
-  CACHE INTERNAL "List of module libraries.")

--- a/modules/mux/CMakeLists.txt
+++ b/modules/mux/CMakeLists.txt
@@ -138,11 +138,6 @@ endforeach()
 
 target_link_libraries(mux PUBLIC cargo mux-utils tracer)
 
-# Append to the list of module libraries, the cache MUST be updated.
-list(APPEND MODULES_LIBRARIES mux)
-set(MODULES_LIBRARIES ${MODULES_LIBRARIES}
-  CACHE INTERNAL "List of module libraries.")
-
 # For online coverage we want to add UnitMux as a test suite
 if(${CA_ENABLE_COVERAGE} AND ${CA_RUNTIME_COMPILER_ENABLED})
   # TODO: Reenable when it is working on Jenkins

--- a/modules/tracer/CMakeLists.txt
+++ b/modules/tracer/CMakeLists.txt
@@ -40,8 +40,3 @@ target_compile_definitions(tracer PUBLIC
   $<$<BOOL:${CA_TRACE_IMPLEMENTATION}>:CA_TRACE_IMPLEMENTATION=1>)
 
 target_link_libraries(tracer PRIVATE utils)
-
-# Append to the list of module libraries, the cache MUST be updated.
-list(APPEND MODULES_LIBRARIES tracer)
-set(MODULES_LIBRARIES ${MODULES_LIBRARIES}
-  CACHE INTERNAL "List of module libraries.")

--- a/modules/utils/CMakeLists.txt
+++ b/modules/utils/CMakeLists.txt
@@ -27,10 +27,5 @@ target_compile_definitions(utils PRIVATE
   $<$<BOOL:${CA_PLATFORM_QNX}>:CA_PLATFORM_QNX>)
 target_link_libraries(utils PRIVATE cargo)
 
-# Append to the list of module libraries, the cache MUST be updated.
-list(APPEND MODULES_LIBRARIES utils)
-set(MODULES_LIBRARIES ${MODULES_LIBRARIES}
-  CACHE INTERNAL "List of module libraries.")
-
 # Add any target-specific utils libraries
 add_subdirectory(targets)

--- a/source/cl/source/extension/CMakeLists.txt
+++ b/source/cl/source/extension/CMakeLists.txt
@@ -214,10 +214,5 @@ target_include_directories(extension
 target_link_libraries(extension PUBLIC
   builtins cargo CL-binary compiler-loader mux)
 
-# Append to the list of module libraries, the cache MUST be updated.
-list(APPEND MODULES_LIBRARIES extension)
-set(MODULES_LIBRARIES ${MODULES_LIBRARIES}
-  CACHE INTERNAL "List of module libraries.")
-
 # Install enabled extension headers.
 install(FILES ${CL_EXTENSION_HEADERS} DESTINATION include/CL COMPONENT OCL)


### PR DESCRIPTION
# Overview

[NFC] Remove unused CMake variables.

# Reason for change

MODULES_INCLUDE_DIRS and MODULES_LIBRARIES were still around to support libraries that could not use target_include_directories for whatever reason, but the only library that ever made use of this was cargo, and we changed that in 2016 already. This has been dead code ever since.

# Description of change

*Describe the intended behaviour your changes are meant to introduce to the
project and explain how they resolve the problem stated above. Detail any
relevant changes that may affect other users of the project, such as
compilation options, runtime flags, expected inputs and outputs, API entry
points, etc.*

*If you have added new testing, provide details on what tests you have added
and what the purpose of them is.*

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-19](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
