### PR TITLE
Switch to calling an action for PR tests and improve caching

### DIFF
--- a/.github/actions/do_build_pr/run_host_x86_64/action.yml
+++ b/.github/actions/do_build_pr/run_host_x86_64/action.yml
@@ -1,0 +1,28 @@
+name: build_pr_host_x86_64
+description: Build pr host x86_64
+
+inputs:
+  cache_seed:
+    type: boolean
+    default: false
+
+runs:
+  using: "composite"
+  steps:
+      - name: remove any old dirs
+        shell: bash  
+        run:
+          rm -rf build build_offline
+      - name: build host x86_64 online release
+        uses: ./.github/actions/do_build_ock
+        with:
+          build_type: Release
+          offline_kernel_tests: ${{ inputs.cache_seed == 'true' && 'OFF' || 'ON' }}
+      - name: build host x86_64 offline release
+        uses: ./.github/actions/do_build_ock
+        with:
+          build_type: Release
+          extra_flags: -DCA_RUNTIME_COMPILER_ENABLED=OFF -DCA_EXTERNAL_CLC=${{ github.workspace }}/build/bin/clc
+          build_dir: build_offline
+          build_targets: UnitCL
+          assemble_spirv_ll_lit_test_offline: ${{ inputs.cache_seed == 'true' && 'OFF' || 'ON' }}

--- a/.github/actions/do_build_pr/run_riscv_m1/action.yml
+++ b/.github/actions/do_build_pr/run_riscv_m1/action.yml
@@ -1,0 +1,27 @@
+name: build_pr_riscv_m1
+description: Build pr riscv_m1
+
+inputs:
+  cache_seed:
+    type: boolean
+    default: false
+
+runs:
+  using: "composite"
+  steps:
+      - name: remove any old dirs
+        shell: bash  
+        run:
+          rm -rf build
+
+      - name: build_ock
+        uses: ./.github/actions/do_build_ock
+        with:
+          build_type: ${{ inputs.build_type }}
+          mux_targets_enable: riscv
+          mux_compilers_enable: refsi_m1
+          external_compiler_dirs: "${{ github.workspace }}/examples/refsi/refsi_m1/compiler/refsi_m1"
+          riscv_enabled: ON
+          enable_rvv_scalable_vecz_check: ON
+          enable_rvv_scalable_vp_vecz_check: ON
+          offline_kernel_tests: ${{ inputs.cache_seed == 'true' && 'OFF' || 'ON' }}

--- a/.github/actions/do_build_pr/run_ubuntu_clang_x86_llvm_latest_cl3_0_offline/action.yml
+++ b/.github/actions/do_build_pr/run_ubuntu_clang_x86_llvm_latest_cl3_0_offline/action.yml
@@ -1,0 +1,42 @@
+name: build_pr_ubuntu_clang_x86_llvm_latest_cl3_0_offline
+description: Build pr ubuntu_clang_x86_llvm_latest_cl3_0_offline
+
+inputs:
+  cache_seed:
+    type: boolean
+    default: false
+
+runs:
+  using: "composite"
+  steps:
+      - name: remove any old dirs
+        shell: bash  
+        run:
+          rm -rf build build_offline install_offline
+
+      - name: build ock x86 relassert
+        uses: ./.github/actions/do_build_ock
+        with:
+          build_32_bit: ON
+          extra_flags: -DCMAKE_C_COMPILER=$GITHUB_WORKSPACE/llvm_install/bin/clang -DCMAKE_CXX_COMPILER=$GITHUB_WORKSPACE/llvm_install/bin/clang++
+          build_targets: ${{ inputs.cache_seed == 'true' && 'UnitCL clc' || 'check-ock' }}
+          enable_api: ""
+          builtin_kernel: ON
+          use_linker: gold
+          debug_support: ON
+          offline_kernel_tests: ${{ inputs.cache_seed == 'true' && 'OFF' || 'ON' }}
+          
+      - name: build ock x86 offline
+        uses: ./.github/actions/do_build_ock
+        with:
+          build_32_bit: ON
+          extra_flags: -DCMAKE_C_COMPILER=$GITHUB_WORKSPACE/llvm_install/bin/clang -DCMAKE_CXX_COMPILER=$GITHUB_WORKSPACE/llvm_install/bin/clang++
+          build_targets:  ${{ inputs.cache_seed == 'true' && 'UnitCL' || 'check-ock' }}
+          runtime_compiler_enabled: OFF
+          assemble_spirv_ll_lit_test_offline: ${{ inputs.cache_seed == 'true' && 'OFF' || 'ON' }}
+          external_clc: ${GITHUB_WORKSPACE}/build/bin/clc
+          use_linker: gold
+          debug_support: ON
+          install_dir: $GITHUB_WORKSPACE/install_offline
+          build_dir: $GITHUB_WORKSPACE/build_offline
+          offline_kernel_tests: ${{ inputs.cache_seed == 'true' && 'OFF' || 'ON' }}

