### PR TITLE
Update for LLVM 21.

### DIFF
--- a/modules/compiler/riscv/source/module.cpp
+++ b/modules/compiler/riscv/source/module.cpp
@@ -192,11 +192,20 @@ static llvm::TargetMachine *createTargetMachine(
 
   options.MCOptions.ABIName = target.llvm_abi;
 
+#if LLVM_VERSION_GREATER_EQUAL(21, 0)
+  return llvm_target->createTargetMachine(
+      llvm::Triple(target.llvm_triple), target.llvm_cpu, target.llvm_features,
+      options,
+      target.riscv_hal_device_info->link_shared ? llvm::Reloc::Model::PIC_
+                                                : llvm::Reloc::Model::Static,
+      llvm::CodeModel::Small, llvm::CodeGenOptLevel::Aggressive);
+#else
   return llvm_target->createTargetMachine(
       target.llvm_triple, target.llvm_cpu, target.llvm_features, options,
       target.riscv_hal_device_info->link_shared ? llvm::Reloc::Model::PIC_
                                                 : llvm::Reloc::Model::Static,
       llvm::CodeModel::Small, llvm::CodeGenOptLevel::Aggressive);
+#endif
 }
 
 llvm::TargetMachine *riscv::RiscvModule::getTargetMachine() {

--- a/modules/compiler/source/base/source/module.cpp
+++ b/modules/compiler/source/base/source/module.cpp
@@ -1683,7 +1683,11 @@ Result BaseModule::finalize(
     pm.addPass(
         compiler::utils::SimpleCallbackPass([triple, DL](llvm::Module &m) {
           m.setDataLayout(DL);
+#if LLVM_VERSION_GREATER_EQUAL(21, 0)
+          m.setTargetTriple(llvm::Triple(triple));
+#else
           m.setTargetTriple(triple);
+#endif
         }));
     pm.addPass(compiler::utils::AlignModuleStructsPass());
   }

--- a/modules/compiler/source/base/source/target.cpp
+++ b/modules/compiler/source/base/source/target.cpp
@@ -96,8 +96,14 @@ Result BaseTarget::init(uint32_t builtins_capabilities) {
     }
 
     builtins_module_from_file = std::move(error_or_builtins_module.get());
-    if ("unknown-unknown-unknown" !=
-        builtins_module_from_file->getTargetTriple()) {
+#if LLVM_VERSION_GREATER_EQUAL(21, 0)
+    const auto builtins_module_triple_str =
+        builtins_module_from_file->getTargetTriple().str();
+#else
+    const auto builtins_module_triple_str =
+        builtins_module_from_file->getTargetTriple();
+#endif
+    if ("unknown-unknown-unknown" != builtins_module_triple_str) {
       return Result::FAILURE;
     }
   }

--- a/modules/compiler/spirv-ll/source/builder_core.cpp
+++ b/modules/compiler/spirv-ll/source/builder_core.cpp
@@ -425,7 +425,11 @@ llvm::Error Builder::create<OpMemoryModel>(const OpMemoryModel *op) {
       llvm_unreachable("Unsupported value provided for addressing model.");
   }
 
+#if LLVM_VERSION_GREATER_EQUAL(21, 0)
+  module.llvmModule->setTargetTriple(llvm::Triple("unknown-unknown-unknown"));
+#else
   module.llvmModule->setTargetTriple("unknown-unknown-unknown");
+#endif
 
   const char *dataLayout32 =
       "e-p:32:32:32-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f32:32:32-f64:"

--- a/modules/compiler/vecz/test/lit/llvm/packetization_debug_info.ll
+++ b/modules/compiler/vecz/test/lit/llvm/packetization_debug_info.ll
@@ -56,7 +56,7 @@ entry:
   call void @llvm.dbg.declare(metadata i64* %tid, metadata !14, metadata !29), !dbg !31
   %call = call i64 @__mux_get_global_id(i32 0) #3, !dbg !31
   store i64 %call, i64* %tid, align 8, !dbg !31
-; CHECK-GE19: #dbg_value(i32 undef, [[DI_A:![0-9]+]], !DIExpression(),
+; CHECK-GE19: #dbg_value(i32 {{undef|poison}}, [[DI_A:![0-9]+]], !DIExpression(),
 ; CHECK-LT19: call void @llvm.dbg.value(metadata i32 undef, metadata [[DI_A:![0-9]+]], metadata !DIExpression())
 ; CHECK-SAME: [[A_LOC:![0-9]+]]
   call void @llvm.dbg.declare(metadata i32* %a, metadata !19, metadata !29), !dbg !32
@@ -65,7 +65,7 @@ entry:
   %arrayidx = getelementptr inbounds i32, i32 addrspace(1)* %1, i64 %0, !dbg !32
   %2 = load i32, i32 addrspace(1)* %arrayidx, align 4, !dbg !32
   store i32 %2, i32* %a, align 4, !dbg !32
-; CHECK-GE19: #dbg_value(i32 undef, [[DI_B:![0-9]+]], !DIExpression(),
+; CHECK-GE19: #dbg_value(i32 {{undef|poison}}, [[DI_B:![0-9]+]], !DIExpression(),
 ; CHECK-LT19: call void @llvm.dbg.value(metadata i32 undef, metadata [[DI_B:![0-9]+]], metadata !DIExpression())
 ; CHECK-SAME: [[B_LOC:![0-9]+]]
   call void @llvm.dbg.declare(metadata i32* %b, metadata !20, metadata !29), !dbg !33

--- a/modules/compiler/vecz/tools/source/veczc.cpp
+++ b/modules/compiler/vecz/tools/source/veczc.cpp
@@ -141,9 +141,14 @@ static llvm::TargetMachine *initLLVMTarget(llvm::StringRef triple_string,
   }
   llvm::PassRegistry &registry = *llvm::PassRegistry::getPassRegistry();
   llvm::initializeAlwaysInlinerLegacyPassPass(registry);
+#if LLVM_VERSION_GREATER_EQUAL(21, 0)
+  return target->createTargetMachine(triple, cpu_model, target_features, opts,
+                                     llvm::Reloc::Model::Static);
+#else
   return target->createTargetMachine(triple.getTriple(), cpu_model,
                                      target_features, opts,
                                      llvm::Reloc::Model::Static);
+#endif
 }
 
 static vecz::VeczPassOptions getDefaultPassOptions() {
@@ -362,7 +367,11 @@ int main(const int argc, const char *const argv[]) {
                         : nullptr);
   assert(!UserTriple.size() || tm);
   if (tm) {
+#if LLVM_VERSION_GREATER_EQUAL(21, 0)
+    module->setTargetTriple(tm->getTargetTriple());
+#else
     module->setTargetTriple(tm->getTargetTriple().getTriple());
+#endif
     module->setDataLayout(tm->createDataLayout());
   }
 


### PR DESCRIPTION
# Overview

Update for LLVM 21.

# Reason for change

LLVM 21 has made changes to have modules store a triple, rather than a triple string, and several APIs were adjusted accordingly.

# Description of change

Update OCK to handle the new APIs.

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-19](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
