### PR TITLE
Docker changes for aarch64 (graviton)

### DIFF
--- a/.github/dockerfiles/Dockerfile_22.04-aarch64
+++ b/.github/dockerfiles/Dockerfile_22.04-aarch64
@@ -7,3 +7,5 @@ RUN apt-get install --yes cmake
 RUN apt-get install --yes gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
 RUN apt-get install --yes python3 python3-pip
 RUN apt-get install --yes spirv-tools
+RUN apt-get install --yes zstd
+RUN apt-get -y install gh


### PR DESCRIPTION
# Overview

Changes for aarch64 dockerfile

# Reason for change

Changes made to build/run SYCL CTS on graviton (aarch64)

# Description of change

Additions as required.

# Anything else we should know?

This is a companion prerequisite PR to: https://github.com/uxlfoundation/oneapi-construction-kit/pull/681
... which is on-going. No further updates should be needed here.