--- a/.github/actions/do_build_pr/run_ubuntu_gcc_aarch64_llvm_latest_cl3_0_fp16/action.yml
+++ b/.github/actions/do_build_pr/run_ubuntu_gcc_aarch64_llvm_latest_cl3_0_fp16/action.yml
@@ -1,0 +1,27 @@
+name: build_ubuntu_gcc_aarch64_llvm_latest_cl3_0_fp16
+description: Build pr ubuntu_gcc_aarch64_llvm_latest_cl3_0_fp16
+
+inputs:
+  cache_seed:
+    type: boolean
+    default: false
+
+runs:
+  using: "composite"
+  steps:
+      - name: remove any old dirs
+        shell: bash  
+        run:
+          rm -rf build
+      - name: build ock
+        uses: ./.github/actions/do_build_ock
+        with:
+          build_targets: ${{ inputs.cache_seed == 'true' && 'UnitCL clc' || 'check-ock-cross' }} 
+          host_fp16: ON
+          use_linker: gold
+          debug_support: ON
+          builtin_kernel: ON
+          enable_api: ""
+          toolchain_file: "scripts/../platform/arm-linux/aarch64-toolchain.cmake"
+          extra_flags: -DCA_BUILTINS_TOOLS_DIR=${{ github.workspace }}/llvm_install_native/bin
+          offline_kernel_tests: ${{ inputs.cache_seed == 'true' && 'OFF' || 'ON' }}

--- a/.github/actions/do_build_pr/run_ubuntu_gcc_x86_64_refsi_g1_wi_cl3_0/action.yml
+++ b/.github/actions/do_build_pr/run_ubuntu_gcc_x86_64_refsi_g1_wi_cl3_0/action.yml
@@ -1,0 +1,32 @@
+name: build_pr_ubuntu_gcc_x86_64_refsi_g1_wi_cl3_0
+description: Build pr ubuntu_gcc_x86_64_refsi_g1_wi_cl3_0
+
+inputs:
+  cache_seed:
+    type: boolean
+    default: false
+
+runs:
+  using: "composite"
+  steps:
+      - name: remove any old dirs
+        shell: bash  
+        run:
+          rm -rf build
+      - name: build ock
+        uses: ./.github/actions/do_build_ock
+        with:
+          build_targets: install # Build the install target so we don't miss compilation errors
+          mux_targets_enable: riscv
+          external_compiler_dirs: ${{ github.workspace }}/examples/refsi/refsi_g1_wi/compiler/refsi_g1_wi
+          mux_compilers_enable: refsi_g1_wi
+          riscv_enabled: ON
+          disable_unitcl_vecz_checks: ON
+          enable_rvv_scalable_vecz_check: ON
+          enable_rvv_scalable_vp_vecz_check: ON
+          use_linker: gold
+          hal_description: RV64GCV
+          hal_refsi_soc: G1
+          hal_refsi_thread_mode: WI
+          debug_support: ON
+          offline_kernel_tests: ${{ inputs.cache_seed == 'true' && 'OFF' || 'ON' }} 

--- a/.github/actions/do_build_pr/run_ubuntu_gcc_x86_64_riscv_fp16_cl3_0/action.yml
+++ b/.github/actions/do_build_pr/run_ubuntu_gcc_x86_64_riscv_fp16_cl3_0/action.yml
@@ -1,0 +1,33 @@
+name: build_pr_ubuntu_gcc_x86_64_riscv_fp16_cl3-0
+description: Build pr ubuntu_gcc_x86_64_riscv_fp16_cl3-0
+
+inputs:
+  cache_seed:
+    type: boolean
+    default: false
+
+runs:
+  using: "composite"
+  steps:
+      - name: remove any old dirs
+        shell: bash  
+        run:
+          rm -rf build
+
+      - name: build ock
+        uses: ./.github/actions/do_build_ock
+        with:
+          build_targets: ${{ inputs.cache_seed == 'true' && 'UnitCL clc' || 'check-ock' }}
+          mux_targets_enable: riscv
+          mux_compilers_enable: riscv
+          riscv_enabled: ON
+          disable_unitcl_vecz_checks: ON
+          enable_rvv_scalable_vecz_check: ON
+          enable_rvv_scalable_vp_vecz_check: ON
+          host_enable_builtins: OFF
+          use_linker: gold
+          hal_description: RV64GCV_Zfh
+          hal_refsi_soc: G1
+          hal_refsi_thread_mode: WG
+          debug_support: ON
+          offline_kernel_tests: ${{ inputs.cache_seed == 'true' && 'OFF' || 'ON' }}        

