### PR TITLE
Fix CL_KERNEL_LOCAL_MEM_SIZE a third time.

### DIFF
--- a/modules/compiler/targets/host/source/module.cpp
+++ b/modules/compiler/targets/host/source/module.cpp
@@ -241,6 +241,7 @@ compiler::Kernel *HostModule::createKernel(const std::string &name) {
     const compiler::utils::EncodeKernelMetadataPassOptions pass_opts{name};
     pm.addPass(compiler::utils::EncodeKernelMetadataPass(pass_opts));
     pm.addPass(compiler::utils::ReduceToFunctionPass());
+    pm.addPass(compiler::utils::ComputeLocalMemoryUsagePass());
 
     pm.run(*kernel_module, pass_mach->getMAM());
     // Retrieve the estimation of the amount of local memory this kernel uses.


### PR DESCRIPTION
# Overview

Fix CL_KERNEL_LOCAL_MEM_SIZE a third time.

# Reason for change

My previous change made it so that ComputeLocalMemoryUsagePass assuredly ran before ReplaceLocalModuleScopeVariablesPass which is necessary for correct results, but also made it so that with deferred compilation, it could run after encoding the kernel metadata, meaning the correct results came in too late.

# Description of change

Previously, it was getting additionally run in HostModule::createKernel so that results would always be available. Restore this.

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-19](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
