### PR TITLE
[CI] Update run_pr_tests to take flags for llvm_current and llvm_previous

### DIFF
--- a/.github/workflows/run_pr_tests.yml
+++ b/.github/workflows/run_pr_tests.yml
@@ -12,6 +12,16 @@ on:
         description: 'method of sourcing llvm (install or cache), currently advisory until all converted'
         type: string
         default: 'install'
+      llvm_previous:
+        required: false
+        type: string
+        description: 'previous llvm version to for those jobs tied to previous.'
+        default: '18'
+      llvm_current:
+        required: false
+        type: string
+        description: 'previous llvm version to for those jobs tied to current.'        
+        default: '19'
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
     inputs:
@@ -24,6 +34,16 @@ on:
         type: string
         description: 'method of sourcing llvm (install or cache), currently advisory until all converted'
         default: 'install'
+      llvm_previous:
+        required: false
+        type: string
+        description: 'previous llvm version to for those jobs tied to previous.'
+        default: '18'
+      llvm_current:
+        required: false
+        type: string
+        description: 'previous llvm version to for those jobs tied to current.'        
+        default: '19'
 
 permissions:
   packages: read
@@ -45,7 +65,7 @@ jobs:
       - name: setup-ubuntu
         uses:  ./.github/actions/setup_build
         with:
-          llvm_version: 18
+          llvm_version: ${{ inputs.llvm_previous }}
           llvm_build_type: RelAssert
           llvm_source: ${{ inputs.llvm_source}}
 
@@ -80,7 +100,7 @@ jobs:
       - name: setup-ubuntu
         uses:  ./.github/actions/setup_build
         with:
-          llvm_version: 18
+          llvm_version: ${{ inputs.llvm_previous }}
           llvm_build_type: RelAssert
           llvm_source: ${{ inputs.llvm_source}}
 
@@ -111,7 +131,7 @@ jobs:
       - name: setup-ubuntu
         uses:  ./.github/actions/setup_build
         with:
-          llvm_version: 19
+          llvm_version: ${{ inputs.llvm_current }}
           llvm_build_type: RelAssert
           llvm_source: ${{ inputs.llvm_source}}
 
@@ -182,7 +202,7 @@ jobs:
       - name: setup-windows
         uses: ./.github/actions/setup_build
         with:
-          llvm_version: 19
+          llvm_version: ${{ inputs.llvm_current }}
           llvm_build_type: RelAssert
           os: windows
           llvm_source: cache
@@ -206,7 +226,7 @@ jobs:
     - name: setup-ubuntu
       uses: ./.github/actions/setup_build
       with:
-        llvm_version: '18'
+        llvm_version: ${{ inputs.llvm_previous }}
         llvm_build_type: RelAssert
         llvm_source: ${{ inputs.llvm_source}}
     - name: build ock
@@ -227,7 +247,7 @@ jobs:
     - name: setup-ubuntu
       uses: ./.github/actions/setup_build
       with:
-        llvm_version: '19'
+        llvm_version: ${{ inputs.llvm_current }}
         llvm_build_type: RelAssert
         cross_arch: x86
         llvm_source: ${{ inputs.llvm_source}}
@@ -248,7 +268,7 @@ jobs:
     - name: setup-ubuntu
       uses: ./.github/actions/setup_build
       with:
-        llvm_version: '19'
+        llvm_version: ${{ inputs.llvm_current }}
         llvm_build_type: RelAssert
         llvm_source: ${{ inputs.llvm_source}}
     - name: build and run ock
@@ -268,7 +288,7 @@ jobs:
     - name: setup-ubuntu
       uses: ./.github/actions/setup_build
       with:
-        llvm_version: '19'
+        llvm_version: ${{ inputs.llvm_current }}
         llvm_build_type: Release
         llvm_source: ${{ inputs.llvm_source}}
     - name: build and run ock
@@ -288,7 +308,7 @@ jobs:
     - name: setup-ubuntu
       uses: ./.github/actions/setup_build
       with:
-        llvm_version: '19'
+        llvm_version: ${{ inputs.llvm_current }}
         llvm_build_type: RelAssert
         llvm_source:  ${{ inputs.llvm_source}}
     - name: build and run ock
@@ -333,7 +353,7 @@ jobs:
     - name: setup-ubuntu
       uses: ./.github/actions/setup_build
       with:
-        llvm_version: '19'
+        llvm_version: ${{ inputs.llvm_current }}
         llvm_build_type: RelAssert
         llvm_source: ${{ inputs.llvm_source}}
     - name: build ock


### PR DESCRIPTION
# Overview

This is a precursor to running the tests overnight on a single version, by using inputs for run_pr_tests for llvm versions rather than hardwiring it.

# Reason for change

It also simplifies the switch to the next llvm to changing two lines.
