### PR TITLE
For CMake 3.24+, use COMPILE_WARNINGS_AS_ERRORS.

### DIFF
--- a/cmake/AddCA.cmake
+++ b/cmake/AddCA.cmake
@@ -148,11 +148,22 @@ add_compile_options(
   $<$<CXX_COMPILER_ID:Clang,AppleClang>:-fcolor-diagnostics>
   $<$<CXX_COMPILER_ID:GNU>:-fdiagnostics-color=always>)
 
-set(CA_COMPILE_OPTIONS
+# Enable warnings as errors when not a subproject
+set(CA_COMPILE_WARNING_AS_ERROR OFF)
+if(CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR)
+  set(CA_COMPILE_WARNING_AS_ERROR ON)
+endif()
+
+set(CA_COMPILE_OPTIONS)
+
+if(CA_COMPILE_WARNING_AS_ERROR AND CMAKE_VERSION VERSION_LESS "3.24")
+  list(APPEND CA_COMPILE_OPTIONS
+    $<$<OR:$<BOOL:${UNIX}>,$<BOOL:${ANDROID}>,$<BOOL:${MINGW}>>:-Werror>
+  )
+endif()
+
+list(APPEND CA_COMPILE_OPTIONS
   $<$<OR:$<BOOL:${UNIX}>,$<BOOL:${ANDROID}>,$<BOOL:${MINGW}>>:
-    $<$<STREQUAL:${CMAKE_SOURCE_DIR},${PROJECT_SOURCE_DIR}>:
-      -Werror             # Enable warnings as errors when not a subproject
-    >
     -Wno-error=deprecated-declarations  # Disable: use of deprecated functions
     -Wno-error=array-bounds  # Disable errors that vary heavily on compiler and
     -Wno-error=uninitialized # optimization level and have false positives.
@@ -483,6 +494,8 @@ macro(add_ca_library)
     PRIVATE ${CA_COMPILE_OPTIONS})
   target_compile_definitions(${ARGV0}
     PRIVATE ${CA_COMPILE_DEFINITIONS} ${CA_COMPILER_COMPILE_DEFINITIONS})
+  set_target_properties(${ARGV0} PROPERTIES
+    COMPILE_WARNING_AS_ERROR ${CA_COMPILE_WARNING_AS_ERROR})
   set_ca_target_output_directory(${ARGV0})
   if(COMMAND add_ca_tidy)
     add_ca_tidy(${ACL_UNPARSED_ARGUMENTS} DEPENDS ${ACL_DEPENDS})
@@ -509,6 +522,8 @@ macro(add_ca_interface_library)
     INTERFACE ${CA_COMPILE_OPTIONS})
   target_compile_definitions(${ARGV0}
     INTERFACE ${CA_COMPILE_DEFINITIONS} ${CA_COMPILER_COMPILE_DEFINITIONS})
+  set_target_properties(${ARGV0} PROPERTIES
+    COMPILE_WARNING_AS_ERROR ${CA_COMPILE_WARNING_AS_ERROR})
 endmacro()
 
 #[=======================================================================[.rst:
@@ -569,6 +584,7 @@ macro(add_ca_executable)
   target_compile_definitions(${ARGV0}
     PRIVATE ${CA_COMPILE_DEFINITIONS} ${CA_COMPILER_COMPILE_DEFINITIONS})
   set_target_properties(${ARGV0} PROPERTIES
+    COMPILE_WARNING_AS_ERROR ${CA_COMPILE_WARNING_AS_ERROR}
     RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/bin)
   if(COMMAND add_ca_tidy)
     add_ca_tidy(${ACE_UNPARSED_ARGUMENTS} DEPENDS ${ACE_DEPENDS})

--- a/modules/compiler/builtins/libimg/CMakeLists.txt
+++ b/modules/compiler/builtins/libimg/CMakeLists.txt
@@ -88,6 +88,8 @@ target_include_directories(image_library_host SYSTEM PUBLIC
   "${CODEPLAY_IMG_OPENCL_INCLUDE_DIR}")
 target_compile_options(image_library_host
   PRIVATE ${CA_COMPILE_OPTIONS})
+set_target_properties(image_library_host PROPERTIES
+  COMPILE_WARNING_AS_ERROR ${CA_COMPILE_WARNING_AS_ERROR})
 
 target_compile_definitions(image_library_host
   PUBLIC CL_TARGET_OPENCL_VERSION=${CA_CL_STANDARD_INTERNAL}


### PR DESCRIPTION
# Overview

For CMake 3.24+, use COMPILE_WARNINGS_AS_ERRORS.

# Reason for change

Unlike the hardcoded -Werror in CA_COMPILE_OPTIONS, COMPILE_WARNINGS_AS_ERRORS can be disabled by the user if desired with `cmake --compile-no-warning-as-error`.

# Description of change

*Describe the intended behaviour your changes are meant to introduce to the
project and explain how they resolve the problem stated above. Detail any
relevant changes that may affect other users of the project, such as
compilation options, runtime flags, expected inputs and outputs, API entry
points, etc.*

*If you have added new testing, provide details on what tests you have added
and what the purpose of them is.*

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-19](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
