### PR TITLE
Increase CMake minimum version.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-cmake_minimum_required(VERSION 3.16 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.20 FATAL_ERROR)
 project(ComputeAorta VERSION 4.0.0 LANGUAGES C CXX ASM)
 
 # There's no situation where it's necessary to *not* generate this file and the

--- a/clik/CMakeLists.txt
+++ b/clik/CMakeLists.txt
@@ -14,7 +14,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-cmake_minimum_required(VERSION 3.0.0)
+cmake_minimum_required(VERSION 3.20)
 project(clik VERSION 1.0.0)
 
 if(CMAKE_SOURCE_DIR STREQUAL CMAKE_BINARY_DIR)

--- a/compiler_passes/CMakeLists.txt
+++ b/compiler_passes/CMakeLists.txt
@@ -14,7 +14,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-cmake_minimum_required(VERSION 3.16 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.20 FATAL_ERROR)
 project(ock_compiler_utils VERSION 1.0.0 LANGUAGES C CXX ASM)
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../cmake)

--- a/doc/overview/tutorials/creating-a-new-mux-target/running-new-target-script.rst
+++ b/doc/overview/tutorials/creating-a-new-mux-target/running-new-target-script.rst
@@ -97,7 +97,7 @@ The generated `CMakeLists.txt` is very simple and will look something like this:
 .. code:: cmake
 
   project(refsi_tutorial)
-  cmake_minimum_required(VERSION 3.4.3 FATAL_ERROR)
+  cmake_minimum_required(VERSION 3.20 FATAL_ERROR)
 
   set(CA_EXTERNAL_MUX_TARGET_DIRS "${CMAKE_CURRENT_SOURCE_DIR}/mux/refsi_tutorial"
     CACHE STRING "override" FORCE)

--- a/examples/applications/CMakeLists.txt
+++ b/examples/applications/CMakeLists.txt
@@ -14,7 +14,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-cmake_minimum_required(VERSION 3.26)
+cmake_minimum_required(VERSION 3.20)
 project(OCKTests)
 
 set(COMPILE_FLAGS "-fsycl -Wall ${WIN_FLAG}")

--- a/examples/hal_cpu_remote_server/CMakeLists.txt
+++ b/examples/hal_cpu_remote_server/CMakeLists.txt
@@ -13,7 +13,7 @@
 # under the License.
 #
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-cmake_minimum_required(VERSION 3.16 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.20 FATAL_ERROR)
 
 project(hal_cpu_remote_server VERSION 1.0.0 LANGUAGES C CXX ASM)
 set(CMAKE_CXX_STANDARD 17)            # Enable C++17 mode

--- a/examples/hals/hal_refsi_tutorial/CMakeLists.txt
+++ b/examples/hals/hal_refsi_tutorial/CMakeLists.txt
@@ -14,7 +14,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-cmake_minimum_required(VERSION 3.0.0)
+cmake_minimum_required(VERSION 3.20)
 
 if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
   project(hal_refsi_tutorial VERSION 1.0.0)

--- a/examples/refsi/hal_refsi/CMakeLists.txt
+++ b/examples/refsi/hal_refsi/CMakeLists.txt
@@ -14,7 +14,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-cmake_minimum_required(VERSION 3.0.0)
+cmake_minimum_required(VERSION 3.20)
 
 if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
   project(hal_refsi VERSION 1.0.0)

--- a/examples/refsi/hal_refsi/external/refsidrv/CMakeLists.txt
+++ b/examples/refsi/hal_refsi/external/refsidrv/CMakeLists.txt
@@ -14,7 +14,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-cmake_minimum_required(VERSION 3.0.0)
+cmake_minimum_required(VERSION 3.20)
 
 if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
   project(refsidrv VERSION 1.0.0)

--- a/examples/refsi/hal_refsi/source/loader/CMakeLists.txt
+++ b/examples/refsi/hal_refsi/source/loader/CMakeLists.txt
@@ -14,7 +14,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-cmake_minimum_required(VERSION 3.0.0)
+cmake_minimum_required(VERSION 3.20)
 
 if(CMAKE_BUILD_TYPE)
   if(CMAKE_BUILD_TYPE STREQUAL "Debug")

--- a/external/benchmark/CMakeLists.txt
+++ b/external/benchmark/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.5.1)
+cmake_minimum_required (VERSION 3.20)
 
 foreach(p
     CMP0048 # OK to clear PROJECT_VERSION on project()

--- a/external/benchmark/cmake/GoogleTest.cmake.in
+++ b/external/benchmark/cmake/GoogleTest.cmake.in
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.20)
 
 project(googletest-download NONE)
 

--- a/external/cookie/{{cookiecutter.external_dir}}/CMakeLists.txt
+++ b/external/cookie/{{cookiecutter.external_dir}}/CMakeLists.txt
@@ -19,7 +19,7 @@
 {% endif -%}
 
 project({{cookiecutter.target_name}})
