### PR TITLE
[CI] Change to use --prepend-path for qemu using city runner

### DIFF
--- a/.github/actions/run_opencl_cts/action.yml
+++ b/.github/actions/run_opencl_cts/action.yml
@@ -30,9 +30,9 @@ runs:
         echo "Running OpenCL CTS tests with CTS file $CTS_CSV_FILE with filter $CTS_FILTER"
         export QEMU_SETTING=""
         if [[ "${{inputs.target}}" =~ .*aarch64.* ]] ; then
-          QEMU_SETTING="-p qemu --qemu '/usr/bin/qemu-aarch64 -L /usr/aarch64-linux-gnu'"
+          QEMU_SETTING="--prepend-path '/usr/bin/qemu-aarch64 -L /usr/aarch64-linux-gnu'"
         elif [[ "${{inputs.target}}" =~ .*riscv64.* ]] ; then
-          QEMU_SETTING="-p qemu --qemu '/usr/bin/qemu-riscv64 -L /usr/riscv64-linux-gnu'"
+          QEMU_SETTING="--prepend-path '/usr/bin/qemu-riscv64 -L /usr/riscv64-linux-gnu'"
         fi
         echo QEMU SETTING: $QEMU SETTING
         set -x


### PR DESCRIPTION
# Overview

 The qemu path for city runner was having slightly different behaviour  than the default profile. Rather than fixing it there,
 move to using  --prepend-path which means the same profile is used. 

# Reason for change

aarch64/riscv64 qemu failures on spirv_new in opencl-cts