--- a/.github/actions/do_build_pr/run_ubuntu_gcc_x86_64_riscv_fp16_cl3_0_unitcl_vecz/action.yml
+++ b/.github/actions/do_build_pr/run_ubuntu_gcc_x86_64_riscv_fp16_cl3_0_unitcl_vecz/action.yml
@@ -1,0 +1,31 @@
+name: build_pr_ubuntu_gcc_x86_64_riscv_fp16_cl3_0_unitcl_vecz
+description: Build pr ubuntu_gcc_x86_64_riscv_fp16_cl3_0_unitcl_vecz
+
+inputs:
+  cache_seed:
+    type: boolean
+    default: false
+
+runs:
+  using: "composite"
+  steps:
+      - name: remove any old dirs
+        shell: bash  
+        run:
+          rm -rf build
+
+      - name: build ock
+        uses: ./.github/actions/do_build_ock
+        with:
+          build_targets: ${{ inputs.cache_seed == 'true' && 'clc UnitCL' || 'check-ock-UnitCL-group-vecz' }}
+          mux_targets_enable: riscv
+          mux_compilers_enable: riscv
+          riscv_enabled: ON
+          enable_rvv_scalable_vecz_check: ON
+          enable_rvv_scalable_vp_vecz_check: ON
+          use_linker: gold
+          hal_description: RV64GCV_Zfh
+          hal_refsi_soc: G1
+          hal_refsi_thread_mode: WG
+          debug_support: ON
+          offline_kernel_tests: ${{ inputs.cache_seed == 'true' && 'OFF' || 'ON' }}

--- a/.github/actions/do_build_pr/run_ubuntu_gcc_x86_llvm_latest_x86_64_images_cl3_0_release/action.yml
+++ b/.github/actions/do_build_pr/run_ubuntu_gcc_x86_llvm_latest_x86_64_images_cl3_0_release/action.yml
@@ -1,0 +1,26 @@
+name: build_pr_ubuntu_gcc_x86_llvm_latest_x86_64_images_cl3_0_release
+description: Build pr ubuntu_gcc_x86_llvm_latest_x86_64_images_cl3_0_release
+
+inputs:
+  cache_seed:
+    type: boolean
+    default: false
+
+runs:
+  using: "composite"
+  steps:
+      - name: remove any old dirs
+        shell: bash  
+        run:
+          rm -rf build
+
+      - name: build ock
+        uses: ./.github/actions/do_build_ock
+        with:
+          build_type: Release
+          build_targets: ${{ inputs.cache_seed == 'true' && 'UnitCL clc' || 'check-ock' }}
+          host_image: ON
+          use_linker: gold
+          enable_api: ""
+          builtin_kernel: ON
+          offline_kernel_tests: ${{ inputs.cache_seed == 'true' && 'OFF' || 'ON' }}

--- a/.github/actions/do_build_pr/run_windows_msvc_x86_64_llvm_latest_cl3_0_offline/action.yml
+++ b/.github/actions/do_build_pr/run_windows_msvc_x86_64_llvm_latest_cl3_0_offline/action.yml
@@ -1,0 +1,43 @@
+name: build_pr_windows_msvc_x86_64_llvm_latest_cl3_0_offline
+description: Build pr windows_msvc_x86_64_llvm_latest_cl3_0_offline
+
+inputs:
+  cache_seed:
+    type: boolean
+    default: false
+  pull_request:
+    type: boolean
+    default: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: remove any old dirs
+      shell: bash  
+      run:
+        rm -rf build build_offline install_offline
+
+    - name: build ock x86_64
+      uses: ./.github/actions/do_build_ock
+      with:
+        build_targets: ${{ inputs.cache_seed == 'true' && 'UnitCL clc' || 'check-ock' }}
+        enable_api: ""
+        builtin_kernel: ON
+        shell_to_use: pwsh
+        gtest_launcher: "python3;-u;${{ github.workspace }}/scripts/gtest-terse-runner.py"
+        debug_support: ON
+        enable_unitcl_expensive: ${{ !inputs.is_pull_request && 'ON' || 'OFF' }}
+        offline_kernel_tests: ${{ inputs.cache_seed == 'true' && 'OFF' || 'ON' }}
+
+    - name: build ock x86_64 offline
+      uses: ./.github/actions/do_build_ock
+      with:
+        build_targets: ${{ inputs.cache_seed == 'true' && 'UnitCL' || 'check-ock' }}
+        runtime_compiler_enabled: OFF
+        external_clc: "${{ github.workspace }}/build/bin/clc.exe"
+        shell_to_use: pwsh
+        gtest_launcher: "python3;-u;${{ github.workspace }}/scripts/gtest-terse-runner.py"
+        debug_support: ON
+        install_dir: ${{ github.workspace }}/install_offline
+        build_dir: ${{ github.workspace }}/build_offline
+        offline_kernel_tests: ${{ inputs.cache_seed == 'true' && 'OFF' || 'ON' }}