-cmake_minimum_required(VERSION 3.4.3 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.20 FATAL_ERROR)
 
 set(CA_EXTERNAL_MUX_TARGET_DIRS "${CMAKE_CURRENT_SOURCE_DIR}/mux/{{cookiecutter.target_name}}"
   CACHE STRING "override" FORCE)

--- a/external/googletest/CMakeLists.txt
+++ b/external/googletest/CMakeLists.txt
@@ -46,7 +46,7 @@ endif()
 
 # Project version:
 
-cmake_minimum_required(VERSION 3.13)
+cmake_minimum_required(VERSION 3.20)
 project(gtest VERSION ${GOOGLETEST_VERSION} LANGUAGES CXX C)
 
 if (COMMAND set_up_hermetic_build)

--- a/hal/CMakeLists.txt
+++ b/hal/CMakeLists.txt
@@ -14,7 +14,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-cmake_minimum_required(VERSION 3.4.3 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.20 FATAL_ERROR)
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 set_property(GLOBAL PROPERTY HAL_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}")

--- a/modules/compiler/builtins/abacus/CMakeLists.txt
+++ b/modules/compiler/builtins/abacus/CMakeLists.txt
@@ -15,7 +15,7 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
-  cmake_minimum_required(VERSION 3.4.3)
+  cmake_minimum_required(VERSION 3.20)
   project(Abacus)
 endif()
 

--- a/modules/compiler/builtins/libimg/CMakeLists.txt
+++ b/modules/compiler/builtins/libimg/CMakeLists.txt
@@ -14,7 +14,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-cmake_minimum_required(VERSION 3.2.2 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.20 FATAL_ERROR)
 project(image_library VERSION 1.0.0)
 
 # If the online coverage is enabled we add the modules so that the XML file

--- a/modules/compiler/spirv-ll/CMakeLists.txt
+++ b/modules/compiler/spirv-ll/CMakeLists.txt
@@ -16,7 +16,7 @@
 
 if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
   # Support standalone spirv-ll build for ComputeCpp.
-  cmake_minimum_required(VERSION 3.4.3 FATAL_ERROR)
+  cmake_minimum_required(VERSION 3.20 FATAL_ERROR)
   project(spirv-ll)
   list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/../../cmake)
 

--- a/modules/compiler/vecz/CMakeLists.txt
+++ b/modules/compiler/vecz/CMakeLists.txt
@@ -16,7 +16,7 @@
 
 if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
   option(CA_VECZ_ONLY "Build Vecz only and not all of ComputeAorta" ON)
-  cmake_minimum_required(VERSION 3.4.3)
+  cmake_minimum_required(VERSION 3.20)
 
   project(VECZ)
 endif()

--- a/platform/arm-android/android-cmake/android.toolchain.cmake
+++ b/platform/arm-android/android-cmake/android.toolchain.cmake
@@ -184,7 +184,7 @@
 #
 # ------------------------------------------------------------------------------
 
-cmake_minimum_required( VERSION 2.6.3 )
+cmake_minimum_required( VERSION 3.20 )
 
 if( DEFINED CMAKE_CROSSCOMPILING )
  # subsequent toolchain loading is not really needed

--- a/source/cl/test/BenchCL/CMakeLists.txt
+++ b/source/cl/test/BenchCL/CMakeLists.txt
@@ -16,7 +16,7 @@
 
 if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
   project(BenchCL)
-  cmake_minimum_required(VERSION 3.4.3)
+  cmake_minimum_required(VERSION 3.20)
 
   set(BENCHCL_OPENCL_LIBRARY "" CACHE PATH
     "Path to the OpenCL library to link against.")

--- a/source/vk/external/Khronos/CMakeLists.txt
+++ b/source/vk/external/Khronos/CMakeLists.txt
@@ -18,7 +18,7 @@
 # CMake project initialization ---------------------------------------------------------------------------------------------------
 # This section contains pre-project() initialization, and ends with the project() command.
 
-cmake_minimum_required(VERSION 3.10.2)
+cmake_minimum_required(VERSION 3.20)
 
 # NONE = this project has no language toolchain requirement.
 project(Vulkan-Headers NONE)


### PR DESCRIPTION
# Overview

Increase CMake minimum version.

# Reason for change

Despite declaring a minimum CMake version of 3.16 at the top level, we were using CMake 3.19+ features without checking for support for them already.

# Description of change

As no 3.19 version of CMake is available at PyPI for testing, bump the minimum to 3.20 instead which we can check to work.

# Anything else we should know?

Propagate this change throughout the project to fix compatibility with CMake 4.0, which will raise errors on too old cmake_minimum_required versions.

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-19](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
