### PR TITLE
[CI] Update opencl_cts override files for test_api

### DIFF
--- a/.github/opencl_cts/override_all.csv
+++ b/.github/opencl_cts/override_all.csv
@@ -1,1 +1,0 @@
-API,api/test_api,Xfail

--- a/.github/opencl_cts/override_host_riscv64_linux.csv
+++ b/.github/opencl_cts/override_host_riscv64_linux.csv
@@ -1,1 +1,2 @@
 Math,math_brute_force/test_bruteforce -w,Xfail
+API,api/test_api,Xfail


### PR DESCRIPTION
# Overview

Delete the override_all.csv file and move test_api over to the host_riscv64_linux target.

# Reason for change

test_api now passes for host x86_64 and aarch64, although still fails for riscv64
