### PR TITLE
LLVM 21: Update for Attribute::NoCapture removal.

### DIFF
--- a/modules/compiler/spirv-ll/source/builder_opencl.cpp
+++ b/modules/compiler/spirv-ll/source/builder_opencl.cpp
@@ -221,7 +221,13 @@ static llvm::Error createPrintf(const OpExtInst &opc, Module &module,
         "printf", module.llvmModule.get());
     SPIRV_LL_ASSERT_PTR(printf);
     printf->setCallingConv(llvm::CallingConv::SPIR_FUNC);
+#if LLVM_VERSION_GREATER_EQUAL(21, 0)
+    printf->addParamAttr(
+        0, llvm::Attribute::getWithCaptureInfo(module.llvmModule->getContext(),
+                                               llvm::CaptureInfo::none()));
+#else
     printf->addParamAttr(0, llvm::Attribute::NoCapture);
+#endif
     printf->addParamAttr(0, llvm::Attribute::ReadOnly);
     printf->setUnnamedAddr(llvm::GlobalValue::UnnamedAddr::Local);
   }

--- a/modules/compiler/spirv-ll/test/spvasm/op_lifetime_unsized.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_lifetime_unsized.spvasm
@@ -52,5 +52,5 @@
 ; CHECK: call void @llvm.lifetime.end{{(.p0)?}}(i64 -1, ptr [[PTR]])
 ; CHECK: store i32 424, ptr [[PTR]]
 ; CHECK: ret void
-; CHECK: declare void @llvm.lifetime.start{{(.p0)?}}(i64{{.*}}, ptr nocapture)
-; CHECK: declare void @llvm.lifetime.end{{(.p0)?}}(i64{{.*}}, ptr nocapture)
+; CHECK: declare void @llvm.lifetime.start{{(.p0)?}}(i64{{.*}}, ptr {{nocapture|captures\(none\)}})
+; CHECK: declare void @llvm.lifetime.end{{(.p0)?}}(i64{{.*}}, ptr {{nocapture|captures\(none\)}})

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_printf.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_printf.spvasm
@@ -62,4 +62,7 @@
 ; CHECK: %call = tail call spir_func i32 (ptr addrspace(2), ...) @printf(ptr addrspace(2) %0, i32 42)
                OpReturn
                OpFunctionEnd
-; CHECK: declare extern_weak spir_func i32 @printf(ptr addrspace(2) nocapture readonly, ...) local_unnamed_addr
+; CHECK: declare extern_weak spir_func i32 @printf(ptr addrspace(2)
+; CHECK-DAG: {{nocapture|captures\(none\)}}
+; CHECK-DAG: readonly
+; CHECK-SAME: , ...) local_unnamed_addr

--- a/modules/compiler/test/lit/passes/image-arg-subst-tgt-tys-64.ll
+++ b/modules/compiler/test/lit/passes/image-arg-subst-tgt-tys-64.ll
@@ -20,8 +20,8 @@
 target triple = "spir64-unknown-unknown"
 target datalayout = "e-p:64:64:64-m:e-i64:64-f80:128-n8:16:32:64-S128"
 
