### PR TITLE
Switch aarch64 PR job to run non-cross using github runner. 

### DIFF
--- a/.github/actions/do_build_pr/run_ubuntu_gcc_aarch64_llvm_latest_cl3_0_fp16/action.yml
+++ b/.github/actions/do_build_pr/run_ubuntu_gcc_aarch64_llvm_latest_cl3_0_fp16/action.yml
@@ -16,12 +16,10 @@ runs:
       - name: build ock
         uses: ./.github/actions/do_build_ock
         with:
-          build_targets: ${{ inputs.cache_seed == 'true' && 'UnitCL clc' || 'check-ock-cross' }} 
+          build_targets: ${{ inputs.cache_seed == 'true' && 'UnitCL clc' || 'check-ock' }}
           host_fp16: ON
           use_linker: gold
           debug_support: ON
           builtin_kernel: ON
-          enable_api: ""
-          toolchain_file: "scripts/../platform/arm-linux/aarch64-toolchain.cmake"
-          extra_flags: -DCA_BUILTINS_TOOLS_DIR=${{ github.workspace }}/llvm_install_native/bin
+          enable_api: "cl"
           offline_kernel_tests: ${{ inputs.cache_seed == 'true' && 'OFF' || 'ON' }}

--- a/.github/workflows/pr_tests_cache.yml
+++ b/.github/workflows/pr_tests_cache.yml
@@ -131,7 +131,7 @@ jobs:
     needs: [ubuntu_22_llvm_current_x86_jobs]  
     runs-on: ubuntu-22.04-arm
     container:
-      image: ghcr.io/alan-forbes-cp/ock_ubuntu_22.04-aarch64:latest
+      image: ghcr.io/uxlfoundation/ock_ubuntu_22.04-aarch64:latest
       volumes:
         - ${{github.workspace}}:${{github.workspace}}    
     steps:

--- a/.github/workflows/pr_tests_cache.yml
+++ b/.github/workflows/pr_tests_cache.yml
@@ -129,9 +129,9 @@ jobs:
   ubuntu_22_llvm_current_aarch64_jobs:
     if: github.repository == 'uxlfoundation/oneapi-construction-kit' || github.event_name != 'schedule'
     needs: [ubuntu_22_llvm_current_x86_jobs]  
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-22.04-arm
     container:
-      image: ghcr.io/uxlfoundation/ock_ubuntu_22.04-x86-64:latest
+      image: ghcr.io/alan-forbes-cp/ock_ubuntu_22.04-aarch64:latest
       volumes:
         - ${{github.workspace}}:${{github.workspace}}    
     steps:
@@ -145,7 +145,6 @@ jobs:
           llvm_version: ${{ env.llvm_current }}
           llvm_build_type: RelAssert
           save: true
-          cross_arch: aarch64
 
       - name: build ubuntu_gcc_aarch64_llvm_latest_cl3_0_fp16
         uses: ./.github/actions/do_build_pr/run_ubuntu_gcc_aarch64_llvm_latest_cl3_0_fp16

--- a/.github/workflows/run_pr_tests.yml
+++ b/.github/workflows/run_pr_tests.yml
@@ -260,7 +260,7 @@ jobs:
   run-ubuntu-gcc-aarch64-llvm-latest-cl3-0-fp16:
     runs-on: ubuntu-22.04-arm
     container:
-      image: ghcr.io/alan-forbes-cp/ock_ubuntu_22.04-aarch64:latest
+      image: ghcr.io/uxlfoundation/ock_ubuntu_22.04-aarch64:latest
       volumes:
         - ${{github.workspace}}:${{github.workspace}}
     timeout-minutes: 90 # aarch64 needs longer timeout

--- a/.github/workflows/run_pr_tests.yml
+++ b/.github/workflows/run_pr_tests.yml
@@ -23,6 +23,7 @@ jobs:
 
   # build and run host x86_64, execute UnitCL and lit tests and build and run offline
   run_host_x86_64:
+    if: false
     runs-on: ubuntu-22.04
     container:
       image: ghcr.io/uxlfoundation/ock_ubuntu_22.04-x86-64:latest
@@ -57,6 +58,7 @@ jobs:
   # build and run riscv m1, execute UnitCL and lit tests
   run_riscv_m1:
 
+    if: false
     runs-on: ubuntu-22.04
     container:
       image: ghcr.io/uxlfoundation/ock_ubuntu_22.04-x86-64:latest
@@ -87,6 +89,7 @@ jobs:
   # build and run clang-tidy
   run_clang_tidy_changes:
 
