### PR TITLE
Add CA_LLVM_LIBDIR_SUFFIX.

### DIFF
--- a/cmake/ImportLLVM.cmake
+++ b/cmake/ImportLLVM.cmake
@@ -47,20 +47,20 @@ endif()
 # Add our cmake modules directory to the cmake include path including
 # LLVM/Clang.
 string(REPLACE "\\" "/" CA_LLVM_INSTALL_DIR "${CA_LLVM_INSTALL_DIR}")
-if(NOT EXISTS "${CA_LLVM_INSTALL_DIR}/lib/cmake/llvm/LLVMConfig.cmake")
+if(NOT EXISTS "${CA_LLVM_INSTALL_DIR}/lib${CA_LLVM_LIBDIR_SUFFIX}/cmake/llvm/LLVMConfig.cmake")
   message(FATAL_ERROR
-    "'${CA_LLVM_INSTALL_DIR}/lib/cmake/llvm/LLVMConfig.cmake' does not exist"
+    "'${CA_LLVM_INSTALL_DIR}/lib${CA_LLVM_LIBDIR_SUFFIX}/cmake/llvm/LLVMConfig.cmake' does not exist"
     " (search path set with CA_LLVM_INSTALL_DIR)")
 endif()
-if(NOT EXISTS "${CA_LLVM_INSTALL_DIR}/lib/cmake/clang/ClangTargets.cmake")
+if(NOT EXISTS "${CA_LLVM_INSTALL_DIR}/lib${CA_LLVM_LIBDIR_SUFFIX}/cmake/clang/ClangTargets.cmake")
   message(FATAL_ERROR
-    "'${CA_LLVM_INSTALL_DIR}/lib/cmake/clang/ClangTargets.cmake' does not exist"
+    "'${CA_LLVM_INSTALL_DIR}/lib${CA_LLVM_LIBDIR_SUFFIX}/cmake/clang/ClangTargets.cmake' does not exist"
     " (search path set with CA_LLVM_INSTALL_DIR)")
 endif()
 list(APPEND CMAKE_MODULE_PATH
-  ${CA_LLVM_INSTALL_DIR}/lib/cmake/llvm
-  ${CA_LLVM_INSTALL_DIR}/lib/cmake/clang)
-set(LLVM_DIR ${CA_LLVM_INSTALL_DIR}/lib/cmake/llvm)
+  ${CA_LLVM_INSTALL_DIR}/lib${CA_LLVM_LIBDIR_SUFFIX}/cmake/llvm
+  ${CA_LLVM_INSTALL_DIR}/lib${CA_LLVM_LIBDIR_SUFFIX}/cmake/clang)
+set(LLVM_DIR ${CA_LLVM_INSTALL_DIR}/lib${CA_LLVM_LIBDIR_SUFFIX}/cmake/llvm)
 
 # Include LLVM.
 include(LLVMConfig)

--- a/doc/developer-guide.md
+++ b/doc/developer-guide.md
@@ -253,6 +253,9 @@ The builtin CMake options used when invoking CMake on the command line.
   relevant llvm headers and support tools, and their version must match
   a supported LLVM version.
 
+* `CA_LLVM_LIBDIR_SUFFIX`: Tells the oneAPI Construction Kit what value of
+  `LLVM_LIBDIR_SUFFIX` was used for building LLVM.
+
 * `CA_ENABLE_API`: Semi-colon separated list of APIs to enable. Valid values
   are `cl` for OpenCL, and `vk` for Vulkan. Enabling an API when an optional
   component is not present dependent on license agreement will result in a CMake

--- a/modules/compiler/riscv/CMakeLists.txt
+++ b/modules/compiler/riscv/CMakeLists.txt
@@ -48,7 +48,7 @@ if (LLVMRISCVCODEGEN)
 
     if(NOT TARGET compiler-linker-utils)
       set(error "compiler-riscv-utils requires compiler-linker-utils")
-      if(NOT EXISTS "${CA_LLVM_INSTALL_DIR}/lib/cmake/lld/LLDConfig.cmake")
+      if(NOT EXISTS "${CA_LLVM_INSTALL_DIR}/lib${CA_LLVM_LIBDIR_SUFFIX}/cmake/lld/LLDConfig.cmake")
         string(APPEND error " which requires liblld")
       endif()
       message(FATAL_ERROR "${error}")

--- a/modules/compiler/source/base/CMakeLists.txt
+++ b/modules/compiler/source/base/CMakeLists.txt
@@ -105,7 +105,7 @@ set(LLVM_LIBS "LLVMCodeGen" "LLVMCoroutines" "LLVMCoverage"
 # Otherwise, we have to provide the full path to them.
 if(NOT OCK_IN_LLVM_TREE)
   list(TRANSFORM CLANG_LIBS
-       PREPEND "${CA_LLVM_INSTALL_DIR}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}")
+       PREPEND "${CA_LLVM_INSTALL_DIR}/lib${CA_LLVM_LIBDIR_SUFFIX}/${CMAKE_STATIC_LIBRARY_PREFIX}")
   list(TRANSFORM CLANG_LIBS
        APPEND "${CMAKE_STATIC_LIBRARY_SUFFIX}")
 endif()

--- a/modules/compiler/utils/CMakeLists.txt
+++ b/modules/compiler/utils/CMakeLists.txt
@@ -40,8 +40,8 @@ endif()
 
 # Determine whether LLVM was built with LLD, in which case add a support
 # library that exposes lld to ComputeMux compiler targets.
-if(EXISTS "${CA_LLVM_INSTALL_DIR}/lib/cmake/lld/LLDConfig.cmake")
-  list(APPEND CMAKE_MODULE_PATH ${CA_LLVM_INSTALL_DIR}/lib/cmake/lld)
+if(EXISTS "${CA_LLVM_INSTALL_DIR}/lib${CA_LLVM_LIBDIR_SUFFIX}/cmake/lld/LLDConfig.cmake")
+  list(APPEND CMAKE_MODULE_PATH ${CA_LLVM_INSTALL_DIR}/lib${CA_LLVM_LIBDIR_SUFFIX}/cmake/lld)
   include(LLDConfig)
 
   add_ca_library(compiler-linker-utils STATIC
@@ -71,7 +71,7 @@ if(EXISTS "${CA_LLVM_INSTALL_DIR}/lib/cmake/lld/LLDConfig.cmake")
 
   if(NOT OCK_IN_LLVM_TREE)
     list(TRANSFORM LLD_LIBS
-         PREPEND "${CA_LLVM_INSTALL_DIR}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}")
+         PREPEND "${CA_LLVM_INSTALL_DIR}/lib${CA_LLVM_LIBDIR_SUFFIX}/${CMAKE_STATIC_LIBRARY_PREFIX}")
     list(TRANSFORM LLD_LIBS
          APPEND "${CMAKE_STATIC_LIBRARY_SUFFIX}")
   endif()


### PR DESCRIPTION
# Overview

Add CA_LLVM_LIBDIR_SUFFIX.

# Reason for change

When building against an LLVM that was built with LLVM_LIBDIR_SUFFIX set, we would fail to locate that LLVM's CMake files due to hardcoded paths.

# Description of change

Allow CA_LLVM_LIBDIR_SUFFIX to be set to the same value to work around that.

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-19](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