--- a/.github/actions/setup_build/action.yml
+++ b/.github/actions/setup_build/action.yml
@@ -95,6 +95,6 @@ runs:
       uses: hendrikmuhs/ccache-action@53911442209d5c18de8a31615e0923161e435875 # v1.2.16
       with:
         max-size: 200M
-        key: ccache-build
+        key: ccache-build-${{ inputs.os }}
         variant: ccache
         save: ${{ inputs.save }}

--- a/.github/workflows/pr_tests_cache.yml
+++ b/.github/workflows/pr_tests_cache.yml
@@ -1,0 +1,228 @@
+name: Seed the cache for ock builds
+on:
+  # pull_request:
+  #   paths:
+  #     - '.github/workflows/pr_tests_cache.yml'
+  push:
+    branch: main
+    paths:    
+      - 'source/**'
+      - 'clik/**'
+      - 'modules/**'
+      - 'examples/**'
+      - 'cmake/**'
+      - 'hal/**'
+      - '.github/workflow/pr_tests_cache.yml'
+      - '.github/actions/do_build_ock/**'
+      - '.github/actions/setup_build/**'
+      - '.github/action/do_build_pr/**'
+      - 'CMakeLists.txt'
+
+  workflow_dispatch:
+
+env:
+  llvm_previous: '18'
+  llvm_current: '19'
+
+concurrency:
+  group: pr-test-cache-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  actions: write
+jobs:
+  ubuntu_22_llvm_prev_jobs:
+    if: github.repository == 'uxlfoundation/oneapi-construction-kit' || github.event_name != 'schedule'
+    runs-on: ubuntu-22.04
+    container:
+      image: ghcr.io/uxlfoundation/ock_ubuntu_22.04-x86-64:latest
+      volumes:
+        - ${{github.workspace}}:${{github.workspace}}    
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: setup ubuntu
+        uses: ./.github/actions/setup_build
+        with:
+          llvm_version: ${{ env.llvm_previous }}
+          llvm_build_type: RelAssert
+          save: true
+
+      - name: build host_x86_64
+        uses:  ./.github/actions/do_build_pr/run_host_x86_64
+        with:
+          cache_seed: true
+
+      - name: build riscv M1
+        uses: ./.github/actions/do_build_pr/run_riscv_m1
+        with:
+          cache_seed: true
+
+      - name: build ubuntu_gcc_x86_64_riscv_fp16_cl3_0_unitcl_vecz
+        uses: ./.github/actions/do_build_pr/run_ubuntu_gcc_x86_64_riscv_fp16_cl3_0_unitcl_vecz
+        with:
+          cache_seed: true
+
+  ubuntu_22_llvm_current_jobs:
+    if: github.repository == 'uxlfoundation/oneapi-construction-kit' || github.event_name != 'schedule'
+    needs: [ubuntu_22_llvm_prev_jobs]
+    runs-on: ubuntu-22.04
+    container:
+      image: ghcr.io/uxlfoundation/ock_ubuntu_22.04-x86-64:latest
+      volumes:
+        - ${{github.workspace}}:${{github.workspace}}    
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: setup-ubuntu
+        uses:  ./.github/actions/setup_build
+        with:
+          llvm_version: ${{ env.llvm_current }}
+          llvm_build_type: RelAssert
+          save: true
+
+      - name: build ubuntu_gcc_x86_64_riscv_fp16_cl3_0
+        uses: ./.github/actions/do_build_pr/run_ubuntu_gcc_x86_64_riscv_fp16_cl3_0
+        with:
+          cache_seed: true
+    
+      - name: build ubuntu_gcc_x86_llvm_latest_x86_64_images_cl3_0_release
+        uses: ./.github/actions/do_build_pr/run_ubuntu_gcc_x86_llvm_latest_x86_64_images_cl3_0_release
+        with:
+          cache_seed: true
+
+      - name: build ubuntu_gcc_x86_64_refsi_g1_wi_cl3_0
+        uses: ./.github/actions/do_build_pr/run_ubuntu_gcc_x86_64_refsi_g1_wi_cl3_0          
+        with:
+          cache_seed: true
+
+  # 32 bit x86
+  ubuntu_22_llvm_current_x86_jobs:
+    if: github.repository == 'uxlfoundation/oneapi-construction-kit' || github.event_name != 'schedule'
+    needs: [ubuntu_22_llvm_current_jobs]  
+    runs-on: ubuntu-22.04
+    container:
+      image: ghcr.io/uxlfoundation/ock_ubuntu_22.04-x86-64:latest
+      volumes:
+        - ${{github.workspace}}:${{github.workspace}}    
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      # installs tools, ninja, installs llvm and sets up sccache
+      - name: setup-ubuntu
+        uses:  ./.github/actions/setup_build
+        with:
+          llvm_version: ${{ env.llvm_current }}
+          llvm_build_type: RelAssert
+          save: true
+          cross_arch: x86
+
+      - name: build ubuntu_clang_x86_llvm_latest_cl3_0_offline
+        uses: ./.github/actions/do_build_pr/run_ubuntu_clang_x86_llvm_latest_cl3_0_offline
+        with:
+          cache_seed: true
+
+  # aarch 64
+  ubuntu_22_llvm_current_aarch64_jobs:
+    if: github.repository == 'uxlfoundation/oneapi-construction-kit' || github.event_name != 'schedule'
+    needs: [ubuntu_22_llvm_current_x86_jobs]  
+    runs-on: ubuntu-22.04
+    container:
+      image: ghcr.io/uxlfoundation/ock_ubuntu_22.04-x86-64:latest
+      volumes:
+        - ${{github.workspace}}:${{github.workspace}}    
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+        # installs tools, ninja, installs llvm and sets up sccache
+      - name: setup-ubuntu
+        uses: ./.github/actions/setup_build
+        with:
+          llvm_version: ${{ env.llvm_current }}
+          llvm_build_type: RelAssert
+          save: true
+          cross_arch: aarch64
+
+      - name: build ubuntu_gcc_aarch64_llvm_latest_cl3_0_fp16
+        uses: ./.github/actions/do_build_pr/run_ubuntu_gcc_aarch64_llvm_latest_cl3_0_fp16
+        with:
+          cache_seed: true
+
+  windows_llvm_current_jobs:
+    if: github.repository == 'uxlfoundation/oneapi-construction-kit' || github.event_name != 'schedule'
+    needs: [ubuntu_22_llvm_current_aarch64_jobs]    
+    runs-on: windows-2019
+    steps:    
+      - name: Setup Windows llvm base
+        uses: llvm/actions/setup-windows@main
+        with:
+          arch: amd64
+
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      # installs tools, ninja, installs llvm and sets up ccache
+      - name: setup-windows
+        uses:  ./.github/actions/setup_build
+        with:
+          llvm_version: ${{ env.llvm_current }}
+          llvm_build_type: RelAssert
+          save: true
+          os: windows
+      - name: build windows_msvc_x86_64_llvm_latest_cl3_0_offline
+        uses: ./.github/actions/do_build_pr/run_windows_msvc_x86_64_llvm_latest_cl3_0_offline
+        with:
+          cache_seed: true
+
+
+  # The following tries to delete old caches but fails on the branch due to permissions errors
+  # Look to uncomment in the future.
+
+  # clean_cache:
+  #  if: github.repository == 'uxlfoundation/oneapi-construction-kit' || github.event_name != 'schedule'
+  #   name: Cache clean
+  #   needs: [windows_llvm_current_jobs]
+  #   runs-on: ubuntu-latest
+  #   permissions:
+  #     actions: write
+  #   steps:
+  #     - name: Checkout repo
+  #       uses: actions/checkout@v4
+  #       with:
+  #         sparse-checkout: .github
+  #     - name: Cache clean
+  #       env:
+  #         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  #         # Define unique cache prefixes for deletion
+  #         CACHE_PREFIX_LIST: "ccache-ccache-build-ubuntu ccache-ccache-build-windows"
+  #       run: |
+  #         set -x
+  #         echo Cache branch name is ${{ github.ref }}
+  #         # Define args for gh cache commands
+  #         GH_LIST_ARGS="-r ${{ github.ref }} -L 100 --order desc --sort created-at"
+  #         echo CACHE PREFIXES FOR CLEANING ... $CACHE_PREFIX_LIST_UBUNTU $CACHE_PREFIX_LIST_WINDOWS
+  #         # Generate current cache list for ${{ github.ref_name }}, newest first (note: 100 cache entries is gh maximum)
+  #         echo CACHE LIST BEFORE ...
+  #         gh cache list $GH_LIST_ARGS | tee CACHE_LIST
+  #         echo > CCACHE_LIST
+
+
+  #         # Generate corresponding list of cache keys for deletion - retain only the newest key for each prefix
+  #         for CACHE_PREFIX in $CACHE_PREFIX_LIST
+  #         do
+  #           grep -E -o "^${CACHE_PREFIX}[^[:space:]]+" CACHE_LIST | sed '1d' >> CCACHE_LIST
+  #         done
+
+  #         cat CCACHE_LIST
+
+  #         DELETE_LIST=$(cat CCACHE_LIST)
+  #         echo Ubuntu Delete List is $DELETE_LIST, Delete Args = $GH_DELETE_ARGS_KEY
+  #         for KEY in $DELETE_LIST ; do  gh cache delete $KEY ; done
+
+  #         # Generate post-clean list
+  #         echo CACHE LIST AFTER ...
+  #         gh cache list $GH_LIST_ARGS

