### PR TITLE
Add a workflow to tidy up cache entries

### DIFF
--- a/.github/workflows/delete_cache_entries.yml
+++ b/.github/workflows/delete_cache_entries.yml
@@ -1,0 +1,64 @@
+# Workflow for deleting ccache entries
+# If this works try to extend the pr_tests_cache.yml rather than doing it here
+name: Run planned testing
+on:
+  # Note: use pull_request: for localized testing only
+  pull_request:
+    paths:
+      - '.github/workflows/delete_cache_entries.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/delete_cache_entries.yml'
+  schedule:
+    # Run Mon-Fri at 6pm
+    - cron: '00 18 * * 1-5'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  clean_up_pr_caches:
+    if: github.repository == 'uxlfoundation/oneapi-construction-kit'
+    name: Cache clean
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: .github
+      - name: Cache clean
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Define unique cache prefixes for deletion
+          CACHE_PREFIX_LIST: "ccache-ccache-build-ubuntu ccache-ccache-build-windows"
+        run: |
+          set -x
+          echo Cache branch name is main
+          # Define args for gh cache commands
+          GH_LIST_ARGS="-r refs/heads/main -L 100 --order desc --sort created_at"
+          echo CACHE PREFIXES FOR CLEANING ... $CACHE_PREFIX_LIST_UBUNTU $CACHE_PREFIX_LIST_WINDOWS
+          # Generate current cache list for main, newest first (note: 100 cache entries is gh maximum)
+          echo CACHE LIST BEFORE ...
+          gh cache list $GH_LIST_ARGS | tee CACHE_LIST
+
+          # Generate corresponding list of cache keys for deletion - retain only the newest key for each prefix
+          # key is first argument
+          for CACHE_PREFIX in $CACHE_PREFIX_LIST
+          do
+            grep -E -o "${CACHE_PREFIX}[^[:space:]]+" CACHE_LIST | sed '1d' | awk '{ print $1 }'
+          done > CCACHE_LIST
+
+          cat CCACHE_LIST
+
+          DELETE_LIST=$(cat CCACHE_LIST)
+          echo Ubuntu Delete List is $DELETE_LIST
+          for KEY in $DELETE_LIST ; do ${{ github.event_name == 'pull_request'  && 'echo' || '' }} gh cache delete $KEY ; done
+
+          # Generate post-clean list
+          echo CACHE LIST AFTER ...
+          gh cache list $GH_LIST_ARGS


### PR DESCRIPTION
# Overview

Add a workflow to tidy up cache entries

# Reason for change

Old cache timestamped files are cluttering up our cache space

# Description of change

Use gh to delete old cache entries

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-19](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