+    if: false
     runs-on: ubuntu-22.04
     container:
       image: ghcr.io/uxlfoundation/ock_ubuntu_22.04-x86-64:latest
@@ -133,6 +136,7 @@ jobs:
   # run clang-format-diff on the repo
   run_clang_format:
 
+    if: false
     runs-on: ubuntu-22.04
 
     steps:
@@ -155,6 +159,7 @@ jobs:
   # Based on: mr-windows-msvc-x86_64-llvm-previous-cl3.0-offline
   run_windows_msvc_x86_64_llvm_latest_cl3_0_offline:
 
+    if: false
     runs-on: windows-2019
 
     steps:
@@ -181,6 +186,7 @@ jobs:
 
   # Based on: mr-ubuntu-gcc-x86_64-riscv-fp16-cl3.0-unitcl_vecz
   run_ubuntu_gcc_x86_64_riscv_fp16_cl3_0_unitcl_vecz:
+    if: false
     runs-on: ubuntu-22.04
     container:
       image: ghcr.io/uxlfoundation/ock_ubuntu_22.04-x86-64:latest
@@ -200,6 +206,7 @@ jobs:
 
   # Based on: mr-ubuntu-clang-x86-llvm-previous-cl3-0-offline
   run-ubuntu-clang-x86-llvm-latest-cl3-0-offline:
+    if: false
     runs-on: ubuntu-22.04
     container:
       image: ghcr.io/uxlfoundation/ock_ubuntu_22.04-x86-64:latest
@@ -220,6 +227,7 @@ jobs:
 
   # Based on: mr-ubuntu-gcc-x86_64-riscv-fp16-cl3-0
   run-ubuntu-gcc-x86_64-riscv-fp16-cl3-0:
+    if: false
     runs-on: ubuntu-22.04
     container:
       image: ghcr.io/uxlfoundation/ock_ubuntu_22.04-x86-64:latest
@@ -239,6 +247,7 @@ jobs:
 
   # Based on: mr-ubuntu-gcc-x86-llvm-latest-x86_64-images-cl3-0-release
   run-ubuntu-gcc-x86-llvm-latest-x86_64-images-cl3-0-release:
+    if: false
     runs-on: ubuntu-22.04
     container:
       image: ghcr.io/uxlfoundation/ock_ubuntu_22.04-x86-64:latest
@@ -258,9 +267,9 @@ jobs:
 
   # Based on: mr-ubuntu-gcc-aarch64-llvm-previous-cl3-0-fp16
   run-ubuntu-gcc-aarch64-llvm-latest-cl3-0-fp16:
-    runs-on: cp-ubuntu-24.04
+    runs-on: ubuntu-22.04-arm
     container:
-      image: ghcr.io/uxlfoundation/ock_ubuntu_22.04-x86-64:latest
+      image: ghcr.io/alan-forbes-cp/ock_ubuntu_22.04-aarch64:latest
       volumes:
         - ${{github.workspace}}:${{github.workspace}}
     timeout-minutes: 90 # aarch64 needs longer timeout
@@ -272,13 +281,13 @@ jobs:
       with:
         llvm_version: '19'
         llvm_build_type: RelAssert
-        cross_arch: aarch64
     - name: build and run ock      
       uses: ./.github/actions/do_build_pr/run_ubuntu_gcc_aarch64_llvm_latest_cl3_0_fp16
 
   # Based on a combination of: mr-ubuntu-gcc-x86_64-clik
   #                       and: mr-ubuntu-gcc-x86_64-clik-refsi
   run-ubuntu-gcc-x86_64-clik-refsi:
+    if: false
     runs-on: ubuntu-22.04
     container:
       image: ghcr.io/uxlfoundation/ock_ubuntu_22.04-x86-64:latest
@@ -302,7 +311,8 @@ jobs:
 
   # Based on: mr-ubuntu-gcc-x86_64-refsi-g1-wi-cl3-0
   run-ubuntu-gcc-x86_64-refsi-g1-wi-cl3-0:
-    if: ${{ !inputs.is_pull_request }}  # do not run as PR job for now to avoid flooding the concurrency
+    #if: ${{ !inputs.is_pull_request }}  # do not run as PR job for now to avoid flooding the concurrency
+    if: false
     runs-on: ubuntu-22.04
     container:
       image: ghcr.io/uxlfoundation/ock_ubuntu_22.04-x86-64:latest

--- a/.github/workflows/run_pr_tests.yml
+++ b/.github/workflows/run_pr_tests.yml
@@ -23,7 +23,6 @@ jobs:
 
   # build and run host x86_64, execute UnitCL and lit tests and build and run offline
   run_host_x86_64:
-    if: false
     runs-on: ubuntu-22.04
     container:
       image: ghcr.io/uxlfoundation/ock_ubuntu_22.04-x86-64:latest
@@ -58,7 +57,6 @@ jobs:
   # build and run riscv m1, execute UnitCL and lit tests
   run_riscv_m1:
 
-    if: false
     runs-on: ubuntu-22.04
     container:
       image: ghcr.io/uxlfoundation/ock_ubuntu_22.04-x86-64:latest
@@ -89,7 +87,6 @@ jobs:
   # build and run clang-tidy
   run_clang_tidy_changes:
 
-    if: false
     runs-on: ubuntu-22.04
     container:
       image: ghcr.io/uxlfoundation/ock_ubuntu_22.04-x86-64:latest
@@ -136,7 +133,6 @@ jobs:
   # run clang-format-diff on the repo
   run_clang_format:
 
-    if: false
     runs-on: ubuntu-22.04
 
     steps:
@@ -159,7 +155,6 @@ jobs:
   # Based on: mr-windows-msvc-x86_64-llvm-previous-cl3.0-offline
   run_windows_msvc_x86_64_llvm_latest_cl3_0_offline:
 
-    if: false
     runs-on: windows-2019
 
     steps:
@@ -186,7 +181,6 @@ jobs:
 
   # Based on: mr-ubuntu-gcc-x86_64-riscv-fp16-cl3.0-unitcl_vecz
   run_ubuntu_gcc_x86_64_riscv_fp16_cl3_0_unitcl_vecz:
-    if: false
     runs-on: ubuntu-22.04
     container:
       image: ghcr.io/uxlfoundation/ock_ubuntu_22.04-x86-64:latest
@@ -206,7 +200,6 @@ jobs:
 
   # Based on: mr-ubuntu-clang-x86-llvm-previous-cl3-0-offline
   run-ubuntu-clang-x86-llvm-latest-cl3-0-offline:
-    if: false
     runs-on: ubuntu-22.04
     container:
       image: ghcr.io/uxlfoundation/ock_ubuntu_22.04-x86-64:latest
@@ -227,7 +220,6 @@ jobs:
 
   # Based on: mr-ubuntu-gcc-x86_64-riscv-fp16-cl3-0
   run-ubuntu-gcc-x86_64-riscv-fp16-cl3-0:
-    if: false
     runs-on: ubuntu-22.04
     container:
       image: ghcr.io/uxlfoundation/ock_ubuntu_22.04-x86-64:latest
@@ -247,7 +239,6 @@ jobs:
 
   # Based on: mr-ubuntu-gcc-x86-llvm-latest-x86_64-images-cl3-0-release
   run-ubuntu-gcc-x86-llvm-latest-x86_64-images-cl3-0-release:
-    if: false
     runs-on: ubuntu-22.04
     container:
       image: ghcr.io/uxlfoundation/ock_ubuntu_22.04-x86-64:latest
@@ -287,7 +278,6 @@ jobs:
   # Based on a combination of: mr-ubuntu-gcc-x86_64-clik
   #                       and: mr-ubuntu-gcc-x86_64-clik-refsi
   run-ubuntu-gcc-x86_64-clik-refsi:
-    if: false
     runs-on: ubuntu-22.04
     container:
       image: ghcr.io/uxlfoundation/ock_ubuntu_22.04-x86-64:latest
@@ -311,8 +301,7 @@ jobs:
 
   # Based on: mr-ubuntu-gcc-x86_64-refsi-g1-wi-cl3-0
   run-ubuntu-gcc-x86_64-refsi-g1-wi-cl3-0:
-    #if: ${{ !inputs.is_pull_request }}  # do not run as PR job for now to avoid flooding the concurrency
-    if: false
+    if: ${{ !inputs.is_pull_request }}  # do not run as PR job for now to avoid flooding the concurrency
     runs-on: ubuntu-22.04
     container:
       image: ghcr.io/uxlfoundation/ock_ubuntu_22.04-x86-64:latest


### PR DESCRIPTION
# Overview

Switch run-ubuntu-gcc-aarch64-llvm-latest-cl3-0-fp16 to run as a non-cross platform job using a github hosted aarch64 runner.

# Reason for change

Use aarch64 github runner.

# Description of change

Updates runner, docker image and "cross" status

# Anything else we should know?

Depends on: https://github.com/uxlfoundation/oneapi-construction-kit/pull/696

Comment from Colin re. vulkan: 
> I'm inclined to drop the vulkan in the test rather than bloating the aarch64 docker - I also don't see an aarch64 non-windows vulkak sdk and we want to drop it anyway
