### PR TITLE
Fix API mismatch in `insertDeclare`

### DIFF
--- a/modules/compiler/compiler_pipeline/source/replace_local_module_scope_variables_pass.cpp
+++ b/modules/compiler/compiler_pipeline/source/replace_local_module_scope_variables_pass.cpp
@@ -716,7 +716,7 @@ PreservedAnalyses compiler::utils::ReplaceLocalModuleScopeVariablesPass::run(
         // function which is called by kernelFunc.
         auto last_arg = func->arg_end() - 1;
         DIB.insertDeclare(last_arg, DILocal, offset_expr, location,
-                          func->getEntryBlock().getFirstNonPHIOrDbg());
+                          &*func->getEntryBlock().getFirstNonPHIOrDbg());
       }
     }
 


### PR DESCRIPTION
This was discovered as oneAPI build error:

```
error: no matching function for call to ‘llvm::DIBuilder::insertDeclare(llvm::Argument*&, llvm::DILocalVariable*&, llvm::DIExpression*&, llvm::DILocation*&, llvm::Instruction&)’
  718 |         DIB.insertDeclare(last_arg, DILocal, offset_expr, location,
      |         ~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  719 |                           *func->getEntryBlock().getFirstNonPHIOrDbg());

...

note:   no known conversion for argument 5 from ‘llvm::Instruction’ to ‘llvm::Instruction*’
```
