### PR TITLE
Add llvm 18 and 19 as apt sources to the dockers

### DIFF
--- a/.github/dockerfiles/Dockerfile_22.04-aarch64
+++ b/.github/dockerfiles/Dockerfile_22.04-aarch64
@@ -8,5 +8,10 @@ RUN apt-get install --yes gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
 RUN apt-get install --yes python3 python3-pip
 RUN pip install cmakelint colorama lit
 RUN apt-get install --yes spirv-tools
+RUN apt-get install --yes wget gpg
+RUN wget -qO - https://apt.llvm.org/llvm-snapshot.gpg.key | gpg --dearmor - | tee /usr/share/keyrings/llvm-archive-keyring.gpg >/dev/null
+RUN echo 'deb [signed-by=/usr/share/keyrings/llvm-archive-keyring.gpg] http://apt.llvm.org/jammy/ llvm-toolchain-jammy-18 main' | tee /etc/apt/sources.list.d/llvm.list >/dev/null
+RUN echo 'deb [signed-by=/usr/share/keyrings/llvm-archive-keyring.gpg] http://apt.llvm.org/jammy/ llvm-toolchain-jammy-19 main' | tee -a /etc/apt/sources.list.d/llvm.list >/dev/null
+
 RUN apt-get install --yes zstd
 RUN apt-get -y install gh

--- a/.github/dockerfiles/Dockerfile_22.04-x86-64
+++ b/.github/dockerfiles/Dockerfile_22.04-x86-64
@@ -22,7 +22,8 @@ RUN apt-get update
 
 # Add clang-tidy
 RUN wget -qO - https://apt.llvm.org/llvm-snapshot.gpg.key | gpg --dearmor - | tee /usr/share/keyrings/llvm-archive-keyring.gpg >/dev/null
-RUN echo 'deb [signed-by=/usr/share/keyrings/llvm-archive-keyring.gpg] http://apt.llvm.org/jammy/ llvm-toolchain-jammy-19 main' | tee /etc/apt/sources.list.d/llvm.list >/dev/null
+RUN echo 'deb [signed-by=/usr/share/keyrings/llvm-archive-keyring.gpg] http://apt.llvm.org/jammy/ llvm-toolchain-jammy-18 main' | tee /etc/apt/sources.list.d/llvm.list >/dev/null
+RUN echo 'deb [signed-by=/usr/share/keyrings/llvm-archive-keyring.gpg] http://apt.llvm.org/jammy/ llvm-toolchain-jammy-19 main' | tee -a /etc/apt/sources.list.d/llvm.list >/dev/null
 RUN apt-get update
 RUN apt-get install --yes clang-tidy-19
 

--- a/.github/dockerfiles/Dockerfile_24.04-x86-64
+++ b/.github/dockerfiles/Dockerfile_24.04-x86-64
@@ -22,7 +22,8 @@ RUN apt-get update
 
 # Add clang-tidy
 RUN wget -qO - https://apt.llvm.org/llvm-snapshot.gpg.key | gpg --dearmor - | tee /usr/share/keyrings/llvm-archive-keyring.gpg >/dev/null
-RUN echo 'deb [signed-by=/usr/share/keyrings/llvm-archive-keyring.gpg] http://apt.llvm.org/noble/ llvm-toolchain-noble-19 main' | tee /etc/apt/sources.list.d/llvm.list >/dev/null
+RUN echo 'deb [signed-by=/usr/share/keyrings/llvm-archive-keyring.gpg] http://apt.llvm.org/noble/ llvm-toolchain-noble-18 main' | tee /etc/apt/sources.list.d/llvm.list >/dev/null
+RUN echo 'deb [signed-by=/usr/share/keyrings/llvm-archive-keyring.gpg] http://apt.llvm.org/noble/ llvm-toolchain-noble-19 main' | tee -a /etc/apt/sources.list.d/llvm.list >/dev/null
 RUN apt-get update
 RUN apt-get install --yes clang-tidy-19
 


### PR DESCRIPTION
# Overview

Add llvm 18 and 19 as apt sources to the docker

# Reason for change

Required for running PRs where we install llvm

# Description of change

Updated dockers to add apt sources for 18 and 19 to all dockers.
This also installs gpg and wget in the aarch64 docker.