--- a/.github/workflows/run_pr_tests.yml
+++ b/.github/workflows/run_pr_tests.yml
@@ -3,10 +3,6 @@ name: Run ock tests for PR testing
 on:
   workflow_call:
     inputs:
-      update_cache:
-        required: false
-        type: boolean
-        default: false
       is_pull_request:
         required: false
         type: boolean
@@ -15,10 +11,6 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
     inputs:
-      update_cache:
-        required: false
-        type: boolean
-        default: false
       is_pull_request:
         required: false
         type: bool
@@ -46,13 +38,9 @@ jobs:
         with:
           llvm_version: 18
           llvm_build_type: RelAssert
-          save:  ${{ inputs.update_cache }}
 
-      # These need to match the configurations of build_pr_cache to use the cache effectively
-      - name: build host x86_64 online release
-        uses: ./.github/actions/do_build_ock
-        with:
-          build_type: Release
+      - name: build
+        uses:  ./.github/actions/do_build_pr/run_host_x86_64
 
       - name: run just online lit
         run:
@@ -61,16 +49,6 @@ jobs:
       - name: run host online check
         run:
           ninja -C build check-ock-UnitCL
-
-      # use the previous build for online to get clc
-      - name: build host x86_64 offline release
-        uses: ./.github/actions/do_build_ock
-        with:
-          build_type: Release
-          extra_flags: -DCA_RUNTIME_COMPILER_ENABLED=OFF -DCA_EXTERNAL_CLC=${{ github.workspace }}/build/bin/clc
-          build_dir: build_offline
-          build_targets: UnitCL
-          assemble_spirv_ll_lit_test_offline: ON
 
       - name: run host x86_64 offline
         run:
