### PR TITLE
Run Windows PR test via github llvm release download

### DIFF
--- a/.github/actions/do_build_pr/run_windows_msvc_x86_64_llvm_latest_cl3_0_offline/action.yml
+++ b/.github/actions/do_build_pr/run_windows_msvc_x86_64_llvm_latest_cl3_0_offline/action.yml
@@ -5,7 +5,7 @@ inputs:
   cache_seed:
     type: boolean
     default: false
-  pull_request:
+  is_pull_request:
     type: boolean
     default: true
 

--- a/.github/actions/setup_build/action.yml
+++ b/.github/actions/setup_build/action.yml
@@ -103,6 +103,7 @@ runs:
       if: inputs.os == 'windows' && inputs.llvm_source == 'install'
       shell: pwsh
       env:
+        # Map inputs.llvm_version to specific download release here.
         LLVM_RELEASE: "${{ inputs.llvm_version == '20' && '20.1.2' || '19.1.7' }}"
       run: |
         Invoke-WebRequest https://github.com/llvm/llvm-project/releases/download/llvmorg-$env:LLVM_RELEASE/clang+llvm-$env:LLVM_RELEASE-x86_64-pc-windows-msvc.tar.xz -OutFile clang+llvm-$env:LLVM_RELEASE-x86_64-pc-windows-msvc.tar.xz

--- a/.github/actions/setup_build/action.yml
+++ b/.github/actions/setup_build/action.yml
@@ -109,7 +109,6 @@ runs:
         Invoke-WebRequest https://github.com/llvm/llvm-project/releases/download/llvmorg-$env:LLVM_RELEASE/clang+llvm-$env:LLVM_RELEASE-x86_64-pc-windows-msvc.tar.xz -OutFile clang+llvm-$env:LLVM_RELEASE-x86_64-pc-windows-msvc.tar.xz
         7z x clang+llvm-$env:LLVM_RELEASE-x86_64-pc-windows-msvc.tar.xz -so | 7z x -si -ttar
         mv clang+llvm-$env:LLVM_RELEASE-x86_64-pc-windows-msvc llvm_install
-        ls llvm_install
         # Work-around: satisfy hard-wired reference to VS "Professional" lib (when "Enterprise" is actually installed)
         mkdir "C:/Program Files (x86)/Microsoft Visual Studio/2019/Professional/DIA SDK/lib/amd64"
         cp "C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/DIA SDK/lib/amd64/diaguids.lib" "C:/Program Files (x86)/Microsoft Visual Studio/2019/Professional/DIA SDK/lib/amd64"

--- a/.github/actions/setup_build/action.yml
+++ b/.github/actions/setup_build/action.yml
@@ -103,7 +103,7 @@ runs:
       if: inputs.os == 'windows' && inputs.llvm_source == 'install'
       shell: pwsh
       env:
-        LLVM_RELEASE: "${{ inputs.llvm_version == '20' && '20.1.3' || '19.1.7' }}"
+        LLVM_RELEASE: "${{ inputs.llvm_version == '20' && '20.1.2' || '19.1.7' }}"
       run: |
         Invoke-WebRequest https://github.com/llvm/llvm-project/releases/download/llvmorg-$env:LLVM_RELEASE/clang+llvm-$env:LLVM_RELEASE-x86_64-pc-windows-msvc.tar.xz -OutFile clang+llvm-$env:LLVM_RELEASE-x86_64-pc-windows-msvc.tar.xz
         7z x clang+llvm-$env:LLVM_RELEASE-x86_64-pc-windows-msvc.tar.xz -so | 7z x -si -ttar

--- a/.github/actions/setup_build/action.yml
+++ b/.github/actions/setup_build/action.yml
@@ -87,8 +87,8 @@ runs:
         key: llvm-${{ inputs.os }}-${{ steps.set_llvm_key.outputs.key_version }}-${{ steps.set_llvm_key.outputs.key_native_arch }}-v${{ inputs.llvm_version }}-${{ inputs.llvm_build_type }}
         fail-on-cache-miss: true
 
-    - name: install llvm native
-      if: inputs.llvm_source == 'install'
+    - name: install llvm native ubuntu # via "apt install"
+      if: inputs.os == 'ubuntu' && inputs.llvm_source == 'install'
       shell: bash
       run: |
         set -x
@@ -98,6 +98,21 @@ runs:
         sudo apt install -y libpolly-${{ inputs.llvm_version }}-dev clang-${{ inputs.llvm_version }}
 
         ln -s /usr/lib/llvm-${{ inputs.llvm_version }} llvm_install
