### PR TITLE
Fix image organisation for aarch64

### DIFF
--- a/.github/workflows/planned_testing.yml
+++ b/.github/workflows/planned_testing.yml
@@ -195,7 +195,7 @@ jobs:
     runs-on: ${{ contains(matrix.target, 'host_aarch64') && 'cp-graviton' || 'cp-ubuntu-24.04' }}
     container:
       image: ${{  contains(matrix.target, 'host_riscv')   && 'ghcr.io/uxlfoundation/ock_ubuntu_24.04-x86-64:latest'
-             || ( contains(matrix.target, 'host_aarch64') && 'ghcr.io/alan-forbes-cp/ock_ubuntu_22.04-aarch64:latest'
+             || ( contains(matrix.target, 'host_aarch64') && 'ghcr.io/uxlfoundation/ock_ubuntu_22.04-aarch64:latest'
              || 'ghcr.io/uxlfoundation/ock_ubuntu_22.04-x86-64:latest' ) }}
       volumes:
         - ${{github.workspace}}:${{github.workspace}}


### PR DESCRIPTION
# Overview

Fix incorrect image organisation spec for aarch64 OpenCL CTS runs
 
# Reason for change

Organisation is wrong - mistakenly points to dev account

# Description of change

Point to uxlfoundation which now houses the image concerned. By chance the incorrect image currently has the correct content so workflows will pass, but its clearly wrong.
