### PR TITLE
Updates to aarch64 docker for PR job on internal runner

### DIFF
--- a/.github/dockerfiles/Dockerfile_22.04-aarch64
+++ b/.github/dockerfiles/Dockerfile_22.04-aarch64
@@ -6,6 +6,7 @@ RUN apt-get install -y git
 RUN apt-get install --yes cmake
 RUN apt-get install --yes gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
 RUN apt-get install --yes python3 python3-pip
+RUN pip install cmakelint colorama lit
 RUN apt-get install --yes spirv-tools
 RUN apt-get install --yes zstd
 RUN apt-get -y install gh


### PR DESCRIPTION
# Overview

Docker updates to support: changing of PR job for cross aarch64 to use aarch64 runner and not build as cross platform.

# Reason for change

Dockerfile updates as required.

# Description of change

Add missing install components.