+
+    - name: install llvm native windows # via llvm-project/releases/download & extract
+      if: inputs.os == 'windows' && inputs.llvm_source == 'install'
+      shell: pwsh
+      env:
+        LLVM_RELEASE: "${{ inputs.llvm_version == '20' && '20.1.3' || '19.1.7' }}"
+      run: |
+        Invoke-WebRequest https://github.com/llvm/llvm-project/releases/download/llvmorg-$env:LLVM_RELEASE/clang+llvm-$env:LLVM_RELEASE-x86_64-pc-windows-msvc.tar.xz -OutFile clang+llvm-$env:LLVM_RELEASE-x86_64-pc-windows-msvc.tar.xz
+        7z x clang+llvm-$env:LLVM_RELEASE-x86_64-pc-windows-msvc.tar.xz -so | 7z x -si -ttar
+        mv clang+llvm-$env:LLVM_RELEASE-x86_64-pc-windows-msvc llvm_install
+        ls llvm_install
+        # Work-around: satisfy hard-wired reference to VS "Professional" lib (when "Enterprise" is actually installed)
+        mkdir "C:/Program Files (x86)/Microsoft Visual Studio/2019/Professional/DIA SDK/lib/amd64"
+        cp "C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/DIA SDK/lib/amd64/diaguids.lib" "C:/Program Files (x86)/Microsoft Visual Studio/2019/Professional/DIA SDK/lib/amd64"
+
 
     - name: download llvm native
       if: inputs.llvm_source != 'install' && inputs.llvm_source != 'cache'

--- a/.github/workflows/pr_tests_cache.yml
+++ b/.github/workflows/pr_tests_cache.yml
@@ -159,6 +159,7 @@ jobs:
 
   clean_cache:
     if: github.repository == 'uxlfoundation/oneapi-construction-kit' || github.event_name != 'schedule'
+    needs: [ubuntu_22_llvm_current_aarch64_jobs, windows_llvm_current_jobs]
     runs-on: ubuntu-latest
     permissions:
       actions: write

--- a/.github/workflows/pr_tests_cache.yml
+++ b/.github/workflows/pr_tests_cache.yml
@@ -127,32 +127,31 @@ jobs:
         with:
           cache_seed: true
 
-  # Restore when PR #707 is merged means windows jobs is restored to PR testing
-  # windows_llvm_current_jobs:
-  #   if: github.repository == 'uxlfoundation/oneapi-construction-kit' || github.event_name != 'schedule'
-  #   runs-on: windows-2019
-  #   steps:    
-  #     - name: Setup Windows llvm base
-  #       uses: llvm/actions/setup-windows@main
-  #       with:
-  #         arch: amd64
+  windows_llvm_current_jobs:
+    if: github.repository == 'uxlfoundation/oneapi-construction-kit' || github.event_name != 'schedule'
+    runs-on: windows-2019
+    steps:
+      - name: Setup Windows llvm base
+        uses: llvm/actions/setup-windows@main
+        with:
+          arch: amd64
 
-  #     - name: Checkout repo
-  #       uses: actions/checkout@v4
+      - name: Checkout repo
+        uses: actions/checkout@v4
 
-  #     # installs tools, ninja, installs llvm and sets up ccache
-  #     - name: setup-windows
-  #       uses:  ./.github/actions/setup_build
-  #       with:
-  #         llvm_version: ${{ env.llvm_current }}
-  #         llvm_build_type: RelAssert
-  #         save: true
-  #         os: windows
-  #         llvm_source: install
-  #     - name: build windows_msvc_x86_64_llvm_latest_cl3_0_offline
-  #       uses: ./.github/actions/do_build_pr/run_windows_msvc_x86_64_llvm_latest_cl3_0_offline
-  #       with:
-  #         cache_seed: true
+      # installs tools, ninja, installs llvm and sets up ccache
+      - name: setup-windows
+        uses:  ./.github/actions/setup_build
+        with:
+          llvm_version: ${{ env.llvm_current }}
+          llvm_build_type: RelAssert
+          save: true
+          os: windows
+          llvm_source: install
+      - name: build windows_msvc_x86_64_llvm_latest_cl3_0_offline
+        uses: ./.github/actions/do_build_pr/run_windows_msvc_x86_64_llvm_latest_cl3_0_offline
+        with:
+          cache_seed: true
 
 
   # The following tries to delete old caches but fails on the branch due to permissions errors
@@ -160,8 +159,6 @@ jobs:
 
   clean_cache:
     if: github.repository == 'uxlfoundation/oneapi-construction-kit' || github.event_name != 'schedule'
-    # Note when windows job is restored, the dependency should be added here.
-    needs: [ubuntu_22_llvm_current_aarch64_jobs]
     runs-on: ubuntu-latest
     permissions:
       actions: write