@@ -94,10 +72,9 @@ jobs:
         with:
           llvm_version: 18
           llvm_build_type: RelAssert
-          save:  ${{ inputs.update_cache }}
 
       - name: build riscv M1
-        uses: ./.github/actions/do_build_ock/do_build_m1
+        uses: ./.github/actions/do_build_pr/run_riscv_m1
 
       - name: run riscv M1 lit
         run:
@@ -191,35 +168,16 @@ jobs:
 
       # installs tools, ninja, installs llvm and sets up ccache
       - name: setup-windows
-        uses:  ./.github/actions/setup_build
+        uses: ./.github/actions/setup_build
         with:
           llvm_version: 19
           llvm_build_type: RelAssert
-          save:  ${{ inputs.update_cache }}
           os: windows
 
-      - name: build ock x86_64 relassert
-        uses: ./.github/actions/do_build_ock
+      - name: build and test ock
+        uses: ./.github/actions/do_build_pr/run_windows_msvc_x86_64_llvm_latest_cl3_0_offline
         with:
-          build_targets: check-ock
-          enable_api: ""
-          builtin_kernel: ON
-          shell_to_use: pwsh
-          gtest_launcher: "python3;-u;${{ github.workspace }}/scripts/gtest-terse-runner.py"
-          debug_support: ON
-          enable_unitcl_expensive: ${{ !inputs.is_pull_request && 'ON' || 'OFF' }}
-
-      - name: build ock x86_64 offline
-        uses: ./.github/actions/do_build_ock
-        with:
-          build_targets: check-ock
-          runtime_compiler_enabled: OFF
-          external_clc: "${{ github.workspace }}/build/bin/clc.exe"
-          shell_to_use: pwsh
-          gtest_launcher: "python3;-u;${{ github.workspace }}/scripts/gtest-terse-runner.py"
-          debug_support: ON
-          install_dir: ${{ github.workspace }}/install_offline
-          build_dir: ${{ github.workspace }}/build_offline
+          is_pull_request: inputs.is_pull_request
 
   # Based on: mr-ubuntu-gcc-x86_64-riscv-fp16-cl3.0-unitcl_vecz
   run_ubuntu_gcc_x86_64_riscv_fp16_cl3_0_unitcl_vecz:
@@ -237,22 +195,8 @@ jobs:
       with:
         llvm_version: '18'
         llvm_build_type: RelAssert
-        save:  ${{ inputs.update_cache }}
-    - run: echo WORKSPACE is $GITHUB_WORKSPACE && echo PWD is `pwd` && ls -al
     - name: build ock
-      uses: ./.github/actions/do_build_ock
-      with:
-        build_targets: check-ock-UnitCL-group-vecz
-        mux_targets_enable: riscv
-        mux_compilers_enable: riscv
-        riscv_enabled: ON
-        enable_rvv_scalable_vecz_check: ON
-        enable_rvv_scalable_vp_vecz_check: ON
-        use_linker: gold
-        hal_description: RV64GCV_Zfh
-        hal_refsi_soc: G1
-        hal_refsi_thread_mode: WG
-        debug_support: ON
+      uses: ./.github/actions/do_build_pr/run_ubuntu_gcc_x86_64_riscv_fp16_cl3_0_unitcl_vecz
 
   # Based on: mr-ubuntu-clang-x86-llvm-previous-cl3-0-offline
   run-ubuntu-clang-x86-llvm-latest-cl3-0-offline:
@@ -270,32 +214,9 @@ jobs:
       with:
         llvm_version: '19'
         llvm_build_type: RelAssert
-        save:  ${{ inputs.update_cache }}
         cross_arch: x86
-    - run: echo WORKSPACE is $GITHUB_WORKSPACE && echo PWD is `pwd` && ls -al
-    - name: build ock x86 relassert
-      uses: ./.github/actions/do_build_ock
-      with:
-        build_32_bit: ON
-        extra_flags: -DCMAKE_C_COMPILER=$GITHUB_WORKSPACE/llvm_install/bin/clang -DCMAKE_CXX_COMPILER=$GITHUB_WORKSPACE/llvm_install/bin/clang++
-        build_targets: check-ock
-        enable_api: ""
-        builtin_kernel: ON
-        use_linker: gold
-        debug_support: ON
-    - name: build ock x86 offline
-      uses: ./.github/actions/do_build_ock
-      with:
-        build_32_bit: ON
-        extra_flags: -DCMAKE_C_COMPILER=$GITHUB_WORKSPACE/llvm_install/bin/clang -DCMAKE_CXX_COMPILER=$GITHUB_WORKSPACE/llvm_install/bin/clang++
-        build_targets: check-ock
-        runtime_compiler_enabled: OFF
-        assemble_spirv_ll_lit_test_offline: ON
-        external_clc: ${GITHUB_WORKSPACE}/build/bin/clc
-        use_linker: gold
-        debug_support: ON
-        install_dir: $GITHUB_WORKSPACE/install_offline
-        build_dir: $GITHUB_WORKSPACE/build_offline
+    - name: build and run ock
+      uses: ./.github/actions/do_build_pr/run_ubuntu_clang_x86_llvm_latest_cl3_0_offline
 
   # Based on: mr-ubuntu-gcc-x86_64-riscv-fp16-cl3-0
   run-ubuntu-gcc-x86_64-riscv-fp16-cl3-0:
@@ -313,24 +234,8 @@ jobs:
       with:
         llvm_version: '19'
         llvm_build_type: RelAssert
-        save:  ${{ inputs.update_cache }}
-    - run: echo WORKSPACE is $GITHUB_WORKSPACE && echo PWD is `pwd` && ls -al
-    - name: build ock
-      uses: ./.github/actions/do_build_ock
-      with:
-        build_targets: check-ock
-        mux_targets_enable: riscv
-        mux_compilers_enable: riscv
-        riscv_enabled: ON
-        disable_unitcl_vecz_checks: ON
-        enable_rvv_scalable_vecz_check: ON
-        enable_rvv_scalable_vp_vecz_check: ON
-        host_enable_builtins: OFF
-        use_linker: gold
-        hal_description: RV64GCV_Zfh
-        hal_refsi_soc: G1
-        hal_refsi_thread_mode: WG
-        debug_support: ON
+    - name: build and run ock
+      uses: ./.github/actions/do_build_pr/run_ubuntu_gcc_x86_64_riscv_fp16_cl3_0
 
   # Based on: mr-ubuntu-gcc-x86-llvm-latest-x86_64-images-cl3-0-release
   run-ubuntu-gcc-x86-llvm-latest-x86_64-images-cl3-0-release:
@@ -348,17 +253,8 @@ jobs:
       with:
         llvm_version: '19'
         llvm_build_type: Release
