### PR TITLE
Fix more CL_KERNEL_LOCAL_MEM_SIZE.

### DIFF
--- a/.github/opencl_cts/override_host_riscv64_linux.csv
+++ b/.github/opencl_cts/override_host_riscv64_linux.csv
@@ -1,2 +1,1 @@
 Math,math_brute_force/test_bruteforce -w,Xfail
-API,api/test_api,Xfail

--- a/modules/compiler/targets/host/source/HostPassMachinery.cpp
+++ b/modules/compiler/targets/host/source/HostPassMachinery.cpp
@@ -271,6 +271,8 @@ llvm::ModulePassManager HostPassMachinery::getKernelFinalizationPasses(
   KWOpts.IsPackedStruct = true;
   PM.addPass(compiler::utils::AddKernelWrapperPass(KWOpts));
 
+  PM.addPass(compiler::utils::ComputeLocalMemoryUsagePass());
+
   PM.addPass(compiler::utils::ReplaceLocalModuleScopeVariablesPass());
 
   PM.addPass(AddFloatingPointControlPass(options.denorms_may_be_zero));
@@ -299,8 +301,6 @@ llvm::ModulePassManager HostPassMachinery::getKernelFinalizationPasses(
     PM.addPass(llvm::createModuleToFunctionPassAdaptor(
         compiler::utils::RemoveLifetimeIntrinsicsPass()));
   }
-
-  PM.addPass(compiler::utils::ComputeLocalMemoryUsagePass());
 
   PM.addPass(compiler::utils::AddMetadataPass<
              compiler::utils::VectorizeMetadataAnalysis,

--- a/modules/compiler/targets/host/source/module.cpp
+++ b/modules/compiler/targets/host/source/module.cpp
@@ -241,7 +241,6 @@ compiler::Kernel *HostModule::createKernel(const std::string &name) {
     const compiler::utils::EncodeKernelMetadataPassOptions pass_opts{name};
     pm.addPass(compiler::utils::EncodeKernelMetadataPass(pass_opts));
     pm.addPass(compiler::utils::ReduceToFunctionPass());
-    pm.addPass(compiler::utils::ComputeLocalMemoryUsagePass());
 
     pm.run(*kernel_module, pass_mach->getMAM());
     // Retrieve the estimation of the amount of local memory this kernel uses.


### PR DESCRIPTION
# Overview

Fix more CL_KERNEL_LOCAL_MEM_SIZE.

# Reason for change

In addition to the previous issue in handling local kernel arguments, CL_KERNEL_LOCAL_MEM_SIZE was also incorrect for non-deferred-compilation targets due to running
ComputeLocalMemoryUsagePass either not at all, or after ReplaceLocalModuleScopeVariablesPass. In order to get the correct local memory usage, the former needs to be run before the latter.

# Description of change

Update where it gets run.

# Anything else we should know?

This fixes the same OpenCL CTS test as before, `test_api`'s `kernel_local_memory_size`, in other configurations.

This PR leaves CL_KERNEL_LOCAL_MEM_SIZE unmodified for non-host targets.

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-19](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