--- a/.github/workflows/run_ock_internal_tests.yml
+++ b/.github/workflows/run_ock_internal_tests.yml
@@ -198,8 +198,6 @@ jobs:
   # Based on: mr-windows-msvc-x86_64-llvm-previous-cl3.0-offline
   run_windows_msvc_x86_64_llvm_latest_cl3_0_offline:
     runs-on: windows-2019
-    # do not run as PR job due to not yet supporting windows install
-    #if: contains(inputs.target_list, 'host_x86_64_windows') && !inputs.is_pull_request
     if: contains(inputs.target_list, 'host_x86_64_windows')
     steps:
       - name: Setup Windows llvm base
@@ -216,7 +214,6 @@ jobs:
         with:
           llvm_version: ${{ inputs.llvm_current }}
           os: windows
-          #llvm_source: ${{ inputs.llvm_source == 'install' && 'cache' || inputs.llvm_source }}
           llvm_source: ${{ inputs.llvm_source }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/run_ock_internal_tests.yml
+++ b/.github/workflows/run_ock_internal_tests.yml
@@ -216,7 +216,8 @@ jobs:
         with:
           llvm_version: ${{ inputs.llvm_current }}
           os: windows
-          llvm_source: ${{ inputs.llvm_source == 'install' && 'cache' || inputs.llvm_source }}
+          #llvm_source: ${{ inputs.llvm_source == 'install' && 'cache' || inputs.llvm_source }}
+          llvm_source: ${{ inputs.llvm_source }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: build and test ock

--- a/.github/workflows/run_ock_internal_tests.yml
+++ b/.github/workflows/run_ock_internal_tests.yml
@@ -199,7 +199,8 @@ jobs:
   run_windows_msvc_x86_64_llvm_latest_cl3_0_offline:
     runs-on: windows-2019
     # do not run as PR job due to not yet supporting windows install
-    if: contains(inputs.target_list, 'host_x86_64_windows') && !inputs.is_pull_request
+    #if: contains(inputs.target_list, 'host_x86_64_windows') && !inputs.is_pull_request
+    if: contains(inputs.target_list, 'host_x86_64_windows')
     steps:
       - name: Setup Windows llvm base
         uses: llvm/actions/setup-windows@main

--- a/.github/workflows/run_pr_tests_caller.yml
+++ b/.github/workflows/run_pr_tests_caller.yml
@@ -28,6 +28,3 @@ jobs:
       llvm_source: install
       llvm_previous: 19
       llvm_current: 20
-      target_list: '[ "host_x86_64_windows" ]'
-
-

--- a/.github/workflows/run_pr_tests_caller.yml
+++ b/.github/workflows/run_pr_tests_caller.yml
@@ -26,8 +26,10 @@ jobs:
     with:
       is_pull_request: true
       llvm_source: install
-      llvm_previous: 19
-      llvm_current: 20
+      #llvm_previous: 19
+      #llvm_current: 20
+      llvm_previous: 18
+      llvm_current: 19
       target_list: '[ "host_x86_64_windows" ]'
 
 

--- a/.github/workflows/run_pr_tests_caller.yml
+++ b/.github/workflows/run_pr_tests_caller.yml
@@ -26,10 +26,8 @@ jobs:
     with:
       is_pull_request: true
       llvm_source: install
-      #llvm_previous: 19
-      #llvm_current: 20
-      llvm_previous: 18
-      llvm_current: 19
+      llvm_previous: 19
+      llvm_current: 20
       target_list: '[ "host_x86_64_windows" ]'
 
 

--- a/.github/workflows/run_pr_tests_caller.yml
+++ b/.github/workflows/run_pr_tests_caller.yml
@@ -28,5 +28,6 @@ jobs:
       llvm_source: install
       llvm_previous: 19
       llvm_current: 20
+      target_list: '[ "host_x86_64_windows" ]'
 
 


### PR DESCRIPTION
# Overview

Update Windows PR test to build via LLVM github release 'download & extract' (rather than cache)

# Reason for change

First use of non-cache for windows (previously hard-wired).  
First use of download&extract Github LLVM artefacts.

# Description of change

- Use Github download/extract artefacts for Windows PR jobs. 
- Update `llvm_version` setting to incorporate downloads from `llvm-release`. 
- Work-around hard-wired reference to VS "Professional" lib (when "Enterprise" is actually installed)
- Fix `pull_request:` param - should be `is_pull_request:`

# Anything else we should know?

The test to which this PR refers was blocked by the following issue: https://codeplaysoft.atlassian.net/browse/OR-750
Now unblocked.