-        save:  ${{ inputs.update_cache }}
-    - run: echo WORKSPACE is $GITHUB_WORKSPACE && echo PWD is `pwd` && ls -al
-    - name: build ock
-      uses: ./.github/actions/do_build_ock
-      with:
-        build_type: Release
-        build_targets: check-ock
-        host_image: ON
-        use_linker: gold
-        enable_api: ""
-        builtin_kernel: ON
+    - name: build and run ock
+      uses: ./.github/actions/do_build_pr/run_ubuntu_gcc_x86_llvm_latest_x86_64_images_cl3_0_release
 
   # Based on: mr-ubuntu-gcc-aarch64-llvm-previous-cl3-0-fp16
   run-ubuntu-gcc-aarch64-llvm-latest-cl3-0-fp16:
@@ -376,20 +272,9 @@ jobs:
       with:
         llvm_version: '19'
         llvm_build_type: RelAssert
-        save:  ${{ inputs.update_cache }}
         cross_arch: aarch64
-    - run: echo WORKSPACE is $GITHUB_WORKSPACE && echo PWD is `pwd` && ls -al
-    - name: build ock
-      uses: ./.github/actions/do_build_ock
-      with:
-        build_targets: check-ock-cross
-        host_fp16: ON
-        use_linker: gold
-        debug_support: ON
-        builtin_kernel: ON
-        enable_api: ""
-        toolchain_file: "scripts/../platform/arm-linux/aarch64-toolchain.cmake"
-        extra_flags: -DCA_BUILTINS_TOOLS_DIR=${{ github.workspace }}/llvm_install_native/bin
+    - name: build and run ock      
+      uses: ./.github/actions/do_build_pr/run_ubuntu_gcc_aarch64_llvm_latest_cl3_0_fp16
 
   # Based on a combination of: mr-ubuntu-gcc-x86_64-clik
   #                       and: mr-ubuntu-gcc-x86_64-clik-refsi
@@ -432,24 +317,9 @@ jobs:
       with:
         llvm_version: '19'
         llvm_build_type: RelAssert
-        save:  ${{ inputs.update_cache }}
-    - run: echo WORKSPACE is $GITHUB_WORKSPACE && echo PWD is `pwd` && ls -al
     - name: build ock
-      uses: ./.github/actions/do_build_ock
-      with:
-        build_targets: install # Build the install target so we don't miss compilation errors
-        mux_targets_enable: riscv
-        external_compiler_dirs: ${{ github.workspace }}/examples/refsi/refsi_g1_wi/compiler/refsi_g1_wi
-        mux_compilers_enable: refsi_g1_wi
-        riscv_enabled: ON
-        disable_unitcl_vecz_checks: ON
-        enable_rvv_scalable_vecz_check: ON
-        enable_rvv_scalable_vp_vecz_check: ON
-        use_linker: gold
-        hal_description: RV64GCV
-        hal_refsi_soc: G1
-        hal_refsi_thread_mode: WI
-        debug_support: ON
+      uses: ./.github/actions/do_build_pr/run_ubuntu_gcc_x86_64_refsi_g1_wi_cl3_0
+
     # For now DO NOT include run_cities.py testing. Run commands generated by the import tool are:
     #- run: python3 -u scripts/storage.py pull artefact.ca-opencl-cts --verbose --clean --path CA-OpenCL-CTS Ubuntu20 x86_64 14 Release
     #- run: echo 'Subgroups,subgroups/test_subgroups barrier_functions_core' >> skipped.txt

--- a/.github/workflows/run_pr_tests_caller.yml
+++ b/.github/workflows/run_pr_tests_caller.yml
@@ -28,7 +28,6 @@ jobs:
     if: ${{ (github.event_name == 'schedule' && github.repository == 'uxlfoundation/oneapi-construction-kit') || github.event_name == 'pull_request' }}
     uses: ./.github/workflows/run_pr_tests.yml
     with:
-      update_cache: ${{ github.event_name == 'schedule' }}
       is_pull_request:  ${{ github.event_name != 'schedule' }}
 
 # additional ones here for cron and/or push to main - also can be in different file.


### PR DESCRIPTION
# Overview

Switch to calling an action for PR tests and populate the cache sequentially

# Reason for change

There was a race condition in updating the cache as it just ran the tests overnight in parallel. 

# Description of change

Move all the build parts of PR jobs to an action. Add a workflow pr_tests_cache.yml to seed the caches by calling the actions in sequence. The scheduled run_pr_tests overnight will no longer have the ability to seed the cache and this will only be done via pr_tests_cache.yml.

# Anything else we should know?

This does not yet delete the caches. We can't be sure this works so this is initially commented out.

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-19](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