-; CHECK: define spir_kernel void @image_sampler(ptr addrspace(1) nocapture writeonly align 4 %out, ptr %img, i64 %sampler1, i64 %sampler2) {{#[0-9]+}} {
-define spir_kernel void @image_sampler(ptr addrspace(1) nocapture writeonly align 4 %out, target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0) %img, target("spirv.Sampler") %sampler1, target("spirv.Sampler") %sampler2) #0 {
+; CHECK: define spir_kernel void @image_sampler(ptr addrspace(1) writeonly align 4 %out, ptr %img, i64 %sampler1, i64 %sampler2) {{#[0-9]+}} {
+define spir_kernel void @image_sampler(ptr addrspace(1) writeonly align 4 %out, target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0) %img, target("spirv.Sampler") %sampler1, target("spirv.Sampler") %sampler2) #0 {
 entry:
   %call = tail call i64 @__mux_get_global_id(i32 0) #3
   %conv = trunc i64 %call to i32

--- a/modules/compiler/test/lit/passes/image-arg-subst-tgt-tys.ll
+++ b/modules/compiler/test/lit/passes/image-arg-subst-tgt-tys.ll
@@ -21,8 +21,8 @@ target triple = "spir-unknown-unknown"
 target datalayout = "e-p:32:32:32-m:e-i64:64-f80:128-n8:16:32:64-S128"
 
 
-; CHECK: define spir_kernel void @image_sampler(ptr addrspace(1) nocapture writeonly align 4 %out, ptr %img, i32 %sampler1, i32 %sampler2) {{#[0-9]+}} {
-define spir_kernel void @image_sampler(ptr addrspace(1) nocapture writeonly align 4 %out, target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0) %img, target("spirv.Sampler") %sampler1, target("spirv.Sampler") %sampler2) #0 {
+; CHECK: define spir_kernel void @image_sampler(ptr addrspace(1) writeonly align 4 %out, ptr %img, i32 %sampler1, i32 %sampler2) {{#[0-9]+}} {
+define spir_kernel void @image_sampler(ptr addrspace(1) writeonly align 4 %out, target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0) %img, target("spirv.Sampler") %sampler1, target("spirv.Sampler") %sampler2) #0 {
 entry:
   %call = tail call i64 @__mux_get_global_id(i32 0) #3
   %conv = trunc i64 %call to i32

--- a/modules/compiler/test/lit/passes/replace-image-tys-64.ll
+++ b/modules/compiler/test/lit/passes/replace-image-tys-64.ll
@@ -26,13 +26,13 @@
 
 target triple = "spir64-unknown-unknown"
 target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
-; CHECK: define spir_kernel void @image_sampler(ptr addrspace(1) nocapture writeonly %v0,
+; CHECK: define spir_kernel void @image_sampler(ptr addrspace(1) writeonly %v0,
 ; CHECK-IMG-SAME: ptr %img,
 ; CHECK-NOIMG-SAME: target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0) %img,
 ; CHECK-SAMP-SAME: i64 %sampler1, i64 %sampler2
 ; CHECK-NOSAMP-SAME: target("spirv.Sampler") %sampler1, target("spirv.Sampler") %sampler2
 ; CHECK-SAME: ) #0 !custom_metadata [[MD:\![0-9]+]] {
-define spir_kernel void @image_sampler(ptr addrspace(1) nocapture writeonly %v0, target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0) %img, target("spirv.Sampler") %sampler1, target("spirv.Sampler") %sampler2) #0 !custom_metadata !9 {
+define spir_kernel void @image_sampler(ptr addrspace(1) writeonly %v0, target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0) %img, target("spirv.Sampler") %sampler1, target("spirv.Sampler") %sampler2) #0 !custom_metadata !9 {
 ; Check that a sampler stored to and loaded from a stack slot is also remapped
 ; CHECK-SAMP: alloca i64, align 8
   %v4 = alloca target("spirv.Sampler"), align 8

--- a/modules/compiler/test/lit/passes/replace-image-tys.ll
+++ b/modules/compiler/test/lit/passes/replace-image-tys.ll
@@ -27,13 +27,13 @@
 target triple = "spir-unknown-unknown"
 target datalayout = "e-p:32:32:32-m:e-i64:64-f80:128-n8:16:32:64-S128"
 
-; CHECK: define spir_kernel void @image_sampler(ptr addrspace(1) nocapture writeonly %v0,
+; CHECK: define spir_kernel void @image_sampler(ptr addrspace(1) writeonly %v0,
 ; CHECK-IMG-SAME: ptr %img,
 ; CHECK-NOIMG-SAME: target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0) %img,
 ; CHECK-SAMP-SAME: i32 %sampler1, i32 %sampler2
 ; CHECK-NOSAMP-SAME: target("spirv.Sampler") %sampler1, target("spirv.Sampler") %sampler2
 ; CHECK-SAME: ) #0 !custom_metadata [[MD:\![0-9]+]] {
-define spir_kernel void @image_sampler(ptr addrspace(1) nocapture writeonly %v0, target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0) %img, target("spirv.Sampler") %sampler1, target("spirv.Sampler") %sampler2) #0 !custom_metadata !9 {
+define spir_kernel void @image_sampler(ptr addrspace(1) writeonly %v0, target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0) %img, target("spirv.Sampler") %sampler1, target("spirv.Sampler") %sampler2) #0 !custom_metadata !9 {
 ; Check that a sampler stored to and loaded from a stack slot is also remapped
 ; CHECK-SAMP: alloca i32, align 8
   %v4 = alloca target("spirv.Sampler"), align 8

--- a/modules/compiler/test/lit/passes/replace-local-module-scope-mem_builtins.ll
+++ b/modules/compiler/test/lit/passes/replace-local-module-scope-mem_builtins.ll
@@ -27,11 +27,11 @@ target datalayout = "e-p:64:64:64-m:e-i64:64-f80:128-n8:16:32:64-S128"
 @llvm.compiler.used = appending global [3 x ptr] [ptr @memcpy, ptr @memset, ptr @memmove], section "llvm.metadata"
 @a = internal addrspace(3) global i16 undef, align 2
 
-declare void @llvm.memcpy.p0.p3.i64(ptr noalias nocapture writeonly, ptr addrspace(3) noalias nocapture readonly, i64, i1 immarg)
+declare void @llvm.memcpy.p0.p3.i64(ptr noalias writeonly, ptr addrspace(3) noalias readonly, i64, i1 immarg)
 
