### PR TITLE
Update for LLVM 20, 21.

### DIFF
--- a/modules/compiler/compiler_pipeline/source/barrier_regions.cpp
+++ b/modules/compiler/compiler_pipeline/source/barrier_regions.cpp
@@ -1151,9 +1151,9 @@ Function *compiler::utils::Barrier::GenerateNewKernel(BarrierRegion &region) {
         // multiple return instructions in a kernel, if it does then clone
         // the instruction first.
         if (nullptr == entry_call->getParent()) {
-          entry_call->insertBefore(new_ret);
+          entry_call->insertBefore(new_ret->getIterator());
         } else {
-          entry_call->clone()->insertBefore(new_ret);
+          entry_call->clone()->insertBefore(new_ret->getIterator());
         }
       }
     } else if (ReturnInst *ret =

--- a/modules/compiler/compiler_pipeline/source/pass_functions.cpp
+++ b/modules/compiler/compiler_pipeline/source/pass_functions.cpp
@@ -208,7 +208,7 @@ void replaceConstantExpressionWithInstruction(llvm::Constant *const constant) {
             llvm::dyn_cast<llvm::ConstantExpr>(constant)) {
       newInst = constantExpr->getAsInstruction();
       // insert the instruction at the beginning of the entry block
-      newInst->insertBefore(useFunc->getEntryBlock().getFirstNonPHI());
+      newInst->insertBefore(useFunc->getEntryBlock().getFirstNonPHIIt());
     } else if (llvm::ConstantVector *constantVec =
                    llvm::dyn_cast<llvm::ConstantVector>(constant)) {
       // If it is a ConstantVector then only handle the case where it is
@@ -226,7 +226,7 @@ void replaceConstantExpressionWithInstruction(llvm::Constant *const constant) {
       llvm::Type *i32Ty = llvm::Type::getInt32Ty(constant->getContext());
       auto insert = llvm::InsertElementInst::Create(
           undef, splatVal, llvm::ConstantInt::get(i32Ty, 0));
-      insert->insertBefore(useFunc->getEntryBlock().getFirstNonPHI());
+      insert->insertBefore(useFunc->getEntryBlock().getFirstNonPHIIt());
       llvm::Value *zeros = llvm::ConstantAggregateZero::get(
           llvm::FixedVectorType::get(i32Ty, numEls));
       newInst = new llvm::ShuffleVectorInst(insert, undef, zeros);
@@ -242,7 +242,7 @@ void replaceConstantExpressionWithInstruction(llvm::Constant *const constant) {
         if (insertedIns) {
           insertNext->insertAfter(insertedIns);
         } else {
-          insertNext->insertBefore(useFunc->getEntryBlock().getFirstNonPHI());
+          insertNext->insertBefore(useFunc->getEntryBlock().getFirstNonPHIIt());
         }
         insertedIns = insertNext;
       }

--- a/modules/compiler/multi_llvm/include/multi_llvm/dibuilder.h
+++ b/modules/compiler/multi_llvm/include/multi_llvm/dibuilder.h
@@ -1,0 +1,108 @@
+// Copyright (C) Codeplay Software Limited
+//
+// Licensed under the Apache License, Version 2.0 (the "License") with LLVM
+// Exceptions; you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/LICENSE.txt
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef MULTI_LLVM_DIBUILDER_H_INCLUDED
+#define MULTI_LLVM_DIBUILDER_H_INCLUDED
+
+#include <llvm/IR/DIBuilder.h>
+#include <multi_llvm/llvm_version.h>
+
+#include <type_traits>
+
+namespace multi_llvm {
+// TODO In order to enable the use of OCK in DPC++ which currently uses the
+// older DIBuilder interface, we do not yet condition this on LLVM version, we
+// dynamically detect which version of DIBuilder we have. This should be updated
+// after DPC++'s next pulldown to drop the use of DIBuilderWrapperNeeded and
+// base it entirely on LLVM major version.
+#if LLVM_VERSION_GREATER_EQUAL(20, 0) && 0
+using DIBuilder = llvm::DIBuilder;
+#else
+template <typename DIBuilder>
+struct DIBuilderWrapper : DIBuilder {
+  using DIBuilder::DIBuilder;
+
+#if LLVM_VERSION_GREATER_EQUAL(19, 0)
+  llvm::BasicBlock *getBasicBlock(llvm::InsertPosition InsertPt) {
+    return InsertPt.getBasicBlock();
+  }
+#else
+  llvm::BasicBlock *getBasicBlock(llvm::BasicBlock::iterator InsertPt) {
+    // Cannot handle sentinels.
+    return InsertPt->getParent();
+  }
+#endif
+
+  auto insertDeclare(llvm::Value *Storage, llvm::DILocalVariable *VarInfo,
+                     llvm::DIExpression *Expr, const llvm::DILocation *DL,
+                     llvm::BasicBlock *InsertAtEnd) {
+    return DIBuilder::insertDeclare(Storage, VarInfo, Expr, DL, InsertAtEnd);
+  }
+
+  auto insertDeclare(llvm::Value *Storage, llvm::DILocalVariable *VarInfo,
+                     llvm::DIExpression *Expr, const llvm::DILocation *DL,
+                     llvm::BasicBlock::iterator InsertPt) {
+    auto *InsertBB = getBasicBlock(InsertPt);
+    if (InsertPt == InsertBB->end()) {
+      return DIBuilder::insertDeclare(Storage, VarInfo, Expr, DL, InsertBB);
+    } else {
+      return DIBuilder::insertDeclare(Storage, VarInfo, Expr, DL, &*InsertPt);
+    }
+  }
+
+  auto insertDbgValueIntrinsic(llvm::Value *Val, llvm::DILocalVariable *VarInfo,
+                               llvm::DIExpression *Expr,
+                               const llvm::DILocation *DL,
+                               llvm::BasicBlock *InsertAtEnd) {
+    return DIBuilder::insertDbgValueIntrinsic(Val, VarInfo, Expr, DL,
+                                              InsertAtEnd);
+  }
+
+  auto insertDbgValueIntrinsic(llvm::Value *Val, llvm::DILocalVariable *VarInfo,
+                               llvm::DIExpression *Expr,
+                               const llvm::DILocation *DL,
+                               llvm::BasicBlock::iterator InsertPt) {
+    auto *InsertBB = getBasicBlock(InsertPt);
+    if (InsertPt == InsertBB->end()) {
+      return DIBuilder::insertDbgValueIntrinsic(Val, VarInfo, Expr, DL,
+                                                InsertBB);
+    } else {
+      return DIBuilder::insertDbgValueIntrinsic(Val, VarInfo, Expr, DL,
+                                                &*InsertPt);
+    }
+  }
+};
+
+template <typename DIBuilder, typename = void>
+static constexpr bool DIBuilderWrapperNeeded = true;
+
+template <typename DIBuilder>
+static constexpr bool DIBuilderWrapperNeeded<
+    DIBuilder, std::void_t<decltype(std::declval<DIBuilder &>().insertLabel(
+                   std::declval<llvm::DILabel *>(),
+                   std::declval<const llvm::DILocation *>(),
+                   std::declval<llvm::BasicBlock::iterator>()))>> = false;
+
+template <typename DIBuilder>
+using DIBuilderMaybeWrapped =
+    std::conditional_t<DIBuilderWrapperNeeded<DIBuilder>,
+                       DIBuilderWrapper<DIBuilder>, DIBuilder>;
+
+using DIBuilder = DIBuilderMaybeWrapped<llvm::DIBuilder>;
+#endif
+}  // namespace multi_llvm
+
+#endif  // MULTI_LLVM_DIBUILDER_H_INCLUDED

--- a/modules/compiler/spirv-ll/include/spirv-ll/builder.h
+++ b/modules/compiler/spirv-ll/include/spirv-ll/builder.h
@@ -20,10 +20,10 @@
 #define SPIRV_LL_SPV_BUILDER_H_INCLUDED
 
 #include <llvm/ADT/StringSwitch.h>
-#include <llvm/IR/DIBuilder.h>
 #include <llvm/IR/DebugInfoMetadata.h>
 #include <llvm/IR/IRBuilder.h>
 #include <llvm/IR/Metadata.h>
+#include <multi_llvm/dibuilder.h>
 #include <multi_llvm/multi_llvm.h>
 #include <multi_llvm/vector_type_helper.h>
 #include <spirv-ll/context.h>
@@ -816,7 +816,7 @@ class Builder {
   /// @brief The IRBuilder used to generate the LLVM IR
   llvm::IRBuilder<> IRBuilder;
   /// @brief The DIBuilder used to generate the LLVM IR debug instructions
-  llvm::DIBuilder DIBuilder;
+  multi_llvm::DIBuilder DIBuilder;
   /// @brief Function the builder is currently working on
   llvm::Function *CurrentFunction;
   /// @brief A copy of the current function's argument list

--- a/modules/compiler/spirv-ll/include/spirv-ll/builder_debug_info.h
+++ b/modules/compiler/spirv-ll/include/spirv-ll/builder_debug_info.h
@@ -53,7 +53,7 @@ class DebugInfoBuilder : public ExtInstSetHandler {
   uint64_t workarounds = 0;
   /// @brief Map from DebugInfo instructions to the llvm::DIBuilder that builds
   /// them.
-  std::unordered_map<spv::Id, std::unique_ptr<llvm::DIBuilder>>
+  std::unordered_map<spv::Id, std::unique_ptr<multi_llvm::DIBuilder>>
       debug_builder_map;
 
   /// @brief Cache of translated DebugInfo instructions.
@@ -74,13 +74,13 @@ class DebugInfoBuilder : public ExtInstSetHandler {
   /// We may only have one DICompileUnit per DIBuilder, so must support
   /// multiple builders. This function finds the DIBuilder for the instruction
   /// based on its chain of scopes, if applicable.
-  llvm::DIBuilder &getDIBuilder(const OpExtInst *op) const;
+  multi_llvm::DIBuilder &getDIBuilder(const OpExtInst *op) const;
 
   /// @brief Returns the first registered DIBuilder, for when it doesn't matter
   /// which is used.
   ///
   /// @see getDIBuilder
-  llvm::DIBuilder &getDefaultDIBuilder() const;
+  multi_llvm::DIBuilder &getDefaultDIBuilder() const;
 
   /// @brief Returns true if the given ID is DebugInfoNone.
   bool isDebugInfoNone(spv::Id id) const;

--- a/modules/compiler/spirv-ll/source/builder.cpp
+++ b/modules/compiler/spirv-ll/source/builder.cpp
@@ -558,7 +558,8 @@ void spirv_ll::Builder::replaceBuiltinGlobals() {
         if (!llvm::isa<llvm::AllocaInst>(Inst)) {
           break;
         }
-        Inst.moveBefore(new_builtin_var);
+        Inst.moveBefore(*new_builtin_var->getParent(),
+                        new_builtin_var->getIterator());
       }
 
       for (llvm::User *user : user_function.second) {

--- a/modules/compiler/spirv-ll/source/builder_debug_info.cpp
+++ b/modules/compiler/spirv-ll/source/builder_debug_info.cpp
@@ -301,7 +301,7 @@ bool DebugInfoBuilder::isDebugInfoSet(uint32_t set_id) const {
          set == ExtendedInstrSet::OpenCLDebugInfo100;
 }
 
-llvm::DIBuilder &DebugInfoBuilder::getDefaultDIBuilder() const {
+multi_llvm::DIBuilder &DebugInfoBuilder::getDefaultDIBuilder() const {
   assert(debug_builder_map.size() != 0 && "No DIBuilders");
   return *debug_builder_map.begin()->second;
 }
@@ -1928,7 +1928,7 @@ llvm::Error DebugInfoBuilder::create<DebugDeclare>(const OpExtInst &opc) {
         /*Storage*/ variable, di_local, di_expr, di_loc, insert_bb);
   } else {
     dbg_declare = getDIBuilder(op).insertDeclare(
-        /*Storage*/ variable, di_local, di_expr, di_loc, &*insert_pt);
+        /*Storage*/ variable, di_local, di_expr, di_loc, insert_pt);
   }
 
 #if LLVM_VERSION_GREATER_EQUAL(19, 0)
@@ -2004,7 +2004,7 @@ llvm::Error DebugInfoBuilder::create<DebugValue>(const OpExtInst &opc) {
         variable, di_local, di_expr, di_loc, insert_bb);
   } else {
     dbg_value = getDIBuilder(op).insertDbgValueIntrinsic(
-        variable, di_local, di_expr, di_loc, &*insert_pt);
+        variable, di_local, di_expr, di_loc, insert_pt);
   }
 
 #if LLVM_VERSION_GREATER_EQUAL(19, 0)
@@ -2364,7 +2364,7 @@ llvm::Error DebugInfoBuilder::create(const OpExtInst &opc) {
     CREATE_CASE(OpenCLDebugInfo100DebugImportedEntity, DebugImportedEntity)
     case OpenCLDebugInfo100Instructions::OpenCLDebugInfo100DebugCompilationUnit:
       debug_builder_map[opc.IdResult()] =
-          std::make_unique<llvm::DIBuilder>(*module.llvmModule);
+          std::make_unique<multi_llvm::DIBuilder>(*module.llvmModule);
       break;
     case OpenCLDebugInfo100Instructions::OpenCLDebugInfo100DebugFunction: {
       // Translate and register the DISubprogram for the function.
@@ -2404,9 +2404,10 @@ llvm::Error DebugInfoBuilder::create(const OpExtInst &opc) {
   return llvm::Error::success();
 }
 
-llvm::DIBuilder &DebugInfoBuilder::getDIBuilder(const OpExtInst *op) const {
+multi_llvm::DIBuilder &DebugInfoBuilder::getDIBuilder(
+    const OpExtInst *op) const {
   assert(debug_builder_map.size() != 0 && "No DIBuilders");
-  llvm::DIBuilder &default_dib = getDefaultDIBuilder();
+  multi_llvm::DIBuilder &default_dib = getDefaultDIBuilder();
 
   assert(isDebugInfoSet(op->Set()) && "Unexpected extended instruction set");
 

--- a/modules/compiler/vecz/source/transform/instantiation_pass.cpp
+++ b/modules/compiler/vecz/source/transform/instantiation_pass.cpp
@@ -282,7 +282,7 @@ PacketRange InstantiationPass::instantiateByCloning(Instruction *I) {
       continue;
     }
     Instruction *Clone = I->clone();
-    Clone->insertBefore(I);
+    Clone->insertBefore(I->getIterator());
     P[i] = Clone;
     Clones.push_back(Clone);
   }

--- a/modules/compiler/vecz/source/transform/pre_linearize_pass.cpp
+++ b/modules/compiler/vecz/source/transform/pre_linearize_pass.cpp
@@ -138,7 +138,7 @@ bool hoistInstructions(BasicBlock &BB, BranchInst &Branch, bool exceptions) {
   bool modified = false;
   while (!BB.front().isTerminator()) {
     auto &I = BB.front();
-    I.moveBefore(&Branch);
+    I.moveBefore(*Branch.getParent(), Branch.getIterator());
     modified = true;
 
     if (!exceptions) {


### PR DESCRIPTION
# Overview

Update for LLVM 20, 21.

# Reason for change

More functions have had their overloads taking Instruction * deprecated in favour of using iterators to mark insertion points.

# Description of change

Make the suggested changes.

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-19](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
