### PR TITLE
Change city runner default to cd into directory of test.

### DIFF
--- a/scripts/testing/city_runner/profiles/default.py
+++ b/scripts/testing/city_runner/profiles/default.py
@@ -99,6 +99,9 @@ class DefaultTestRun(CTSTestRun):
         if lib_dirs:
             env[env_var_name] = env_var_separator.join(lib_dirs)
 
+        if os.path.exists(exe_path):
+            working_dir = os.path.dirname(exe_path)
+
         # Support `<command> <args>` invocations by splitting the
         # value of the --prepend_args option, the first item being the path to
         # `<command>` binary and subsequent items optional arguments.


### PR DESCRIPTION
# Overview

change city runner default to cd into directory of test.

# Reason for change

A recent change to an OpenCL CTS test showed that their usage of the csv file changes to the directory of the test before running it.

# Description of change

This changes city runner to follow the same method as OpenCL CTS for csv files by default.