-; CHECK: define internal ptr @memcpy(ptr noalias noundef returned writeonly %dst, ptr noalias nocapture noundef readonly %src, i64 noundef %num)
+; CHECK: define internal ptr @memcpy(ptr noalias noundef returned writeonly %dst, ptr noalias noundef readonly %src, i64 noundef %num)
 ; Function Attrs: mustprogress nofree norecurse nosync nounwind memory(readwrite, inaccessiblemem: none)
-define internal ptr @memcpy(ptr noalias noundef returned writeonly %dst, ptr noalias nocapture noundef readonly %src, i64 noundef %num) local_unnamed_addr #7 {
+define internal ptr @memcpy(ptr noalias noundef returned writeonly %dst, ptr noalias noundef readonly %src, i64 noundef %num) local_unnamed_addr #7 {
 entry:
   ret ptr %dst
 }
@@ -43,9 +43,9 @@ entry:
   ret ptr %dst
 }
 
-; CHECK: define internal ptr @memmove(ptr noalias noundef returned writeonly %dst,  ptr noalias nocapture noundef readonly %src, i64 noundef %num)
+; CHECK: define internal ptr @memmove(ptr noalias noundef returned writeonly %dst,  ptr noalias noundef readonly %src, i64 noundef %num)
 ; Function Attrs: mustprogress nofree norecurse nosync nounwind memory(readwrite, inaccessiblemem: none)
-define internal ptr @memmove(ptr noalias noundef returned writeonly %dst,  ptr noalias nocapture noundef readonly %src, i64 noundef %num) local_unnamed_addr #7 {
+define internal ptr @memmove(ptr noalias noundef returned writeonly %dst,  ptr noalias noundef readonly %src, i64 noundef %num) local_unnamed_addr #7 {
 entry:
   ret ptr %dst
 }

--- a/modules/compiler/test/lit/passes/replace-local-module-scope-vars-cmp.ll
+++ b/modules/compiler/test/lit/passes/replace-local-module-scope-vars-cmp.ll
@@ -27,8 +27,8 @@ target datalayout = "e-p:64:64:64-m:e-i64:64-f80:128-n8:16:32:64-S128"
 declare i64 @__mux_get_global_id(i32)
 
 ; Function Attrs: norecurse nounwind
-; CHECK: void @testKernel(ptr addrspace(1) nocapture writeonly align 4 %results, ptr [[STRUCT:%.*]])
-define spir_kernel void @testKernel(ptr addrspace(1) nocapture writeonly align 4 %results) {
+; CHECK: void @testKernel(ptr addrspace(1) writeonly align 4 %results, ptr [[STRUCT:%.*]])
+define spir_kernel void @testKernel(ptr addrspace(1) writeonly align 4 %results) {
 entry:
 ; CHECK: [[PTR0:%.*]] = getelementptr inbounds %localVarTypes, ptr [[STRUCT]], i32 0, i32 0
 ; CHECK: [[TMP0:%.*]] = addrspacecast ptr [[PTR0]] to ptr addrspace(3)

--- a/modules/compiler/vecz/test/lit/llvm/VectorPredication/boscc_reduction.ll
+++ b/modules/compiler/vecz/test/lit/llvm/VectorPredication/boscc_reduction.ll
@@ -22,7 +22,7 @@ target triple = "spir64-unknown-unknown"
 
 declare i64 @__mux_get_global_id(i32)
 
-define spir_kernel void @foo(float addrspace(1)* nocapture readonly %a, i32 addrspace(1)* nocapture %out) {
+define spir_kernel void @foo(float addrspace(1)* readonly %a, i32 addrspace(1)* %out) {
 entry:
   %call = tail call i64 @__mux_get_global_id(i32 0) #2
   %arrayidx = getelementptr inbounds float, float addrspace(1)* %a, i64 %call
@@ -41,6 +41,6 @@ if.end:                                           ; preds = %if.then, %entry
   ret void
 }
 
-; CHECK: define spir_kernel void @__vecz_nxv2_vp_foo(ptr addrspace(1) nocapture readonly %a, ptr addrspace(1) nocapture %out)
+; CHECK: define spir_kernel void @__vecz_nxv2_vp_foo(ptr addrspace(1) readonly %a, ptr addrspace(1) %out)
 ; CHECK:  [[CMP:%.*]] = fcmp oeq <vscale x 2 x float> %{{.*}}, zeroinitializer
 ; CHECK:  %{{.*}} = call i1 @llvm.vp.reduce.or.nxv2i1(i1 false, <vscale x 2 x i1> [[CMP]], {{.*}}, i32 {{.*}})


### PR DESCRIPTION
# Overview

LLVM 21: Update for Attribute::NoCapture removal.

# Reason for change

LLVM 21 removes the nocapture attribute in favor of captures(none).

# Description of change

Make sure we handle that.

In tests where nocapture was not relevant to what was being tested and where it can be removed, remove it. In other tests, change the CHECK lines to permit both nocapture and captures(none).

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-19](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
