### PR TITLE
Address clang & clang-tidy warnings.

### DIFF
--- a/hal/hal_remote/include/hal_remote/hal_binary_decoder.h
+++ b/hal/hal_remote/include/hal_remote/hal_binary_decoder.h
@@ -73,7 +73,7 @@ class hal_binary_decoder {
                // 16
                sizeof(message.kernel_exec.num_args) +
                // 20
-               sizeof(message.kernel_exec.nd_range.offset[0]) * 9 +
+               (sizeof(message.kernel_exec.nd_range.offset[0]) * 9) +
                // 56
 
                sizeof(message.kernel_exec.work_dim) +

--- a/hal/hal_remote/include/hal_remote/hal_binary_encoder.h
+++ b/hal/hal_remote/include/hal_remote/hal_binary_encoder.h
@@ -59,7 +59,7 @@ class hal_binary_encoder {
     DEVICE_DELETE_REPLY = 24
   };
 
-  hal_binary_encoder(uint32_t device = 0) { device = device; }
+  hal_binary_encoder(uint32_t device = 0) : device(device) {}
 
   /// @brief encode mem alloc on a device
   /// @param size
@@ -343,7 +343,6 @@ class hal_binary_encoder {
     std::memcpy(encoding.data() + offset, &command, sizeof(command));
   }
   std::vector<uint8_t> encoding;
-  uint32_t offset = 0;
   uint32_t device = 0;
 };
 }  // namespace hal

--- a/hal/hal_remote/include/hal_remote/hal_server.h
+++ b/hal/hal_remote/include/hal_remote/hal_server.h
@@ -23,8 +23,8 @@
 #include <vector>
 
 namespace hal {
-class hal_t;
-class hal_device_t;
+struct hal_t;
+struct hal_device_t;
 
 /// @brief A server for taking binary data and translating into actions
 /// on a HAL and HAL devices
@@ -59,11 +59,11 @@ class hal_server {
     status_decode_failed
   };
   hal_server(hal::hal_transmitter *transmitter, hal::hal_t *hal);
-  ~hal_server();
 
   virtual error_code process_commands();
 
  protected:
+  ~hal_server();
   virtual error_code process_command();
   virtual hal_server::error_code process_mem_alloc(uint32_t device);
   virtual hal_server::error_code process_mem_free(uint32_t device);

--- a/hal/hal_remote/source/hal_server.cpp
+++ b/hal/hal_remote/source/hal_server.cpp
@@ -26,7 +26,7 @@
 namespace hal {
 hal_server::hal_server(hal_transmitter *transmitter, hal::hal_t *hal)
     : hal(hal), transmitter(transmitter) {
-  if (getenv("HAL_DEBUG_SERVER") && *getenv("HAL_DEBUG_SERVER") == '1') {
+  if (auto *Val = getenv("HAL_DEBUG_SERVER"); Val && strcmp(Val, "1") == 0) {
     debug = true;
   }
 }

--- a/hal/hal_remote/source/hal_socket_transmitter.cpp
+++ b/hal/hal_remote/source/hal_socket_transmitter.cpp
@@ -137,7 +137,7 @@ hal_socket_transmitter::error_code hal_socket_transmitter::setup_connection(
 
   struct addrinfo hints;
   struct addrinfo *result;
-  int sfd, s;
+  int s;
   std::memset(&hints, 0, sizeof(struct addrinfo));
   hints.ai_family = AF_UNSPEC; /* Allow IPv4 or IPv6 */
   hints.ai_socktype = SOCK_STREAM;

--- a/hal/include/arg_pack.h
+++ b/hal/include/arg_pack.h
@@ -69,7 +69,7 @@ struct hal_argpack_t {
   /// @brief Returns the size in bytes of the packed argument structure.
   ///
   /// @return Return the size in bytes of the packet argument structure.
-  const uint64_t size() const { return write_point; }
+  uint64_t size() const { return write_point; }
 
   /// @brief Returns a pointer to the start of the packed argument structure.
   ///

--- a/hal/include/elf.h
+++ b/hal/include/elf.h
@@ -41,7 +41,7 @@ typedef uint16_t Elf64_Half_t;
 typedef uint32_t Elf64_Word_t;
 typedef uint64_t Elf64_XWord_t;
 
-static inline constexpr uint8_t ELF32_ST_TYPE(uint8_t i) { return i & 0xf; }
+static constexpr uint8_t ELF32_ST_TYPE(uint8_t i) { return i & 0xf; }
 
 enum {
   // ELF identification
@@ -79,16 +79,11 @@ enum {
 
 template <bool Is64>
 struct ElfTypes {
-  using Elf_Half_t =
-      typename std::conditional<Is64, Elf64_Half_t, Elf32_Half_t>::type;
-  using Elf_Word_t =
-      typename std::conditional<Is64, Elf64_Word_t, Elf32_Word_t>::type;
-  using Elf_XWord_t =
-      typename std::conditional<Is64, Elf64_XWord_t, Elf32_XWord_t>::type;
-  using Elf_Addr_t =
-      typename std::conditional<Is64, Elf64_Addr_t, Elf32_Addr_t>::type;
-  using Elf_Off_t =
-      typename std::conditional<Is64, Elf64_Off_t, Elf32_Off_t>::type;
+  using Elf_Half_t = std::conditional_t<Is64, Elf64_Half_t, Elf32_Half_t>;
+  using Elf_Word_t = std::conditional_t<Is64, Elf64_Word_t, Elf32_Word_t>;
+  using Elf_XWord_t = std::conditional_t<Is64, Elf64_XWord_t, Elf32_XWord_t>;
+  using Elf_Addr_t = std::conditional_t<Is64, Elf64_Addr_t, Elf32_Addr_t>;
+  using Elf_Off_t = std::conditional_t<Is64, Elf64_Off_t, Elf32_Off_t>;
 };
 
 template <bool Is64>
@@ -248,6 +243,8 @@ struct elf_base_t {
   virtual bool find_symbol(const char *name, Elf_Sym_wrapper_t &) const = 0;
 
  protected:
+  ~elf_base_t() = default;
+
   const uint8_t *elf;
 };
 
@@ -255,10 +252,8 @@ template <bool Is64>
 struct elf_file_t : elf_base_t {
   elf_file_t() : hdr(nullptr) {}
 
-  using Elf_Phdr_t =
-      typename std::conditional<Is64, Elf64_Phdr_t, Elf32_Phdr_t>::type;
-  using Elf_Sym_t =
-      typename std::conditional<Is64, Elf64_Sym_t, Elf32_Sym_t>::type;
+  using Elf_Phdr_t = std::conditional_t<Is64, Elf64_Phdr_t, Elf32_Phdr_t>;
+  using Elf_Sym_t = std::conditional_t<Is64, Elf64_Sym_t, Elf32_Sym_t>;
 
   virtual bool get_header(Elf_Ehdr_wrapper_t &ehdr) const override {
     if (!hdr) {
@@ -364,13 +359,13 @@ struct elf_file_t : elf_base_t {
   }
 
   virtual bool get_phdr(int index, Elf_Phdr_wrapper_t &phdr) const override {
-    const auto offset = hdr->e_phoff + index * hdr->e_phentsize;
+    const auto offset = hdr->e_phoff + (index * hdr->e_phentsize);
     phdr = Elf_Phdr_wrapper_t(*(const Elf_Phdr_t *)(data() + offset));
     return true;
   }
 
   virtual bool get_shdr(int index, Elf_Shdr_wrapper_t &shdr) const override {
-    const auto offset = hdr->e_shoff + index * hdr->e_shentsize;
+    const auto offset = hdr->e_shoff + (index * hdr->e_shentsize);
     shdr = Elf_Shdr_wrapper_t(*(const Elf_Shdr_t<Is64> *)(data() + offset));
     return true;
   }

--- a/hal/include/hal.h
+++ b/hal/include/hal.h
@@ -248,6 +248,9 @@ struct hal_t {
   ///
   /// @return Returns `false` if the operation fails otherwise `true`.
   virtual bool device_delete(hal_device_t *device) = 0;
+
+ protected:
+  ~hal_t() = default;
 };
 
 /// @}

--- a/hal/include/program.h
+++ b/hal/include/program.h
@@ -52,14 +52,14 @@ struct hal_program_impl_t {
   /// @param size is size in bytes of the data parameter.
   ///
   /// @return Returns true if the ELF file was loaded correctly.
-  virtual bool load(const uint8_t *data, size_t size);
+  bool load(const uint8_t *data, size_t size);
 
   /// @brief Load a program into device memory.
   ///
   /// @param dev is the device to load this program into.
   ///
   /// @return Returns true if upload was successful otherwise false.
-  virtual bool upload(hal_device_t *dev);
+  bool upload(hal_device_t *dev);
 
   /// @brief Load the given ELF section into device memory.
   ///
@@ -69,9 +69,8 @@ struct hal_program_impl_t {
   /// @param phdr is the program header for this section.
   ///
   /// @return Returns true if upload was successful otherwise false.
-  virtual bool upload_section_copy(hal_device_t *dev, const uint8_t *data,
-                                   Elf64_XWord_t to_copy,
-                                   Elf_Phdr_wrapper_t phdr);
+  bool upload_section_copy(hal_device_t *dev, const uint8_t *data,
+                           Elf64_XWord_t to_copy, Elf_Phdr_wrapper_t phdr);
 
   /// @brief Initialize the given ELF section in device memory by zeroing it.
   ///
@@ -81,16 +80,15 @@ struct hal_program_impl_t {
   /// @param phdr is the program header for this section.
   ///
   /// @return Returns true if upload was successful otherwise false.
-  virtual bool upload_section_zero(hal_device_t *dev, Elf64_XWord_t offset,
-                                   Elf64_XWord_t to_zero,
-                                   Elf_Phdr_wrapper_t phdr);
+  bool upload_section_zero(hal_device_t *dev, Elf64_XWord_t offset,
+                           Elf64_XWord_t to_zero, Elf_Phdr_wrapper_t phdr);
 
   /// @brief Lookup a symbol address in this elf file.
   ///
   /// @param name is a c-string with the name of the symbol to find.
   ///
   /// @return Returns address of symbol or hal_nullptr.
-  virtual hal_addr_t find_symbol(const char *name) const {
+  hal_addr_t find_symbol(const char *name) const {
     auto itt = symbols.find(name);
     return (itt == symbols.end()) ? hal_nullptr : itt->second;
   }
@@ -101,8 +99,7 @@ struct hal_program_impl_t {
   /// @param kernel_name is the output parameter for the kernel name.
   ///
   /// @return Returns true if the symbol can be located.
-  virtual bool find_symbol(hal::hal_addr_t addr,
-                           std::string &kernel_name) const {
+  bool find_symbol(hal::hal_addr_t addr, std::string &kernel_name) const {
     for (const auto &k : symbols) {
       if (k.second == addr) {
         kernel_name = k.first;
@@ -115,10 +112,10 @@ struct hal_program_impl_t {
   /// @brief Check if this object encapsulates a valid program.
   ///
   /// @return true if a program has been loaded and is valid, else false.
-  virtual bool is_valid() const { return bool(data) && size > 0; }
+  bool is_valid() const { return bool(data) && size > 0; }
 
   /// @brief Discard all data related to the currently loaded program.
-  virtual void unload() {
+  void unload() {
     data.reset();
     size = 0;
     symbols.clear();

--- a/hal/source/arg_pack.cpp
+++ b/hal/source/arg_pack.cpp
@@ -76,7 +76,7 @@ bool hal_argpack_t::add_arg(const hal_arg_t &arg) {
           write_point += padding;
           std::memcpy(pack + write_point, &arg.address, sizeof(arg.address));
           write_point += sizeof(arg.address);
-          break;
+          return true;
         }
         case hal_arg_value: {
           // copy POD data in directly
@@ -88,11 +88,8 @@ bool hal_argpack_t::add_arg(const hal_arg_t &arg) {
           }
           std::memcpy(pack + write_point, arg.pod_data, arg.size);
           write_point += arg.size;
-          break;
+          return true;
         }
-        default:
-          assert(!"Not implemented");
-          return false;
       }
       break;
     case hal_space_local:
@@ -120,8 +117,7 @@ bool hal_argpack_t::add_arg(const hal_arg_t &arg) {
               std::memcpy(pack + write_point, &size, sizeof(size));
               write_point += sizeof(size);
             } else {
-              assert(!"Not implemented");
-              return false;
+              break;
             }
           } else {
             if (!expand(word_size_in_bits / 8)) {
@@ -140,17 +136,15 @@ bool hal_argpack_t::add_arg(const hal_arg_t &arg) {
               return false;
             }
           }
-          break;
+          return true;
         default:
-          assert(!"Not implemented");
-          return false;
+          break;
       }
       break;
-    default:
-      assert(!"Not implemented");
-      return false;
   }
-  return true;
+
+  assert(0 && "Not implemented");
+  return false;
 }
 
 bool hal_argpack_t::build(const hal_arg_t *args, uint32_t num_args) {

--- a/hal/source/hal_riscv_common.cpp
+++ b/hal/source/hal_riscv_common.cpp
@@ -59,7 +59,7 @@ bool update_info_from_riscv_isa_description(
     info.word_size = word_size;
   }
 
-  while (char c = *str++) {
+  while (const char c = *str++) {
     switch (c) {
       case 'M':
         riscv_info.extensions |= rv_extension_M;
@@ -117,7 +117,7 @@ bool update_info_from_riscv_isa_description(
       case 'Z': {
         // Start parsing a multi-letter extension.
         auto *start = str;
-        while (char zc = *str) {
+        while (const char zc = *str) {
           // Z extensions should be followed by an underscore, otherwise we'll
           // eat until the end of the string.
           if (zc == '_') {

--- a/hal/source/profiler.cpp
+++ b/hal/source/profiler.cpp
@@ -71,16 +71,16 @@ void hal_profiler_t::set_output_path(const std::string &path) {
 
 void hal_profiler_t::update_counters(hal::hal_device_t &device,
                                      std::string name) {
-  bool log_enable = log_level != hal::hal_counter_verbose_none;
+  const bool log_enable = log_level != hal::hal_counter_verbose_none;
   size_t total_acc_index = 0;
 
   for (unsigned i = 0; i < num_counters; i++) {
     auto id = descs[i].counter_id;
-    bool log_per_val =
+    const bool log_per_val =
         log_enable && descs[i].log_cfg.min_verbosity_per_value <= log_level;
-    bool log_total =
+    const bool log_total =
         log_enable && descs[i].log_cfg.min_verbosity_total <= log_level;
-    bool multiple_values = descs[i].contained_values > 1;
+    const bool multiple_values = descs[i].contained_values > 1;
 
     uint64_t value;
     for (unsigned j = 0; j < descs[i].contained_values; j++) {
@@ -116,7 +116,6 @@ void hal_profiler_t::update_counters(hal::hal_device_t &device,
   unsigned subval_count = 0;
   auto subval_total = map_subval_to_rows.size();
   for (auto &subval_entry : map_subval_to_rows) {
-    auto &sub_val_type = subval_entry.first;
     auto &sub_val_rows = subval_entry.second;
     for (auto &row : sub_val_rows) {
       if (row.values.size() == 0) {
@@ -159,7 +158,7 @@ void hal_profiler_t::setup_counters(hal::hal_device_t &device) {
   num_counters = device.get_info()->num_counters;
   int log_level = 0;
   if (const char *log_env = std::getenv("CA_PROFILE_LEVEL")) {
-    if (int log_env_val = atoi(log_env)) {
+    if (const int log_env_val = atoi(log_env)) {
       log_level = log_env_val;
     }
   }
@@ -204,6 +203,7 @@ void hal_profiler_t::setup_counters(hal::hal_device_t &device) {
       // column for the actual sub-value values (e.g. the actual hart_id value)
       if (!map_subval_to_rows.count(descs[i].sub_value_name)) {
         std::vector<log_row_t> sv_rows{};
+        sv_rows.reserve(descs[i].contained_values);
         for (unsigned j = 0; j < descs[i].contained_values; j++) {
           sv_rows.push_back({descs[i].sub_value_name, j, {}});
         }

--- a/modules/cargo/test/argument_parser.cpp
+++ b/modules/cargo/test/argument_parser.cpp
@@ -258,13 +258,12 @@ TEST(argument_parser, parse_args_custom) {
   ASSERT_EQ(cargo::success, parser.add_argument({"-option", option}));
   ASSERT_EQ(cargo::success,
             parser.add_argument({"-add",
-                                 [&counter](cargo::string_view sv) {
-                                   (void)sv;
+                                 [&counter](cargo::string_view) {
                                    counter++;
                                    return cargo::argument::parse::COMPLETE;
                                  },
-                                 [&counter](cargo::string_view sv) {
-                                   counter += sv[0] - '0' - 1;
+                                 [&counter](cargo::string_view Sv) {
+                                   counter += Sv[0] - '0' - 1;
                                    return cargo::argument::parse::COMPLETE;
                                  }}));
   ASSERT_FALSE(option);

--- a/modules/cargo/test/mutex.cpp
+++ b/modules/cargo/test/mutex.cpp
@@ -115,6 +115,6 @@ TEST(ostream_lock_guard, operator_output_threads) {
   for (auto &word : words) {
     ASSERT_TRUE(std::any_of(
         lookup.begin(), lookup.end(),
-        [&word](const cargo::string_view &a) { return a == word; }));
+        [&word](const cargo::string_view &A) { return A == word; }));
   }
 }

--- a/modules/compiler/builtins/CMakeLists.txt
+++ b/modules/compiler/builtins/CMakeLists.txt
@@ -601,7 +601,7 @@ add_resources(NAMESPACE builtins
 # Generate the body of get_api_force_file_device()
 set(get_force_header_src "")
 set(get_force_header_str "\
-  if (0 == std::strcmp(device_name, \"@dev_name@\")) {
+  if (0 == std::strcmp(DeviceName, \"@dev_name@\")) {
     return rc::builtins::@prefix@\;
   }
 ")
@@ -617,8 +617,8 @@ if(CA_FORCE_HEADERS_PREFIXES)
   endforeach()
   unset(num_headers)
 else()
-  # If there are no forced headers, device_name isn't used
-  set(get_force_header_src "  (void)device_name;")
+  # If there are no forced headers, DeviceName isn't used
+  set(get_force_header_src "  (void)DeviceName;")
 endif()
 
 # get_force_header_src is used to configure bakery.cpp.in

--- a/modules/compiler/builtins/include/builtins/image_library_integration.h
+++ b/modules/compiler/builtins/include/builtins/image_library_integration.h
@@ -87,8 +87,6 @@ inline ElemType get_v2(const VecType &v, const vec_elem elem) {
 template <typename ElemType, typename VecType>
 inline ElemType get_v4(const VecType &v, const vec_elem elem) {
   switch (elem) {
-    default:
-      return 0;
     case vec_elem::x:
       return v[0];
     case vec_elem::y:
@@ -98,6 +96,7 @@ inline ElemType get_v4(const VecType &v, const vec_elem elem) {
     case vec_elem::w:
       return v[3];
   }
+  return 0;
 }
 
 template <typename VecType, typename ElemType>
@@ -117,8 +116,6 @@ inline void set_v2(VecType &v, const ElemType val, const vec_elem elem) {
 template <typename VecType, typename ElemType>
 inline void set_v4(VecType &v, const ElemType val, const vec_elem elem) {
   switch (elem) {
-    default:
-      return;
     case vec_elem::x:
       v[0] = val;
       return;

--- a/modules/compiler/builtins/source/bakery.cpp.in
+++ b/modules/compiler/builtins/source/bakery.cpp.in
@@ -31,7 +31,7 @@ cargo::array_view<const uint8_t> get_api_30_src_file() {
 #endif
 
 cargo::array_view<const uint8_t> get_api_force_file_device(
-    const char *const device_name) {
+    const char *const DeviceName) {
   // Begin auto-generated boilerplate
 @get_force_header_src@
   // End auto-generated boilerplate
@@ -39,104 +39,104 @@ cargo::array_view<const uint8_t> get_api_force_file_device(
 }
 
 cargo::array_view<const uint8_t> get_pch_file(
-    file::capabilities_bitfield caps) {
-  cargo::array_view<const uint8_t> resource;
-  switch (caps) {
+    file::capabilities_bitfield Caps) {
+  cargo::array_view<const uint8_t> Resource;
+  switch (Caps) {
     case file::CAPS_32BIT | file::CAPS_FP64 | file::CAPS_FP16:
-      resource = rc::builtins::builtins32_fp64_fp16_pch;
+      Resource = rc::builtins::builtins32_fp64_fp16_pch;
       break;
     case file::CAPS_32BIT | file::CAPS_FP64:
-      resource = rc::builtins::builtins32_fp64_pch;
+      Resource = rc::builtins::builtins32_fp64_pch;
       break;
     case file::CAPS_32BIT | file::CAPS_FP16:
-      resource = rc::builtins::builtins32_fp16_pch;
+      Resource = rc::builtins::builtins32_fp16_pch;
       break;
     case file::CAPS_32BIT:
-      resource = rc::builtins::builtins32_pch;
+      Resource = rc::builtins::builtins32_pch;
       break;
     case file::CAPS_FP64 | file::CAPS_FP16:
-      resource = rc::builtins::builtins64_fp64_fp16_pch;
+      Resource = rc::builtins::builtins64_fp64_fp16_pch;
       break;
     case file::CAPS_FP64:
-      resource = rc::builtins::builtins64_fp64_pch;
+      Resource = rc::builtins::builtins64_fp64_pch;
       break;
     case file::CAPS_FP16:
-      resource = rc::builtins::builtins64_fp16_pch;
+      Resource = rc::builtins::builtins64_fp16_pch;
       break;
     case file::CAPS_DEFAULT:
-      resource = rc::builtins::builtins64_pch;
+      Resource = rc::builtins::builtins64_pch;
       break;
     default:
       (void)fprintf(stderr, "Illegal capabilities_bitfield\n");
       abort();
   }
-  if (resource.size() == 1) {
+  if (Resource.size() == 1) {
     (void)fprintf(
         stderr,
         "Attempted to load an unavailable PCH file with capabilities:\n");
     (void)fprintf(stderr, "Bit width: %d\n",
-                  (caps & file::CAPS_32BIT) ? 32 : 64);
+                  (Caps & file::CAPS_32BIT) ? 32 : 64);
     (void)fprintf(stderr, "Doubles: %s\n",
-                  (caps & file::CAPS_FP64) ? "Enabled" : "Disabled");
+                  (Caps & file::CAPS_FP64) ? "Enabled" : "Disabled");
     (void)fprintf(stderr, "Halfs: %s\n",
-                  (caps & file::CAPS_FP16) ? "Enabled" : "Disabled");
+                  (Caps & file::CAPS_FP16) ? "Enabled" : "Disabled");
     (void)fprintf(
         stderr,
         "This usually indicates that the device capabilities were "
         "incorrectly listed in the target device's CMakeLists.txt.\n");
     abort();
   }
-  return resource;
+  return Resource;
 }
 
-cargo::array_view<const uint8_t> get_bc_file(file::capabilities_bitfield caps) {
-  cargo::array_view<const uint8_t> resource;
-  switch (caps) {
+cargo::array_view<const uint8_t> get_bc_file(file::capabilities_bitfield Caps) {
+  cargo::array_view<const uint8_t> Resource;
+  switch (Caps) {
     case file::CAPS_32BIT | file::CAPS_FP64 | file::CAPS_FP16:
-      resource = rc::builtins::builtins32_fp64_fp16_bc;
+      Resource = rc::builtins::builtins32_fp64_fp16_bc;
       break;
     case file::CAPS_32BIT | file::CAPS_FP64:
-      resource = rc::builtins::builtins32_fp64_bc;
+      Resource = rc::builtins::builtins32_fp64_bc;
       break;
     case file::CAPS_32BIT | file::CAPS_FP16:
-      resource = rc::builtins::builtins32_fp16_bc;
+      Resource = rc::builtins::builtins32_fp16_bc;
       break;
     case file::CAPS_32BIT:
-      resource = rc::builtins::builtins32_bc;
+      Resource = rc::builtins::builtins32_bc;
       break;
     case file::CAPS_FP64 | file::CAPS_FP16:
-      resource = rc::builtins::builtins64_fp64_fp16_bc;
+      Resource = rc::builtins::builtins64_fp64_fp16_bc;
       break;
     case file::CAPS_FP64:
-      resource = rc::builtins::builtins64_fp64_bc;
+      Resource = rc::builtins::builtins64_fp64_bc;
       break;
     case file::CAPS_FP16:
-      resource = rc::builtins::builtins64_fp16_bc;
+      Resource = rc::builtins::builtins64_fp16_bc;
       break;
     case file::CAPS_DEFAULT:
-      resource = rc::builtins::builtins64_bc;
+      Resource = rc::builtins::builtins64_bc;
       break;
     default:
       (void)fprintf(stderr, "Illegal capabilities_bitfield\n");
       abort();
   }
-  if (resource.size() == 1) {
+  if (Resource.size() == 1) {
     (void)fprintf(
         stderr,
         "Attempted to load an unavailable BC file with capabilities:\n");
     (void)fprintf(stderr, "Bit width: %d\n",
-                  (caps & file::CAPS_32BIT) ? 32 : 64);
+                  (Caps & file::CAPS_32BIT) ? 32 : 64);
     (void)fprintf(stderr, "Doubles: %s\n",
-                  (caps & file::CAPS_FP64) ? "Enabled" : "Disabled");
+                  (Caps & file::CAPS_FP64) ? "Enabled" : "Disabled");
     (void)fprintf(stderr, "Halfs: %s\n",
-                  (caps & file::CAPS_FP16) ? "Enabled" : "Disabled");
+                  (Caps & file::CAPS_FP16) ? "Enabled" : "Disabled");
     (void)fprintf(
         stderr,
         "This usually indicates that the device capabilities were "
         "incorrectly listed in the target device's CMakeLists.txt.\n");
     abort();
   }
-  return resource;
+  return Resource;
 }
 
 }  // namespace builtins

--- a/modules/compiler/cmake/compiler-config.cmake
+++ b/modules/compiler/cmake/compiler-config.cmake
@@ -88,17 +88,17 @@ cargo::array_view<const compiler::Info *> compilers() {
 ")
 
 file(APPEND ${COMPILER_CONFIG_SOURCE} "\
-  static std::vector<const compiler::Info *> compilers_list;
-  static std::once_flag compilers_initialized;
-  std::call_once(compilers_initialized,
+  static std::vector<const compiler::Info *> CompilersList;
+  static std::once_flag CompilersInitialized;
+  std::call_once(CompilersInitialized,
     [] {
-      auto add_compiler = [](const compiler::Info* info) {
-        compilers_list.push_back(info);
+      auto AddCompiler = [](const compiler::Info* Info) {
+        CompilersList.push_back(Info);
       };
 ")
 foreach(COMPILER_INFO ${COMPILER_INFO_NAMES})
   file(APPEND ${COMPILER_CONFIG_SOURCE} "\
-      ${COMPILER_INFO}(add_compiler);
+      ${COMPILER_INFO}(AddCompiler);
 ")
 endforeach()
 file(APPEND ${COMPILER_CONFIG_SOURCE} "\
@@ -106,7 +106,7 @@ file(APPEND ${COMPILER_CONFIG_SOURCE} "\
 ")
 
 file(APPEND ${COMPILER_CONFIG_SOURCE} "\
-  return compilers_list;
+  return CompilersList;
 }
 }  // namespace compiler
 ")

--- a/modules/compiler/compiler_pipeline/source/attributes.cpp
+++ b/modules/compiler/compiler_pipeline/source/attributes.cpp
@@ -152,9 +152,8 @@ std::optional<uint32_t> getDMAReqdSizeBytes(const Function &F) {
 static constexpr const char *BarrierScheduleAttrName = "mux-barrier-schedule";
 
 void setBarrierSchedule(CallInst &CI, BarrierSchedule Sched) {
-  StringRef Val;
+  StringRef Val = "unknown";
   switch (Sched) {
-    default:
     case BarrierSchedule::Unordered:
       Val = "unordered";
       break;

--- a/modules/compiler/compiler_pipeline/source/barrier_regions.cpp
+++ b/modules/compiler/compiler_pipeline/source/barrier_regions.cpp
@@ -1044,11 +1044,15 @@ Function *compiler::utils::Barrier::GenerateNewKernel(BarrierRegion &region) {
   BasicBlock *entry_point = region.entry;
   LLVMContext &context = module_.getContext();
 
-  LLVM_DEBUG(dbgs() << "\n"; unsigned i = 0; for (auto *d : region.blocks) {
-    dbgs() << "entry block: " << entry_point->getName() << "\n";
-    dbgs() << "region visited path [" << i++ << "] = " << d->getName()
-           << "\n\n";
-    dbgs() << *d << "\n\n";
+  LLVM_DEBUG({
+    dbgs() << "\n";
+    unsigned I = 0;
+    for (auto *D : region.blocks) {
+      dbgs() << "entry block: " << entry_point->getName() << "\n";
+      dbgs() << "region visited path [" << I++ << "] = " << D->getName()
+             << "\n\n";
+      dbgs() << *D << "\n\n";
+    }
   });
 
   SmallVector<Type *, 8> new_func_params;
@@ -1475,14 +1479,14 @@ void compiler::utils::Barrier::SeperateKernelWithBarrier() {
   barrier_md->addOperand(num_barriers__md);
 
   LLVM_DEBUG({
-    for (const auto &kid : kernel_id_map_) {
-      dbgs() << "1. kernel_id[" << kid.first << "] = " << kid.second->getName()
+    for (const auto &Kid : kernel_id_map_) {
+      dbgs() << "1. kernel_id[" << Kid.first << "] = " << Kid.second->getName()
              << "\n";
     }
 
-    for (unsigned i = kBarrier_FirstID;
-         i < kernel_id_map_.size() + kBarrier_FirstID; i++) {
-      dbgs() << "2. kernel_id[" << i << "] = " << kernel_id_map_[i]->getName()
+    for (unsigned I = kBarrier_FirstID;
+         I < kernel_id_map_.size() + kBarrier_FirstID; I++) {
+      dbgs() << "2. kernel_id[" << I << "] = " << kernel_id_map_[I]->getName()
              << "\n";
     }
     dbgs() << "\n\n" << module_ << "\n\n";

--- a/modules/compiler/compiler_pipeline/source/builtin_info.cpp
+++ b/modules/compiler/compiler_pipeline/source/builtin_info.cpp
@@ -1147,8 +1147,6 @@ BuiltinID BuiltinInfo::getMuxGroupCollective(const GroupCollective &Group) {
 #define SIMPLE_SCOPE_SWITCH(OP)                     \
   do {                                              \
     switch (Group.Scope) {                          \
-      default:                                      \
-        llvm_unreachable("Impossible scope kind");  \
       case GroupCollective::ScopeKind::SubGroup:    \
         return eMuxBuiltinSubgroup##OP;             \
       case GroupCollective::ScopeKind::WorkGroup:   \
@@ -1156,6 +1154,7 @@ BuiltinID BuiltinInfo::getMuxGroupCollective(const GroupCollective &Group) {
       case GroupCollective::ScopeKind::VectorGroup: \
         return eMuxBuiltinVecgroup##OP;             \
     }                                               \
+    llvm_unreachable("Impossible scope kind");      \
   } while (0)
 
 #define COMPLEX_SCOPE_SWITCH(OP, SUFFIX)               \

--- a/modules/compiler/compiler_pipeline/source/cl_builtin_info.cpp
+++ b/modules/compiler/compiler_pipeline/source/cl_builtin_info.cpp
@@ -2376,7 +2376,7 @@ Value *CLBuiltinInfo::emitBuiltinInlineVStoreHalf(Function *F, StringRef Mode,
   DataPtr = B.CreateGEP(U16Ty, DataPtr, Offset, "vstore_base");
 
   // Store the ushort.
-  return B.CreateStore(Data, DataPtr, "vstore_half");
+  return B.CreateStore(Data, DataPtr);
 }
 
 /// @brief Emit the body of a relational builtin function.

--- a/modules/compiler/compiler_pipeline/source/work_item_loops_pass.cpp
+++ b/modules/compiler/compiler_pipeline/source/work_item_loops_pass.cpp
@@ -1721,9 +1721,6 @@ Function *compiler::utils::WorkItemLoopsPass::makeWrapperFunction(
 
       auto *const exitBlock = [&]() {
         switch (barrierMain.getSchedule(i)) {
-          default:
-            assert(!"Unexpected barrier schedule enum");
-            LLVM_FALLTHROUGH;
           case BarrierSchedule::Unordered:
           case BarrierSchedule::ScalarTail:
             if (tailInfo && tailInfo->IsVectorPredicated) {
@@ -1737,6 +1734,8 @@ Function *compiler::utils::WorkItemLoopsPass::makeWrapperFunction(
           case BarrierSchedule::Linear:
             return schedule.makeLinearWorkItemLoops(block, i);
         }
+
+        llvm_unreachable("Unexpected barrier schedule enum");
       }();
 
       // the last basic block in our function!

--- a/modules/compiler/source/base/source/module.cpp
+++ b/modules/compiler/source/base/source/module.cpp
@@ -188,7 +188,7 @@ class DeserializeMemoryBuffer final : public llvm::MemoryBuffer {
     init(buffer.begin(), buffer.end(), false);
   }
 
-  virtual llvm::MemoryBuffer::BufferKind getBufferKind() const {
+  llvm::MemoryBuffer::BufferKind getBufferKind() const override {
     return llvm::MemoryBuffer::MemoryBuffer_Malloc;
   }
 };
@@ -200,7 +200,7 @@ class BakedMemoryBuffer : public llvm::MemoryBuffer {
          static_cast<const char *>(buffer) + size, true);
   }
 
-  virtual llvm::MemoryBuffer::BufferKind getBufferKind() const {
+  llvm::MemoryBuffer::BufferKind getBufferKind() const override {
     return llvm::MemoryBuffer::MemoryBuffer_Malloc;
   }
 
@@ -1023,9 +1023,9 @@ clang::LangStandard::Kind BaseModule::setClangOpenCLStandard(
     case Standard::OpenCLC30:
       lang_opts.OpenCLVersion = 300;
       return clang::LangStandard::lang_opencl30;
-    default:
-      llvm_unreachable("clang language standard not initialised");
   }
+
+  llvm_unreachable("clang language standard not initialised");
 }
 
 void BaseModule::setDefaultOpenCLLangOpts(clang::LangOptions &lang_opts) const {

--- a/modules/compiler/spirv-ll/source/builder.cpp
+++ b/modules/compiler/spirv-ll/source/builder.cpp
@@ -1034,7 +1034,7 @@ llvm::Value *spirv_ll::Builder::createOCLBuiltinCall(
   }
 
   SPIRV_LL_ASSERT(
-      llvm::all_of(argVals, [](const llvm::Value *v) { return v != nullptr; }),
+      llvm::all_of(argVals, [](const llvm::Value *V) { return V != nullptr; }),
       "Can't call with a null value");
 
   return createMangledBuiltinCall(fnName, resultType, resMangleInfo, argVals,

--- a/modules/compiler/targets/host/source/target.cpp
+++ b/modules/compiler/targets/host/source/target.cpp
@@ -199,8 +199,7 @@ compiler::Result HostTarget::initWithBuiltins(
           triple = llvm::Triple(llvm::sys::getProcessTriple() + "-elf");
           break;
         default:
-          assert(!"AArch64 cross-compile only supports Linux");
-          break;
+          llvm_unreachable("AArch64 cross-compile only supports Linux");
       }
       break;
     case host::arch::RISCV32:

--- a/modules/compiler/utils/source/metadata_hooks.cpp
+++ b/modules/compiler/utils/source/metadata_hooks.cpp
@@ -39,7 +39,7 @@ md_hooks getElfMetadataWriteHooks() {
     llvm::Constant *MDInit;
     if (GlobalMD) {
       auto *OldData =
-          llvm::dyn_cast<llvm::ConstantDataArray>(GlobalMD->getInitializer());
+          llvm::cast<llvm::ConstantDataArray>(GlobalMD->getInitializer());
       auto OldBytes = OldData->getRawDataValues();
 
       // Append data

--- a/modules/compiler/vecz/source/reachability.cpp
+++ b/modules/compiler/vecz/source/reachability.cpp
@@ -177,23 +177,23 @@ void Reachability::recalculate(Function &F) {
   }
 
   LLVM_DEBUG({
-    size_t i = 0;
+    size_t I = 0;
     for (auto &BB : F) {
-      auto &node = graph[i];
+      auto &Node = graph[I];
       dbgs() << BB.getName() << ":\n";
-      dbgs() << "[ " << node.X << ", " << node.Y << " ] : ";
-      dbgs() << "( " << node.dom << ", " << node.postDom << " ) : ";
-      for (const size_t s : node.successors) {
-        if (graph[s].X <= graph[i].X) {
+      dbgs() << "[ " << Node.X << ", " << Node.Y << " ] : ";
+      dbgs() << "( " << Node.dom << ", " << Node.postDom << " ) : ";
+      for (const size_t S : Node.successors) {
+        if (graph[S].X <= graph[I].X) {
           dbgs() << "!x!";
         }
-        if (graph[s].Y <= graph[i].Y) {
+        if (graph[S].Y <= graph[I].Y) {
           dbgs() << "!y!";
         }
-        dbgs() << s << "; ";
+        dbgs() << S << "; ";
       }
       dbgs() << "\n\n";
-      ++i;
+      ++I;
     }
   });
 

--- a/modules/compiler/vecz/source/transform/control_flow_conversion_pass.cpp
+++ b/modules/compiler/vecz/source/transform/control_flow_conversion_pass.cpp
@@ -2540,10 +2540,10 @@ bool ControlFlowConversionState::Impl::computeNewTargets(Linearization &lin) {
           dbgs() << " (empty)\n";
         } else {
           dbgs() << "\n";
-          for (const auto &pair : deferrals) {
-            for (BasicBlock *deferred : pair.second) {
-              LLVM_DEBUG(dbgs() << "\t(" << pair.first->getName() << ", "
-                                << deferred->getName() << ")\n");
+          for (const auto &Pair : deferrals) {
+            for (BasicBlock *Deferred : Pair.second) {
+              LLVM_DEBUG(dbgs() << "\t(" << Pair.first->getName() << ", "
+                                << Deferred->getName() << ")\n");
             }
           }
         }
@@ -2934,8 +2934,8 @@ bool ControlFlowConversionState::Impl::blendInstructions() {
         dbgs() << "\t\t\tWorklist: [";
         if (!queue.empty()) {
           dbgs() << DR->getBlockTag(*queue.begin()).BB->getName();
-          for (auto it = std::next(queue.begin()); it != queue.end(); ++it) {
-            dbgs() << ", " << DR->getBlockTag(*it).BB->getName();
+          for (auto It = std::next(queue.begin()); It != queue.end(); ++It) {
+            dbgs() << ", " << DR->getBlockTag(*It).BB->getName();
           }
           dbgs() << "]\n";
         }

--- a/modules/compiler/vecz/source/transform/scalarizer.cpp
+++ b/modules/compiler/vecz/source/transform/scalarizer.cpp
@@ -1143,10 +1143,10 @@ SimdPacket *Scalarizer::scalarizeBitCast(BitCastInst *BC, PacketMask PM) {
         }
         Lane = Lane ? B.CreateOr(Lane, SrcPart) : SrcPart;
       }
+      assert(Lane && "No bits found for lane");
       if (DstEleTy != DstEleIntTy) {
         Lane = B.CreateBitCast(Lane, DstEleTy);
       }
-      assert(Lane && "No bits found for lane");
       P->set(i, Lane);
     }
     return P;

--- a/modules/compiler/vecz/source/vectorization_context.cpp
+++ b/modules/compiler/vecz/source/vectorization_context.cpp
@@ -607,31 +607,30 @@ Function *VectorizationContext::getOrCreateMaskedAtomicFunction(
   // Mangle ordering
   auto mangleOrdering = [&O](AtomicOrdering Ordering) {
     switch (Ordering) {
-      default:
-        O << static_cast<unsigned>(Ordering);
-        break;
       case AtomicOrdering::Acquire:
         O << "acquire";
-        break;
+        return;
       case AtomicOrdering::AcquireRelease:
         O << "acqrel";
-        break;
+        return;
       case AtomicOrdering::Monotonic:
         O << "monotonic";
-        break;
+        return;
       case AtomicOrdering::NotAtomic:
         O << "notatomic";
-        break;
+        return;
       case AtomicOrdering::Release:
         O << "release";
-        break;
+        return;
       case AtomicOrdering::SequentiallyConsistent:
         O << "seqcst";
-        break;
+        return;
       case AtomicOrdering::Unordered:
         O << "unordered";
-        break;
+        return;
     }
+
+    O << static_cast<unsigned>(Ordering);
   };
 
   mangleOrdering(I.Ordering);

--- a/modules/kts/include/kts/arguments_shared.h
+++ b/modules/kts/include/kts/arguments_shared.h
@@ -488,7 +488,7 @@ class GenericStreamer : public BufferStreamer {
                   V validator = {})
       : ref_(ref), validator(validator), fallbacks_(f) {}
 
-  virtual void PopulateBuffer(ArgumentBase &arg, const BufferDesc &desc) {
+  void PopulateBuffer(ArgumentBase &arg, const BufferDesc &desc) override {
     arg.SetBufferStorageSize(desc.size_ * sizeof(T));
 
     MemoryAccessor<T> accessor;
@@ -504,8 +504,8 @@ class GenericStreamer : public BufferStreamer {
     }
   }
 
-  virtual bool ValidateBuffer(ArgumentBase &arg, const BufferDesc &desc,
-                              std::vector<std::string> *errors) {
+  bool ValidateBuffer(ArgumentBase &arg, const BufferDesc &desc,
+                      std::vector<std::string> *errors) override {
     if ((arg.GetKind() != eOutputBuffer) && (arg.GetKind() != eInOutBuffer)) {
       return true;
     }
@@ -566,7 +566,7 @@ class GenericStreamer : public BufferStreamer {
     return true;
   }
 
-  virtual size_t GetElementSize() { return sizeof(T); }
+  size_t GetElementSize() override { return sizeof(T); }
 
   bool CheckIfUndef(size_t index) const {
     if (undef_callback_) {
@@ -608,8 +608,8 @@ template <typename T>
 struct BoxedPrimitive : public Primitive {
   BoxedPrimitive(T value) : value_(value) {}
 
-  virtual void *GetAddress() { return &value_; }
-  virtual size_t GetSize() { return sizeof(T); }
+  void *GetAddress() override { return &value_; }
+  size_t GetSize() override { return sizeof(T); }
 
   T value_;
 };

--- a/modules/metadata/include/metadata/detail/stack_serializer.h
+++ b/modules/metadata/include/metadata/detail/stack_serializer.h
@@ -128,9 +128,6 @@ class RawStackSerializer {
         }
         break;
       }
-
-      default:
-        break;
     }
   }
 
@@ -272,10 +269,9 @@ class BasicMsgPackStackSerializer {
         }
         return data;
       }
-      default:
-        assert(0 && "Invalid or unsupported MsgPack type qualifier");
-        return nullptr;
     }
+    assert(0 && "Invalid or unsupported MsgPack type qualifier");
+    return nullptr;
   }
 
   /// @brief Serialize an individual stack element.
@@ -288,19 +284,19 @@ class BasicMsgPackStackSerializer {
         output.emplace_back(MsgPackFmt::MSG_PACK_UINT_64);
         auto *val = elem.template get<typename StackType::unsigned_t>();
         serialize_number(*val, output, MD_ENDIAN::BIG);
-        break;
+        return;
       }
       case md_value_type::MD_TYPE_SINT: {
         output.emplace_back(MsgPackFmt::MSG_PACK_INT_64);
         auto *val = elem.template get<typename StackType::signed_t>();
         serialize_number(*val, output, MD_ENDIAN::BIG);
-        break;
+        return;
       }
       case md_value_type::MD_TYPE_REAL: {
         output.emplace_back(MsgPackFmt::MSG_PACK_DOUBLE);
         auto *val = elem.template get<typename StackType::real_t>();
         serialize_number(*val, output, MD_ENDIAN::BIG);
-        break;
+        return;
       }
       case md_value_type::MD_TYPE_ZSTR: {
         output.emplace_back(MsgPackFmt::MSG_PACK_STR_16);
@@ -308,7 +304,7 @@ class BasicMsgPackStackSerializer {
         const uint16_t str_len = val->size();
         serialize_number(str_len, output, MD_ENDIAN::BIG);
         output.insert(output.end(), val->begin(), val->end());
-        break;
+        return;
       }
       case md_value_type::MD_TYPE_BYTESTR: {
         auto *val = elem.template get<typename StackType::byte_arr_t>();
@@ -322,7 +318,7 @@ class BasicMsgPackStackSerializer {
           serialize_number(byte_str_len, output, MD_ENDIAN::BIG);
         }
         output.insert(output.end(), val->begin(), val->end());
-        break;
+        return;
       }
       case md_value_type::MD_TYPE_ARRAY: {
         output.emplace_back(MsgPackFmt::MSG_PACK_ARR_16);
@@ -332,7 +328,7 @@ class BasicMsgPackStackSerializer {
         for (const auto &item : *val) {
           serialize_element(item, output);
         }
-        break;
+        return;
       }
       case md_value_type::MD_TYPE_HASH: {
         output.emplace_back(MsgPackFmt::MSG_PACK_MAP_16);
@@ -343,12 +339,10 @@ class BasicMsgPackStackSerializer {
           serialize_element(kv.first, output);
           serialize_element(kv.second, output);
         }
-        break;
+        return;
       }
-      default:
-        assert(0 && "Invalid Value Type!");
-        break;
     }
+    assert(0 && "Invalid Value Type!");
   }
 
  public:

--- a/modules/mux/source/hal/include/mux/hal/query_pool.h
+++ b/modules/mux/source/hal/include/mux/hal/query_pool.h
@@ -56,12 +56,17 @@ struct query_pool : mux_query_pool_s {
       mux::allocator allocator) {
     (void)queue;
     (void)query_configs;
-    switch (query_type) {
-      case mux_query_type_duration:
-      case mux_query_type_counter:
-        break;
-      default:
-        return cargo::make_unexpected(mux_error_invalid_value);
+    const bool query_type_valid = [&] {
+      switch (query_type) {
+        case mux_query_type_duration:
+        case mux_query_type_counter:
+          return true;
+      }
+
+      return false;
+    }();
+    if (!query_type_valid) {
+      return cargo::make_unexpected(mux_error_invalid_value);
     }
     // Calculate the result storage offset past the end of the query_pool_s.
     // FIXME: This wastes sizeof(mux_query_duration_result_s) bytes when

--- a/modules/mux/source/image.cpp
+++ b/modules/mux/source/image.cpp
@@ -143,21 +143,30 @@ mux_result_t muxGetSupportedImageFormats(mux_device_t device,
     return mux_error_invalid_value;
   }
 
-  switch (image_type) {
-    case mux_image_type_1d:
-    case mux_image_type_2d:
-    case mux_image_type_3d:
-      break;
-    default:
-      return mux_error_invalid_value;
+  const bool image_type_valid = [&] {
+    switch (image_type) {
+      case mux_image_type_1d:
+      case mux_image_type_2d:
+      case mux_image_type_3d:
+        return true;
+      default:
+        return false;
+    }
+  }();
+  if (!image_type_valid) {
+    return mux_error_invalid_value;
   }
 
-  switch (allocation_type) {
-    case mux_allocation_type_alloc_host:
-    case mux_allocation_type_alloc_device:
-      break;
-    default:
-      return mux_error_invalid_value;
+  const bool allocation_type_valid = [&] {
+    switch (allocation_type) {
+      case mux_allocation_type_alloc_host:
+      case mux_allocation_type_alloc_device:
+        return true;
+    }
+    return false;
+  }();
+  if (!allocation_type_valid) {
+    return mux_error_invalid_value;
   }
 
   if (0 == count && nullptr != out_formats) {

--- a/modules/mux/source/memory.cpp
+++ b/modules/mux/source/memory.cpp
@@ -48,12 +48,16 @@ mux_result_t muxAllocateMemory(mux_device_t device, size_t size, uint32_t heap,
     return mux_error_invalid_value;
   }
 
-  switch (allocation_type) {
-    default:
-      return mux_error_invalid_value;
-    case mux_allocation_type_alloc_host:
-    case mux_allocation_type_alloc_device:
-      break;
+  const bool allocation_type_valid = [&] {
+    switch (allocation_type) {
+      case mux_allocation_type_alloc_host:
+      case mux_allocation_type_alloc_device:
+        return true;
+    }
+    return false;
+  }();
+  if (!allocation_type_valid) {
+    return mux_error_invalid_value;
   }
 
   // Checks for 0 or power-of-two

--- a/modules/mux/test/muxCreateSemaphore.cpp
+++ b/modules/mux/test/muxCreateSemaphore.cpp
@@ -105,19 +105,19 @@ TEST_P(muxCreateSemaphoreTest, 1To1Forward) {
 
   ASSERT_SUCCESS(muxCommandUserCallback(
       buffer_one,
-      [](mux_queue_t, mux_command_buffer_t, void *const user_data) {
-        auto *pair = static_cast<PairType *>(user_data);
-        pair->second = *(pair->first);
-        *(pair->first) += 1;
+      [](mux_queue_t, mux_command_buffer_t, void *const UserData) {
+        auto *Pair = static_cast<PairType *>(UserData);
+        Pair->second = *(Pair->first);
+        *(Pair->first) += 1;
       },
       &pair_one, 0, nullptr, nullptr));
 
   ASSERT_SUCCESS(muxCommandUserCallback(
       buffer_two,
-      [](mux_queue_t, mux_command_buffer_t, void *const user_data) {
-        auto *pair = static_cast<PairType *>(user_data);
-        pair->second = *(pair->first);
-        *(pair->first) += 1;
+      [](mux_queue_t, mux_command_buffer_t, void *const UserData) {
+        auto *Pair = static_cast<PairType *>(UserData);
+        Pair->second = *(Pair->first);
+        *(Pair->first) += 1;
       },
       &pair_two, 0, nullptr, nullptr));
 
@@ -171,19 +171,19 @@ TEST_P(muxCreateSemaphoreTest, 1To1Backward) {
 
   ASSERT_SUCCESS(muxCommandUserCallback(
       buffer_one,
-      [](mux_queue_t, mux_command_buffer_t, void *const user_data) {
-        auto *pair = static_cast<PairType *>(user_data);
-        pair->second = *(pair->first);
-        *(pair->first) += 1;
+      [](mux_queue_t, mux_command_buffer_t, void *const UserData) {
+        auto *Pair = static_cast<PairType *>(UserData);
+        Pair->second = *(Pair->first);
+        *(Pair->first) += 1;
       },
       &pair_one, 0, nullptr, nullptr));
 
   ASSERT_SUCCESS(muxCommandUserCallback(
       buffer_two,
-      [](mux_queue_t, mux_command_buffer_t, void *const user_data) {
-        auto *pair = static_cast<PairType *>(user_data);
-        pair->second = *(pair->first);
-        *(pair->first) += 1;
+      [](mux_queue_t, mux_command_buffer_t, void *const UserData) {
+        auto *Pair = static_cast<PairType *>(UserData);
+        Pair->second = *(Pair->first);
+        *(Pair->first) += 1;
       },
       &pair_two, 0, nullptr, nullptr));
 
@@ -228,11 +228,10 @@ TEST_P(muxCreateSemaphoreTest, 1To1ManyTimes) {
 
     ASSERT_SUCCESS(muxCommandUserCallback(
         buffer[k],
-        [](mux_queue_t, mux_command_buffer_t, void *const user_data) {
-          auto *pair =
-              static_cast<std::pair<unsigned *, unsigned> *>(user_data);
-          pair->second = *(pair->first);
-          *(pair->first) += 1;
+        [](mux_queue_t, mux_command_buffer_t, void *const UserData) {
+          auto *Pair = static_cast<std::pair<unsigned *, unsigned> *>(UserData);
+          Pair->second = *(Pair->first);
+          *(Pair->first) += 1;
         },
         pairs + k, 0, nullptr, nullptr));
   }
@@ -287,9 +286,9 @@ TEST_P(muxCreateSemaphoreTest, OutOfOrderDispatch) {
   // container.
   auto command_buffer_call_back = [](mux_queue_t,
                                      mux_command_buffer_t command_buffer,
-                                     void *const user_data) {
+                                     void *const UserData) {
     auto command_buffers =
-        static_cast<std::vector<mux_command_buffer_t> *>(user_data);
+        static_cast<std::vector<mux_command_buffer_t> *>(UserData);
     command_buffers->push_back(command_buffer);
   };
 

--- a/modules/mux/test/muxDispatch.cpp
+++ b/modules/mux/test/muxDispatch.cpp
@@ -58,8 +58,8 @@ TEST_P(muxDispatchTest, CompleteCallback) {
   // add a callback to the dispatch that sets hit to true
   ASSERT_SUCCESS(muxDispatch(
       queue, command_buffer, nullptr, nullptr, 0, nullptr, 0,
-      [](mux_command_buffer_t, mux_result_t, void *const user_data) {
-        *static_cast<std::atomic<bool> *>(user_data) = true;
+      [](mux_command_buffer_t, mux_result_t, void *const UserData) {
+        *static_cast<std::atomic<bool> *>(UserData) = true;
       },
       &hit));
 
@@ -81,9 +81,9 @@ TEST_P(muxDispatchTest, UserFunctionBeforeSignal) {
 
   ASSERT_SUCCESS(muxCommandUserCallback(
       command_buffer,
-      [](mux_queue_t, mux_command_buffer_t, void *const user_data) {
-        auto data = static_cast<uint32_t *>(user_data);
-        *data *= 2;
+      [](mux_queue_t, mux_command_buffer_t, void *const UserData) {
+        auto Data = static_cast<uint32_t *>(UserData);
+        *Data *= 2;
       },
       &data, 0, nullptr, nullptr));
 
@@ -92,9 +92,9 @@ TEST_P(muxDispatchTest, UserFunctionBeforeSignal) {
 
   ASSERT_SUCCESS(muxDispatch(
       queue, command_buffer_2, nullptr, nullptr, 0, &semaphore, 1,
-      [](mux_command_buffer_t, mux_result_t, void *const user_data) {
-        auto data = static_cast<uint32_t *>(user_data);
-        (*data)++;
+      [](mux_command_buffer_t, mux_result_t, void *const UserData) {
+        auto Data = static_cast<uint32_t *>(UserData);
+        (*Data)++;
       },
       &data));
 
@@ -159,9 +159,9 @@ TEST_P(muxDispatchTest, DISABLED_NoDeadlockWhenResettingWaitedOnSemaphore) {
       mux_success,
       muxCommandUserCallback(
           command_buffers[1],
-          [](mux_queue_t, mux_command_buffer_t, void *const user_data) {
-            auto semaphore = static_cast<mux_semaphore_t>(user_data);
-            muxResetSemaphore(semaphore);
+          [](mux_queue_t, mux_command_buffer_t, void *const UserData) {
+            auto Semaphore = static_cast<mux_semaphore_t>(UserData);
+            muxResetSemaphore(Semaphore);
           },
           semaphores[0], 0, nullptr, nullptr));
 
@@ -213,9 +213,9 @@ TEST_P(muxDispatchTest, DISABLED_MultipleThreadsInteractWithSemaphores) {
       mux_success,
       muxCommandUserCallback(
           command_buffers[1],
-          [](mux_queue_t, mux_command_buffer_t, void *const user_data) {
-            auto semaphore = static_cast<mux_semaphore_t>(user_data);
-            muxResetSemaphore(semaphore);
+          [](mux_queue_t, mux_command_buffer_t, void *const UserData) {
+            auto Semaphore = static_cast<mux_semaphore_t>(UserData);
+            muxResetSemaphore(Semaphore);
           },
           semaphores[0], 0, nullptr, nullptr));
 

--- a/modules/mux/test/muxGetQueryPoolResults.cpp
+++ b/modules/mux/test/muxGetQueryPoolResults.cpp
@@ -57,9 +57,9 @@ TEST_P(muxGetQueryPoolResultsDurationTest, Default) {
   uint64_t store = 0;
   ASSERT_SUCCESS(muxCommandUserCallback(
       command_buffer,
-      [](mux_queue_t, mux_command_buffer_t, void *user_data) {
-        auto &store = *static_cast<uint64_t *>(user_data);
-        store = 42;
+      [](mux_queue_t, mux_command_buffer_t, void *UserData) {
+        auto &Store = *static_cast<uint64_t *>(UserData);
+        Store = 42;
       },
       &store, 0, nullptr, nullptr));
   ASSERT_SUCCESS(muxCommandEndQuery(command_buffer, query_pool, 0, 1, 0,

--- a/modules/mux/test/muxResetCommandBuffer.cpp
+++ b/modules/mux/test/muxResetCommandBuffer.cpp
@@ -47,8 +47,8 @@ TEST_P(muxResetCommandBufferTest, Default) {
 
   ASSERT_SUCCESS(muxCommandUserCallback(
       command_buffer,
-      [](mux_queue_t, mux_command_buffer_t, void *const user_data) {
-        *static_cast<bool *>(user_data) = true;
+      [](mux_queue_t, mux_command_buffer_t, void *const UserData) {
+        *static_cast<bool *>(UserData) = true;
       },
       &shouldNotBeHit, 0, nullptr, nullptr));
 
@@ -56,8 +56,8 @@ TEST_P(muxResetCommandBufferTest, Default) {
 
   ASSERT_SUCCESS(muxCommandUserCallback(
       command_buffer,
-      [](mux_queue_t, mux_command_buffer_t, void *const user_data) {
-        *static_cast<bool *>(user_data) = true;
+      [](mux_queue_t, mux_command_buffer_t, void *const UserData) {
+        *static_cast<bool *>(UserData) = true;
       },
       &shouldBeHit, 0, nullptr, nullptr));
 

--- a/modules/mux/test/muxResetSemaphore.cpp
+++ b/modules/mux/test/muxResetSemaphore.cpp
@@ -64,14 +64,14 @@ TEST_P(muxResetSemaphoreTest, Default) {
 
   ASSERT_SUCCESS(muxCommandUserCallback(
       command_buffer0,
-      [](mux_queue_t, mux_command_buffer_t, void *const user_data) {
-        auto *foo = static_cast<uint32_t *>(user_data);
-        if (42 == *foo) {
+      [](mux_queue_t, mux_command_buffer_t, void *const UserData) {
+        auto *Foo = static_cast<uint32_t *>(UserData);
+        if (42 == *Foo) {
           // This will happen on the first run of the command group
-          *foo = 13;
-        } else if (56 == *foo) {
+          *Foo = 13;
+        } else if (56 == *Foo) {
           // This will happen on the second run of the command group
-          *foo = 79;
+          *Foo = 79;
         }
       },
       &foo, 0, nullptr, nullptr));
@@ -91,10 +91,10 @@ TEST_P(muxResetSemaphoreTest, Default) {
 
   ASSERT_SUCCESS(muxCommandUserCallback(
       command_buffer1,
-      [](mux_queue_t, mux_command_buffer_t, void *const user_data) {
-        auto *foo = static_cast<uint32_t *>(user_data);
-        if (13 == *foo) {
-          *foo = 56;
+      [](mux_queue_t, mux_command_buffer_t, void *const UserData) {
+        auto *Foo = static_cast<uint32_t *>(UserData);
+        if (13 == *Foo) {
+          *Foo = 56;
         }
       },
       &foo, 0, nullptr, nullptr));

--- a/source/cl/include/cl/base.h
+++ b/source/cl/include/cl/base.h
@@ -264,16 +264,15 @@ class release_guard {
           const cl_int retcode = releaseExternal(object);
           OCL_ASSERT(CL_SUCCESS == retcode, "External release failed!");
           OCL_UNUSED(retcode);
-          break;
+          return;
         }
         case ref_count_type::INTERNAL: {
           releaseInternal(object);
-          break;
-        }
-        default: {
-          OCL_ABORT("Unknown cl::ref_count_type!");
+          return;
         }
       }
+
+      OCL_ABORT("Unknown cl::ref_count_type!");
     }
   }
 

--- a/source/cl/source/buffer.cpp
+++ b/source/cl/source/buffer.cpp
@@ -273,9 +273,9 @@ CL_API_ENTRY cl_mem CL_API_CALL cl::CreateSubBuffer(
 
   OCL_CHECK(std::all_of(buffer->context->devices.begin(),
                         buffer->context->devices.end(),
-                        [origin](_cl_device_id *device) {
+                        [origin](_cl_device_id *Device) {
                           return 0 != (origin &
-                                       ((device->mem_base_addr_align / 8) - 1));
+                                       ((Device->mem_base_addr_align / 8) - 1));
                         }),
             OCL_SET_IF_NOT_NULL(errcode_ret, CL_MISALIGNED_SUB_BUFFER_OFFSET);
             return nullptr);

--- a/source/cl/source/extension/CMakeLists.txt
+++ b/source/cl/source/extension/CMakeLists.txt
@@ -42,6 +42,7 @@ set(RUNTIME_EXTENSIONS
 foreach(tag ${CA_CL_RUNTIME_EXTENSION_TAGS})
   list(APPEND RUNTIME_EXTENSIONS ${${tag}_RUNTIME_EXTENSIONS})
 endforeach()
+list(SORT RUNTIME_EXTENSIONS)
 
 # List of all supported compiler extensions.
 set(COMPILER_EXTENSIONS
@@ -54,9 +55,13 @@ set(COMPILER_EXTENSIONS
 foreach(tag ${CA_CL_COMPILER_EXTENSION_TAGS})
   list(APPEND COMPILER_EXTENSIONS ${${tag}_COMPILER_EXTENSIONS})
 endforeach()
+list(SORT COMPILER_EXTENSIONS)
+
+set(ALL_EXTENSIONS ${RUNTIME_EXTENSIONS} ${COMPILER_EXTENSIONS})
+list(SORT ALL_EXTENSIONS)
 
 # Create an individual option for each extension in the list.
-foreach(extension ${RUNTIME_EXTENSIONS} ${COMPILER_EXTENSIONS})
+foreach(extension ${ALL_EXTENSIONS})
   if(${extension} STREQUAL "khr_command_buffer"
     OR ${extension} STREQUAL "khr_command_buffer_mutable_dispatch")
     # TODO Enable `khr_command_buffer` and any layered extensions
@@ -93,12 +98,11 @@ list(REMOVE_DUPLICATES CL_EXTENSION_HEADERS)
 # Generate config.h and extension.cpp
 set(generate_extension_defines)
 set(generate_includes)
-set(generate_declarations)
 set(generate_alloc_error)
 
 string(APPEND generate_extension_defines "
 // OpenCL runtime extensions.")
-foreach(extension ${RUNTIME_EXTENSIONS})
+foreach(extension ${ALL_EXTENSIONS})
   if(OCL_EXTENSION_cl_${extension})
     string(APPEND generate_extension_defines "
 #define OCL_EXTENSION_cl_${extension}")
@@ -108,28 +112,11 @@ foreach(extension ${RUNTIME_EXTENSIONS})
   endif()
   string(APPEND generate_includes "
 #include <extension/${extension}.h>")
-  string(APPEND generate_declarations "
-  static extension::${extension} ${extension};")
-  string(APPEND generate_alloc_error "
-    error = extensions.push_back(&${extension});
-    OCL_ASSERT(!error, \"failed to allocate extension storage\");")
 endforeach()
-
-foreach(extension ${COMPILER_EXTENSIONS})
-  if(OCL_EXTENSION_cl_${extension})
-    string(APPEND generate_extension_defines "
-#define OCL_EXTENSION_cl_${extension}")
-  else()
-    string(APPEND generate_extension_defines "
-// #undef OCL_EXTENSION_cl_${extension}")
-  endif()
-  string(APPEND generate_includes "
-#include <extension/${extension}.h>")
-  string(APPEND generate_declarations "
-  static extension::${extension} ${extension};")
+foreach(extension ${RUNTIME_EXTENSIONS} ${COMPILER_EXTENSIONS})
   string(APPEND generate_alloc_error "
-    error = extensions.push_back(&${extension});
-    OCL_ASSERT(!error, \"failed to allocate extension storage\");")
+    Error = Extensions.push_back(&Extension<extension::${extension}>);
+    OCL_ASSERT(!Error, \"failed to allocate extension storage\");")
 endforeach()
 
 list(LENGTH RUNTIME_EXTENSIONS CA_CL_RUNTIME_EXTENSION_COUNT)

--- a/source/cl/source/extension/source/extension.cpp.in
+++ b/source/cl/source/extension/source/extension.cpp.in
@@ -28,93 +28,94 @@
 #include <mutex>
 
 namespace {
+template <typename T>
+static T Extension;
 cargo::array_view<const extension::extension *const> getExtensions() {
   static cargo::small_vector<const extension::extension *,
                              CA_CL_EXTENSION_COUNT>
-      extensions;
-  static std::once_flag initialized_flag;
-@generate_declarations@
+      Extensions;
+  static std::once_flag InitializedFlag;
 
-  std::call_once(initialized_flag, []() {
-    cargo::result error;
-    OCL_UNUSED(error);
+  std::call_once(InitializedFlag, []() {
+    cargo::result Error;
+    OCL_UNUSED(Error);
 @generate_alloc_error@
   });
 
-  return extensions;
+  return Extensions;
 }
 
 cargo::array_view<const extension::extension *const> getRuntimeExtensions() {
   static cargo::array_view<const extension::extension *const>
-      runtime_extensions{getExtensions().data(), CA_CL_RUNTIME_EXTENSION_COUNT};
-  return runtime_extensions;
+      RuntimeExtensions{getExtensions().data(), CA_CL_RUNTIME_EXTENSION_COUNT};
+  return RuntimeExtensions;
 }
 
 cargo::array_view<const extension::extension *const> getCompilerExtensions() {
   static cargo::array_view<const extension::extension *const>
-      compiler_extensions{
+      CompilerExtensions{
           getExtensions().data() + CA_CL_RUNTIME_EXTENSION_COUNT,
           CA_CL_COMPILER_EXTENSION_COUNT};
-  return compiler_extensions;
+  return CompilerExtensions;
 }
 
-void *GetExtensionFunctionAddressForPlatform(
-    const size_t num_extensions, const extension::extension *const *extensions,
-    cl_platform_id platform, const char *func_name) {
+void *getExtensionFunctionAddressForPlatform(
+    const size_t NumExtensions, const extension::extension *const *Extensions,
+    cl_platform_id Platform, const char *FuncName) {
   OCL_ASSERT(
-      nullptr != platform,
+      nullptr != Platform,
       "Invalid platform. Expecting caller to map nullptr to a valid platform.");
 
-  if (nullptr == func_name) {
+  if (nullptr == FuncName) {
     return nullptr;
   }
 
-  void *function_address = nullptr;
-  for (size_t table_idx = 0; table_idx < num_extensions; ++table_idx) {
-    function_address =
-        extensions[table_idx]->GetExtensionFunctionAddressForPlatform(
-            platform, func_name);
-    if (nullptr != function_address) {
+  void *FunctionAddress = nullptr;
+  for (size_t TableIdx = 0; TableIdx < NumExtensions; ++TableIdx) {
+    FunctionAddress =
+        Extensions[TableIdx]->GetExtensionFunctionAddressForPlatform(
+            Platform, FuncName);
+    if (nullptr != FunctionAddress) {
       // Found a function address for func_name, stop the loop.
       // Check that there aren't multiple extensions using the same func_name
       // because then extension ordering determines discovery. Extension
       // function names should be unique.
       OCL_ASSERT(
-          nullptr == GetExtensionFunctionAddressForPlatform(
-                         num_extensions - table_idx - 1,
-                         extensions + table_idx + 1, platform, func_name),
+          nullptr == getExtensionFunctionAddressForPlatform(
+                         NumExtensions - TableIdx - 1,
+                         Extensions + TableIdx + 1, Platform, FuncName),
           "Each extension function must belong to exactly one extension info.");
       break;
     }
   }
 
-  return function_address;
+  return FunctionAddress;
 }
 
 template <typename T, typename N, typename F>
-inline cl_int GetObjectExtensionInfoSingleValue(
-    const size_t num_extensions, const extension::extension *const *extensions,
-    T object, N param_name, const size_t param_value_size, void *param_value,
-    size_t *param_value_size_ret, F get_info_fn);
+inline cl_int getObjectExtensionInfoSingleValue(
+    const size_t NumExtensions, const extension::extension *const *Extensions,
+    T Object, N ParamName, const size_t ParamValueSize, void *ParamValue,
+    size_t *ParamValueSizeRet, F GetInfoFn);
 
 template <typename T, typename D, typename N, typename F>
-inline cl_int GetObjectDetailExtensionInfoSingleValue(
-    const size_t num_extensions, const extension::extension *const *extensions,
-    T object, D detail, N param_name, const size_t param_value_size,
-    void *param_value, size_t *param_value_size_ret, F get_info_fn);
+inline cl_int getObjectDetailExtensionInfoSingleValue(
+    const size_t NumExtensions, const extension::extension *const *Extensions,
+    T Object, D Detail, N ParamName, const size_t ParamValueSize,
+    void *ParamValue, size_t *ParamValueSizeRet, F GetInfoFn);
 
 template <typename T, typename D, typename N, typename F>
-inline cl_int GetObjectDetailExtensionInfoSingleInputValue(
-    const size_t num_extensions, const extension::extension *const *extensions,
-    T object, D detail, N param_name, const size_t input_value_size,
-    const void *input_value, const size_t param_value_size, void *param_value,
-    size_t *param_value_size_ret, F get_info_fn);
+inline cl_int getObjectDetailExtensionInfoSingleInputValue(
+    const size_t NumExtensions, const extension::extension *const *Extensions,
+    T Object, D Detail, N ParamName, const size_t InputValueSize,
+    const void *InputValue, const size_t ParamValueSize, void *ParamValue,
+    size_t *ParamValueSizeRet, F GetInfoFn);
 
 template <typename T, typename N, typename F>
-inline cl_int GetObjectExtensionInfoAggregatedCString(
-    const size_t num_extensions, const extension::extension *const *extensions,
-    T object, N param_name, const size_t param_value_size, void *param_value,
-    size_t *param_value_size_ret, const char name_separator, F get_info_fn);
+inline cl_int getObjectExtensionInfoAggregatedCString(
+    const size_t NumExtensions, const extension::extension *const *Extensions,
+    T Object, N ParamName, const size_t ParamValueSize, void *ParamValue,
+    size_t *ParamValueSizeRet, const char NameSeparator, F GetInfoFn);
 
 /// @brief Query all passed in extensions via the get_info_fn functor/lambda
 /// until one accepts the query.
@@ -147,32 +148,32 @@ inline cl_int GetObjectExtensionInfoAggregatedCString(
 /// param_name query. Other OpenCL error return code if an extension accepts
 /// param_name but the supplied argument values are wrong.
 template <typename T, typename N, typename F>
-cl_int GetObjectExtensionInfoSingleValue(
-    const size_t num_extensions, const extension::extension *const *extensions,
-    T object, N param_name, const size_t param_value_size, void *param_value,
-    size_t *param_value_size_ret, F get_info_fn) {
-  cl_int retcode = CL_INVALID_VALUE;
-  size_t ext_idx = 0;
-  for (ext_idx = 0; ext_idx < num_extensions; ++ext_idx) {
-    const cl_int supported_retcode = get_info_fn(
-        extensions[ext_idx], object, param_name, 0, nullptr, nullptr);
-    if (CL_SUCCESS != supported_retcode) {
+cl_int getObjectExtensionInfoSingleValue(
+    const size_t NumExtensions, const extension::extension *const *Extensions,
+    T Object, N ParamName, const size_t ParamValueSize, void *ParamValue,
+    size_t *ParamValueSizeRet, F GetInfoFn) {
+  cl_int Retcode = CL_INVALID_VALUE;
+  size_t ExtIdx = 0;
+  for (ExtIdx = 0; ExtIdx < NumExtensions; ++ExtIdx) {
+    const cl_int SupportedRetcode = GetInfoFn(
+        Extensions[ExtIdx], Object, ParamName, 0, nullptr, nullptr);
+    if (CL_SUCCESS != SupportedRetcode) {
       // This extension does not support the info query, keep searching.
       continue;
     }
 
     // Do query.
-    retcode = get_info_fn(extensions[ext_idx], object, param_name,
-                          param_value_size, param_value, param_value_size_ret);
+    Retcode = GetInfoFn(Extensions[ExtIdx], Object, ParamName,
+                          ParamValueSize, ParamValue, ParamValueSizeRet);
 
     // More than one extension shouldn't support the same info query,
     // otherwise results are order dependent which is confusing.
     OCL_ASSERT(
-        CL_SUCCESS != retcode ||
-            CL_SUCCESS != GetObjectExtensionInfoSingleValue(
-                              num_extensions - ext_idx - 1,
-                              extensions + ext_idx + 1, object, param_name, 0,
-                              nullptr, nullptr, get_info_fn),
+        CL_SUCCESS != Retcode ||
+            CL_SUCCESS != getObjectExtensionInfoSingleValue(
+                              NumExtensions - ExtIdx - 1,
+                              Extensions + ExtIdx + 1, Object, ParamName, 0,
+                              nullptr, nullptr, GetInfoFn),
         "More than one extension should not support the same info query, "
         "otherwise results are order dependent which is confusing.");
 
@@ -181,7 +182,7 @@ cl_int GetObjectExtensionInfoSingleValue(
     break;
   }
 
-  return retcode;
+  return Retcode;
 }
 
 /// @brief Query all passed in extensions via the get_info_fn functor/lambda
@@ -224,32 +225,32 @@ cl_int GetObjectExtensionInfoSingleValue(
 /// param_name query. Other OpenCL error return code if an extension accepts
 /// param_name but the supplied argument values are wrong.
 template <typename T, typename D, typename N, typename F>
-cl_int GetObjectDetailExtensionInfoSingleValue(
-    const size_t num_extensions, const extension::extension *const *extensions,
-    T object, D detail, N param_name, const size_t param_value_size,
-    void *param_value, size_t *param_value_size_ret, F get_info_fn) {
-  cl_int retcode = CL_INVALID_VALUE;
-  size_t ext_idx = 0;
-  for (ext_idx = 0; ext_idx < num_extensions; ++ext_idx) {
-    const cl_int supported_retcode = get_info_fn(
-        extensions[ext_idx], object, detail, param_name, 0, nullptr, nullptr);
-    if (CL_SUCCESS != supported_retcode) {
+cl_int getObjectDetailExtensionInfoSingleValue(
+    const size_t NumExtensions, const extension::extension *const *Extensions,
+    T Object, D Detail, N ParamName, const size_t ParamValueSize,
+    void *ParamValue, size_t *ParamValueSizeRet, F GetInfoFn) {
+  cl_int Retcode = CL_INVALID_VALUE;
+  size_t ExtIdx = 0;
+  for (ExtIdx = 0; ExtIdx < NumExtensions; ++ExtIdx) {
+    const cl_int SupportedRetcode = GetInfoFn(
+        Extensions[ExtIdx], Object, Detail, ParamName, 0, nullptr, nullptr);
+    if (CL_SUCCESS != SupportedRetcode) {
       // This extension does not support the info query, keep searching.
       continue;
     }
 
     // Do query.
-    retcode = get_info_fn(extensions[ext_idx], object, detail, param_name,
-                          param_value_size, param_value, param_value_size_ret);
+    Retcode = GetInfoFn(Extensions[ExtIdx], Object, Detail, ParamName,
+                          ParamValueSize, ParamValue, ParamValueSizeRet);
 
     // More than one extension shouldn't support the same info query,
     // otherwise results are order dependent which is confusing.
     OCL_ASSERT(
-        CL_SUCCESS != retcode ||
-            CL_SUCCESS != GetObjectDetailExtensionInfoSingleValue(
-                              num_extensions - ext_idx - 1,
-                              extensions + ext_idx + 1, object, detail,
-                              param_name, 0, nullptr, nullptr, get_info_fn),
+        CL_SUCCESS != Retcode ||
+            CL_SUCCESS != getObjectDetailExtensionInfoSingleValue(
+                              NumExtensions - ExtIdx - 1,
+                              Extensions + ExtIdx + 1, Object, Detail,
+                              ParamName, 0, nullptr, nullptr, GetInfoFn),
         "More than one extension should not support the same info query, "
         "otherwise results are order dependent which is confusing.");
 
@@ -258,7 +259,7 @@ cl_int GetObjectDetailExtensionInfoSingleValue(
     break;
   }
 
-  return retcode;
+  return Retcode;
 }
 
 /// @brief Query all passed in extensions via the get_info_fn functor/lambda
@@ -299,36 +300,36 @@ cl_int GetObjectDetailExtensionInfoSingleValue(
 /// param_name query. Other OpenCL error return code if an extension accepts
 /// param_name but the supplied argument values are wrong.
 template <typename T, typename D, typename N, typename F>
-cl_int GetObjectDetailExtensionInfoSingleInputValue(
-    const size_t num_extensions, const extension::extension *const *extensions,
-    T object, D detail, N param_name, const size_t input_value_size,
-    const void *input_value, const size_t param_value_size, void *param_value,
-    size_t *param_value_size_ret, F get_info_fn) {
-  cl_int retcode = CL_INVALID_VALUE;
-  size_t ext_idx = 0;
-  for (ext_idx = 0; ext_idx < num_extensions; ++ext_idx) {
-    const cl_int supported_retcode =
-        get_info_fn(extensions[ext_idx], object, detail, param_name, 0, nullptr,
+cl_int getObjectDetailExtensionInfoSingleInputValue(
+    const size_t NumExtensions, const extension::extension *const *Extensions,
+    T Object, D Detail, N ParamName, const size_t InputValueSize,
+    const void *InputValue, const size_t ParamValueSize, void *ParamValue,
+    size_t *ParamValueSizeRet, F GetInfoFn) {
+  cl_int Retcode = CL_INVALID_VALUE;
+  size_t ExtIdx = 0;
+  for (ExtIdx = 0; ExtIdx < NumExtensions; ++ExtIdx) {
+    const cl_int SupportedRetcode =
+        GetInfoFn(Extensions[ExtIdx], Object, Detail, ParamName, 0, nullptr,
                     0, nullptr, nullptr);
-    if (CL_SUCCESS != supported_retcode) {
+    if (CL_SUCCESS != SupportedRetcode) {
       // This extension does not support the info query, keep searching.
       continue;
     }
 
     // Do query.
-    retcode = get_info_fn(extensions[ext_idx], object, detail, param_name,
-                          input_value_size, input_value, param_value_size,
-                          param_value, param_value_size_ret);
+    Retcode = GetInfoFn(Extensions[ExtIdx], Object, Detail, ParamName,
+                          InputValueSize, InputValue, ParamValueSize,
+                          ParamValue, ParamValueSizeRet);
 
     // More than one extension shouldn't support the same info query,
     // otherwise results are order dependent which is confusing.
     OCL_ASSERT(
-        CL_SUCCESS != retcode ||
-            CL_SUCCESS != GetObjectDetailExtensionInfoSingleInputValue(
-                              num_extensions - ext_idx - 1,
-                              extensions + ext_idx + 1, object, detail,
-                              param_name, 0, nullptr, 0, nullptr, nullptr,
-                              get_info_fn),
+        CL_SUCCESS != Retcode ||
+            CL_SUCCESS != getObjectDetailExtensionInfoSingleInputValue(
+                              NumExtensions - ExtIdx - 1,
+                              Extensions + ExtIdx + 1, Object, Detail,
+                              ParamName, 0, nullptr, 0, nullptr, nullptr,
+                              GetInfoFn),
         "More than one extension should not support the same info query, "
         "otherwise results are order dependent which is confusing.");
 
@@ -337,7 +338,7 @@ cl_int GetObjectDetailExtensionInfoSingleInputValue(
     break;
   }
 
-  return retcode;
+  return Retcode;
 }
 
 /// @brief Query all passed in extensions via the get_info_fn functor/lambda and
@@ -375,16 +376,16 @@ cl_int GetObjectDetailExtensionInfoSingleInputValue(
 /// accepts the param_name query. Other OpenCL error return code if an extension
 /// accepts param_name but the supplied argument values are wrong.
 template <typename T, typename N, typename F>
-cl_int GetObjectExtensionInfoAggregatedCString(
-    const size_t num_extensions, const extension::extension *const *extensions,
-    T object, N param_name, const size_t param_value_size, void *param_value,
-    size_t *param_value_size_ret, const char name_separator, F get_info_fn) {
+cl_int getObjectExtensionInfoAggregatedCString(
+    const size_t NumExtensions, const extension::extension *const *Extensions,
+    T Object, N ParamName, const size_t ParamValueSize, void *ParamValue,
+    size_t *ParamValueSizeRet, const char NameSeparator, F GetInfoFn) {
   // The caller already checked for correctness of the object.
-  cl_int aggregated_retcode = CL_INVALID_VALUE;
-  size_t aggregated_value_size_ret = 0;
+  cl_int AggregatedRetcode = CL_INVALID_VALUE;
+  size_t AggregatedValueSizeRet = 0;
 
   // First pass over extensions: aggregate the required return size.
-  for (size_t ext_idx = 0; ext_idx < num_extensions; ++ext_idx) {
+  for (size_t ExtIdx = 0; ExtIdx < NumExtensions; ++ExtIdx) {
     // The last info query counts the terminating zero in its value_size_ret
     // while all previous terminating zeros are translated into spaces to
     // fulfill how OpenCL info queries report lists of names in c-strings.
@@ -392,218 +393,218 @@ cl_int GetObjectExtensionInfoAggregatedCString(
     // See The OpenCL Specification, Version 1.2,
     // Last Revision Date: 11/14/12,
     // Section 4.1 Querying Platform Info, page 35.
-    size_t value_size_ret = 0;
-    const cl_int retcode = get_info_fn(extensions[ext_idx], object, param_name,
-                                       0, nullptr, &value_size_ret);
-    if (CL_SUCCESS != retcode) {
+    size_t ValueSizeRet = 0;
+    const cl_int Retcode = GetInfoFn(Extensions[ExtIdx], Object, ParamName,
+                                       0, nullptr, &ValueSizeRet);
+    if (CL_SUCCESS != Retcode) {
       // This extension does not support the info query, skip it to find
       // extensions that do.
       continue;
     }
 
     // At least one extension supports the query info.
-    aggregated_retcode = CL_SUCCESS;
+    AggregatedRetcode = CL_SUCCESS;
 
-    aggregated_value_size_ret += value_size_ret;
+    AggregatedValueSizeRet += ValueSizeRet;
     OCL_ASSERT(
-        value_size_ret <= aggregated_value_size_ret,
+        ValueSizeRet <= AggregatedValueSizeRet,
         "Overflow of variable for storing platform extension names size.");
   }
 
   // If no extension handles the param_name for object, then return with an
   // error code.
-  if (CL_SUCCESS != aggregated_retcode) {
-    return aggregated_retcode;
+  if (CL_SUCCESS != AggregatedRetcode) {
+    return AggregatedRetcode;
   }
 
   OCL_CHECK(
-      nullptr != param_value && param_value_size < aggregated_value_size_ret,
+      nullptr != ParamValue && ParamValueSize < AggregatedValueSizeRet,
       return CL_INVALID_VALUE);
 
   // Second pass: query the wanted info and store it in the arguments.
-  if (nullptr != param_value) {
-    char *value_cursor = static_cast<char *>(param_value);
-    size_t value_size_remaining = param_value_size;
+  if (nullptr != ParamValue) {
+    char *ValueCursor = static_cast<char *>(ParamValue);
+    size_t ValueSizeRemaining = ParamValueSize;
 
-    for (size_t ext_idx = 0; ext_idx < num_extensions; ++ext_idx) {
-      cl_int retcode = get_info_fn(extensions[ext_idx], object, param_name, 0,
+    for (size_t ExtIdx = 0; ExtIdx < NumExtensions; ++ExtIdx) {
+      cl_int Retcode = GetInfoFn(Extensions[ExtIdx], Object, ParamName, 0,
                                    nullptr, nullptr);
-      if (CL_SUCCESS != retcode) {
+      if (CL_SUCCESS != Retcode) {
         // This extension does not support the info query, keep searching.
         continue;
       }
 
-      size_t value_size_ret = 0;
-      retcode =
-          get_info_fn(extensions[ext_idx], object, param_name,
-                      value_size_remaining, value_cursor, &value_size_ret);
-      OCL_ASSERT(CL_SUCCESS == retcode,
+      size_t ValueSizeRet = 0;
+      Retcode =
+          GetInfoFn(Extensions[ExtIdx], Object, ParamName,
+                      ValueSizeRemaining, ValueCursor, &ValueSizeRet);
+      OCL_ASSERT(CL_SUCCESS == Retcode,
                  "Second pass through extension information should not fail.");
       OCL_ASSERT(
-          value_size_ret <= value_size_remaining,
+          ValueSizeRet <= ValueSizeRemaining,
           "Sizes must not add up differently between first and second pass.");
 
-      value_cursor += value_size_ret;
-      value_size_remaining -= value_size_ret;
+      ValueCursor += ValueSizeRet;
+      ValueSizeRemaining -= ValueSizeRet;
 
       // Replace terminating zero with name list "concatenating" whitespace.
       //
       // See The OpenCL Specification, Version 1.2,
       // Last Revision Date: 11/14/12,
       // Section 4.1 Querying Platform Info, page 35.
-      if (0 != value_size_ret) {
-        *(value_cursor - 1) = name_separator;
+      if (0 != ValueSizeRet) {
+        *(ValueCursor - 1) = NameSeparator;
       }
     }
 
     // Re-establish last terminating zero.
-    if (0 != aggregated_value_size_ret) {
-      *(value_cursor - 1) = '\0';
+    if (0 != AggregatedValueSizeRet) {
+      *(ValueCursor - 1) = '\0';
     }
   }
 
-  OCL_SET_IF_NOT_NULL(param_value_size_ret, aggregated_value_size_ret);
+  OCL_SET_IF_NOT_NULL(ParamValueSizeRet, AggregatedValueSizeRet);
 
   return CL_SUCCESS;
 }
 
 template <typename T, typename N, typename F>
-cl_int GetObjectExtensionInfoAggregatedArray(
-    const size_t num_extensions, const extension::extension *const *extensions,
-    T object, N param_name, const size_t param_value_size, void *param_value,
-    size_t *param_value_size_ret, F get_info_fn) {
-  cl_int aggregated_retcode = CL_INVALID_VALUE;
-  size_t aggregated_value_size_ret = 0;
-  for (size_t ext_idx = 0; ext_idx < num_extensions; ++ext_idx) {
-    size_t value_size_ret = 0;
-    const cl_int retcode = get_info_fn(extensions[ext_idx], object, param_name,
-                                       0, nullptr, &value_size_ret);
-    if (CL_SUCCESS != retcode) {
+cl_int getObjectExtensionInfoAggregatedArray(
+    const size_t NumExtensions, const extension::extension *const *Extensions,
+    T Object, N ParamName, const size_t ParamValueSize, void *ParamValue,
+    size_t *ParamValueSizeRet, F GetInfoFn) {
+  cl_int AggregatedRetcode = CL_INVALID_VALUE;
+  size_t AggregatedValueSizeRet = 0;
+  for (size_t ExtIdx = 0; ExtIdx < NumExtensions; ++ExtIdx) {
+    size_t ValueSizeRet = 0;
+    const cl_int Retcode = GetInfoFn(Extensions[ExtIdx], Object, ParamName,
+                                       0, nullptr, &ValueSizeRet);
+    if (CL_SUCCESS != Retcode) {
       // This extension does not support the info query, skip it to find
       // extensions that do.
       continue;
     }
     // At least one extension supports the query info.
-    aggregated_retcode = CL_SUCCESS;
+    AggregatedRetcode = CL_SUCCESS;
 
-    aggregated_value_size_ret += value_size_ret;
+    AggregatedValueSizeRet += ValueSizeRet;
     OCL_ASSERT(
-        value_size_ret <= aggregated_value_size_ret,
+        ValueSizeRet <= AggregatedValueSizeRet,
         "Overflow of variable for storing platform extension names size.");
   }
 
   // If no extension handles the param_name for object, then return with an
   // error code.
-  if (CL_SUCCESS != aggregated_retcode) {
-    return aggregated_retcode;
+  if (CL_SUCCESS != AggregatedRetcode) {
+    return AggregatedRetcode;
   }
   OCL_CHECK(
-      nullptr != param_value && param_value_size < aggregated_value_size_ret,
+      nullptr != ParamValue && ParamValueSize < AggregatedValueSizeRet,
       return CL_INVALID_VALUE);
 
   // Second pass: query the wanted info and store it in the arguments.
-  if (nullptr != param_value) {
-    char *value_cursor = static_cast<char *>(param_value);
-    size_t value_size_remaining = param_value_size;
+  if (nullptr != ParamValue) {
+    char *ValueCursor = static_cast<char *>(ParamValue);
+    size_t ValueSizeRemaining = ParamValueSize;
 
-    for (size_t ext_idx = 0; ext_idx < num_extensions; ++ext_idx) {
-      cl_int retcode = get_info_fn(extensions[ext_idx], object, param_name, 0,
+    for (size_t ExtIdx = 0; ExtIdx < NumExtensions; ++ExtIdx) {
+      cl_int Retcode = GetInfoFn(Extensions[ExtIdx], Object, ParamName, 0,
                                    nullptr, nullptr);
-      if (CL_SUCCESS != retcode) {
+      if (CL_SUCCESS != Retcode) {
         // This extension does not support the info query, keep searching.
         continue;
       }
 
-      size_t value_size_ret = 0;
-      retcode =
-          get_info_fn(extensions[ext_idx], object, param_name,
-                      value_size_remaining, value_cursor, &value_size_ret);
-      OCL_ASSERT(CL_SUCCESS == retcode,
+      size_t ValueSizeRet = 0;
+      Retcode =
+          GetInfoFn(Extensions[ExtIdx], Object, ParamName,
+                      ValueSizeRemaining, ValueCursor, &ValueSizeRet);
+      OCL_ASSERT(CL_SUCCESS == Retcode,
                  "Second pass through extension information should not fail.");
       OCL_ASSERT(
-          value_size_ret <= value_size_remaining,
+          ValueSizeRet <= ValueSizeRemaining,
           "Sizes must not add up differently between first and second pass.");
 
-      value_cursor += value_size_ret;
-      value_size_remaining -= value_size_ret;
+      ValueCursor += ValueSizeRet;
+      ValueSizeRemaining -= ValueSizeRet;
     }
   }
 
-  OCL_SET_IF_NOT_NULL(param_value_size_ret, aggregated_value_size_ret);
+  OCL_SET_IF_NOT_NULL(ParamValueSizeRet, AggregatedValueSizeRet);
 
   return CL_SUCCESS;
 }
 }  // namespace
 
-extension::extension::extension(const char *name, usage_category usage
+extension::extension::extension(const char *Name, usage_category Usage
 #if defined(CL_VERSION_3_0)
                                 ,
-                                cl_version_khr version
+                                cl_version_khr Version
 #endif
                                 )
-    : name(name),
-      usage(usage)
+    : name(Name),
+      usage(Usage)
 #if defined(CL_VERSION_3_0)
       ,
-      version(version)
+      version(Version)
 #endif
 {
-  OCL_ASSERT(nullptr != name || usage_category::DISABLED == usage,
+  OCL_ASSERT(nullptr != Name || usage_category::DISABLED == Usage,
              "Name required if usage indicates it.");
 }
 
 extension::extension::~extension() {}
 
 cl_int extension::extension::GetPlatformInfo(
-    cl_platform_id platform, cl_platform_info param_name,
-    size_t param_value_size, void *param_value,
-    size_t *param_value_size_ret) const {
-  OCL_UNUSED(platform);  // Already checked by clGetPlatformInfo.
+    cl_platform_id Platform, cl_platform_info ParamName,
+    size_t ParamValueSize, void *ParamValue,
+    size_t *ParamValueSizeRet) const {
+  OCL_UNUSED(Platform);  // Already checked by clGetPlatformInfo.
   if (usage_category::PLATFORM == usage) {
-    switch (param_name) {
+    switch (ParamName) {
       default: {
         return CL_INVALID_VALUE;
       }
       case CL_PLATFORM_EXTENSIONS: {
-        const std::size_t size = name.size() + 1;  // +1 for zero terminator.
-        OCL_CHECK(nullptr != param_value && param_value_size < size,
+        const std::size_t Size = name.size() + 1;  // +1 for zero terminator.
+        OCL_CHECK(nullptr != ParamValue && ParamValueSize < Size,
                   return CL_INVALID_VALUE);
 
-        if (nullptr != param_value) {
-          std::memcpy(param_value, name.data(), size);
+        if (nullptr != ParamValue) {
+          std::memcpy(ParamValue, name.data(), Size);
         }
 
-        OCL_SET_IF_NOT_NULL(param_value_size_ret, size);
+        OCL_SET_IF_NOT_NULL(ParamValueSizeRet, Size);
 
         return CL_SUCCESS;
       }
 #if defined(CL_VERSION_3_0)
       case CL_PLATFORM_EXTENSIONS_WITH_VERSION: {
-        size_t platform_extensions_size{};
-        GetPlatformInfo(platform, CL_PLATFORM_EXTENSIONS, 0, nullptr,
-                        &platform_extensions_size);
-        std::string platform_extensions(platform_extensions_size, '\0');
-        GetPlatformInfo(platform, CL_PLATFORM_EXTENSIONS,
-                        platform_extensions.size(), platform_extensions.data(),
+        size_t PlatformExtensionsSize{};
+        GetPlatformInfo(Platform, CL_PLATFORM_EXTENSIONS, 0, nullptr,
+                        &PlatformExtensionsSize);
+        std::string PlatformExtensions(PlatformExtensionsSize, '\0');
+        GetPlatformInfo(Platform, CL_PLATFORM_EXTENSIONS,
+                        PlatformExtensions.size(), PlatformExtensions.data(),
                         nullptr);
-        auto split_extensions = cargo::split(platform_extensions, " ");
-        auto size_in_bytes =
-            split_extensions.size() * sizeof(cl_name_version_khr);
-        OCL_CHECK(nullptr != param_value && (param_value_size < size_in_bytes),
+        auto SplitExtensions = cargo::split(PlatformExtensions, " ");
+        auto SizeInBytes =
+            SplitExtensions.size() * sizeof(cl_name_version_khr);
+        OCL_CHECK(nullptr != ParamValue && (ParamValueSize < SizeInBytes),
                   return CL_INVALID_VALUE);
         cargo::small_vector<cl_name_version_khr, CA_CL_EXTENSION_COUNT>
-            name_version_pairs{};
-        if (nullptr != param_value) {
-          for (const auto &extension : split_extensions) {
-            cl_name_version_khr name_version{};
-            name_version.version = version;
-            std::memcpy(name_version.name, extension.data(), extension.size());
-            name_version.name[extension.size()] = '\0';
-            OCL_UNUSED(name_version_pairs.push_back(name_version));
+            NameVersionPairs{};
+        if (nullptr != ParamValue) {
+          for (const auto &Extension : SplitExtensions) {
+            cl_name_version_khr NameVersion{};
+            NameVersion.version = version;
+            std::memcpy(NameVersion.name, Extension.data(), Extension.size());
+            NameVersion.name[Extension.size()] = '\0';
+            OCL_UNUSED(NameVersionPairs.push_back(NameVersion));
           }
-          std::memcpy(param_value, name_version_pairs.data(), size_in_bytes);
+          std::memcpy(ParamValue, NameVersionPairs.data(), SizeInBytes);
         }
-        OCL_SET_IF_NOT_NULL(param_value_size_ret, size_in_bytes);
+        OCL_SET_IF_NOT_NULL(ParamValueSizeRet, SizeInBytes);
         return CL_SUCCESS;
       }
 #endif
@@ -613,65 +614,65 @@ cl_int extension::extension::GetPlatformInfo(
   return CL_INVALID_VALUE;
 }
 
-cl_int extension::extension::GetDeviceInfo(cl_device_id device,
-                                           cl_device_info param_name,
-                                           size_t param_value_size,
-                                           void *param_value,
-                                           size_t *param_value_size_ret) const {
-  OCL_UNUSED(device);  // Already checked by clGetDeviceInfo.
+cl_int extension::extension::GetDeviceInfo(cl_device_id Device,
+                                           cl_device_info ParamName,
+                                           size_t ParamValueSize,
+                                           void *ParamValue,
+                                           size_t *ParamValueSizeRet) const {
+  OCL_UNUSED(Device);  // Already checked by clGetDeviceInfo.
   if (usage_category::DEVICE == usage || usage_category::PLATFORM == usage) {
     // If this is a compiler extension and no compiler is available, then
     // disable it.
-    if (!device->compiler_available) {
-      auto compiler_extensions = getCompilerExtensions();
-      if (std::find(compiler_extensions.begin(), compiler_extensions.end(),
-                    this) != compiler_extensions.end()) {
+    if (!Device->compiler_available) {
+      auto CompilerExtensions = getCompilerExtensions();
+      if (std::find(CompilerExtensions.begin(), CompilerExtensions.end(),
+                    this) != CompilerExtensions.end()) {
         return CL_INVALID_DEVICE;
       }
     }
-    switch (param_name) {
+    switch (ParamName) {
       default: {
         return CL_INVALID_VALUE;
       }
       case CL_DEVICE_EXTENSIONS: {
-        const std::size_t size = name.size() + 1;
-        OCL_CHECK(nullptr != param_value && param_value_size < size,
+        const std::size_t Size = name.size() + 1;
+        OCL_CHECK(nullptr != ParamValue && ParamValueSize < Size,
                   return CL_INVALID_VALUE);
 
-        if (nullptr != param_value) {
-          std::memcpy(param_value, name.data(), size);
+        if (nullptr != ParamValue) {
+          std::memcpy(ParamValue, name.data(), Size);
         }
 
-        OCL_SET_IF_NOT_NULL(param_value_size_ret, size);
+        OCL_SET_IF_NOT_NULL(ParamValueSizeRet, Size);
 
         return CL_SUCCESS;
       }
 #if defined(CL_VERSION_3_0)
       case CL_DEVICE_EXTENSIONS_WITH_VERSION: {
-        size_t device_extensions_size{};
-        GetDeviceInfo(device, CL_DEVICE_EXTENSIONS, 0, nullptr,
-                      &device_extensions_size);
-        std::string device_extensions(device_extensions_size, '\0');
-        GetDeviceInfo(device, CL_DEVICE_EXTENSIONS, device_extensions.size(),
-                      device_extensions.data(), nullptr);
-        auto split_extensions = cargo::split(device_extensions, " ");
-        auto size_in_bytes =
-            split_extensions.size() * sizeof(cl_name_version_khr);
-        OCL_CHECK(nullptr != param_value && (param_value_size < size_in_bytes),
+        size_t DeviceExtensionsSize{};
+        GetDeviceInfo(Device, CL_DEVICE_EXTENSIONS, 0, nullptr,
+                      &DeviceExtensionsSize);
+        std::string DeviceExtensions(DeviceExtensionsSize, '\0');
+        GetDeviceInfo(Device, CL_DEVICE_EXTENSIONS, DeviceExtensions.size(),
+                      DeviceExtensions.data(), nullptr);
+        auto SplitExtensions = cargo::split(DeviceExtensions, " ");
+        auto SizeInBytes =
+            SplitExtensions.size() * sizeof(cl_name_version_khr);
+        OCL_CHECK(nullptr != ParamValue && (ParamValueSize < SizeInBytes),
                   return CL_INVALID_VALUE);
-        if (nullptr != param_value) {
+        if (nullptr != ParamValue) {
           cargo::small_vector<cl_name_version_khr, CA_CL_EXTENSION_COUNT>
-              name_version_pairs{};
-          for (const auto &extension : split_extensions) {
-            cl_name_version_khr name_version{};
-            name_version.version = version;
-            std::memcpy(name_version.name, extension.data(), extension.size());
-            name_version.name[extension.size()] = '\0';
-            OCL_UNUSED(name_version_pairs.push_back(name_version));
+              NameVersionPairs{};
+          for (const auto &Extension : SplitExtensions) {
+            cl_name_version_khr NameVersion{};
+            NameVersion.version = version;
+            std::memcpy(NameVersion.name, Extension.data(), Extension.size());
+            NameVersion.name[Extension.size()] = '\0';
+            OCL_UNUSED(NameVersionPairs.push_back(NameVersion));
           }
-          std::memcpy(param_value, name_version_pairs.data(), size_in_bytes);
+          std::memcpy(ParamValue, NameVersionPairs.data(), SizeInBytes);
         }
-        OCL_SET_IF_NOT_NULL(param_value_size_ret, size_in_bytes);
+        OCL_SET_IF_NOT_NULL(ParamValueSizeRet, SizeInBytes);
         return CL_SUCCESS;
       }
 #endif
@@ -780,447 +781,447 @@ void *extension::extension::GetExtensionFunctionAddressForPlatform(
   return nullptr;
 }
 
-cl_int extension::GetPlatformInfo(cl_platform_id platform,
-                                  cl_platform_info param_name,
-                                  size_t param_value_size, void *param_value,
-                                  size_t *param_value_size_ret) {
-  cl_int retcode = CL_INVALID_VALUE;
+cl_int extension::GetPlatformInfo(cl_platform_id Platform,
+                                  cl_platform_info ParamName,
+                                  size_t ParamValueSize, void *ParamValue,
+                                  size_t *ParamValueSizeRet) {
+  cl_int Retcode = CL_INVALID_VALUE;
 
-  auto query_fn = [](const extension *extension, cl_platform_id object,
-                     cl_platform_info param_name, size_t param_value_size,
-                     void *param_value, size_t *param_value_size_ret) {
-    return extension->GetPlatformInfo(object, param_name, param_value_size,
-                                      param_value, param_value_size_ret);
+  auto QueryFn = [](const extension *Extension, cl_platform_id Object,
+                     cl_platform_info ParamName, size_t ParamValueSize,
+                     void *ParamValue, size_t *ParamValueSizeRet) {
+    return Extension->GetPlatformInfo(Object, ParamName, ParamValueSize,
+                                      ParamValue, ParamValueSizeRet);
   };
 
   // Extend with extension related param_names.
-  switch (param_name) {
+  switch (ParamName) {
     case CL_PLATFORM_EXTENSIONS: {
-      const char extension_name_separator = ' ';
-      retcode = GetObjectExtensionInfoAggregatedCString(
-          getExtensions().size(), getExtensions().data(), platform, param_name,
-          param_value_size, param_value, param_value_size_ret,
-          extension_name_separator, query_fn);
+      const char ExtensionNameSeparator = ' ';
+      Retcode = getObjectExtensionInfoAggregatedCString(
+          getExtensions().size(), getExtensions().data(), Platform, ParamName,
+          ParamValueSize, ParamValue, ParamValueSizeRet,
+          ExtensionNameSeparator, QueryFn);
       break;
     }
 #if defined(CL_VERSION_3_0)
     case CL_PLATFORM_EXTENSIONS_WITH_VERSION: {
-      retcode = GetObjectExtensionInfoAggregatedArray(
-          getExtensions().size(), getExtensions().data(), platform, param_name,
-          param_value_size, param_value, param_value_size_ret, query_fn);
+      Retcode = getObjectExtensionInfoAggregatedArray(
+          getExtensions().size(), getExtensions().data(), Platform, ParamName,
+          ParamValueSize, ParamValue, ParamValueSizeRet, QueryFn);
       break;
     }
 #endif
     default: {
       // Assuming that yet unknown extension have a single value to query
       // and are not aggregated.
-      retcode = GetObjectExtensionInfoSingleValue(
-          getExtensions().size(), getExtensions().data(), platform, param_name,
-          param_value_size, param_value, param_value_size_ret, query_fn);
+      Retcode = getObjectExtensionInfoSingleValue(
+          getExtensions().size(), getExtensions().data(), Platform, ParamName,
+          ParamValueSize, ParamValue, ParamValueSizeRet, QueryFn);
       break;
     }
   }
 
-  return retcode;
+  return Retcode;
 }
 
-cl_int extension::GetDeviceInfo(cl_device_id device, cl_device_info param_name,
-                                size_t param_value_size, void *param_value,
-                                size_t *param_value_size_ret) {
-  cl_int retcode = CL_INVALID_VALUE;
+cl_int extension::GetDeviceInfo(cl_device_id Device, cl_device_info ParamName,
+                                size_t ParamValueSize, void *ParamValue,
+                                size_t *ParamValueSizeRet) {
+  cl_int Retcode = CL_INVALID_VALUE;
 
-  auto query_fn = [](const extension *extension, cl_device_id object,
-                     cl_device_info param_name, size_t param_value_size,
-                     void *param_value, size_t *param_value_size_ret) {
-    return extension->GetDeviceInfo(object, param_name, param_value_size,
-                                    param_value, param_value_size_ret);
+  auto QueryFn = [](const extension *Extension, cl_device_id Object,
+                     cl_device_info ParamName, size_t ParamValueSize,
+                     void *ParamValue, size_t *ParamValueSizeRet) {
+    return Extension->GetDeviceInfo(Object, ParamName, ParamValueSize,
+                                    ParamValue, ParamValueSizeRet);
   };
 
   // Extend with extension related param_names.
-  switch (param_name) {
+  switch (ParamName) {
     case CL_DEVICE_EXTENSIONS: {
-      const char extension_name_separator = ' ';
-      retcode = GetObjectExtensionInfoAggregatedCString(
-          getExtensions().size(), getExtensions().data(), device, param_name,
-          param_value_size, param_value, param_value_size_ret,
-          extension_name_separator, query_fn);
+      const char ExtensionNameSeparator = ' ';
+      Retcode = getObjectExtensionInfoAggregatedCString(
+          getExtensions().size(), getExtensions().data(), Device, ParamName,
+          ParamValueSize, ParamValue, ParamValueSizeRet,
+          ExtensionNameSeparator, QueryFn);
       break;
     }
 #if defined(CL_VERSION_3_0)
     case CL_DEVICE_EXTENSIONS_WITH_VERSION: {
-      retcode = GetObjectExtensionInfoAggregatedArray(
-          getExtensions().size(), getExtensions().data(), device, param_name,
-          param_value_size, param_value, param_value_size_ret, query_fn);
+      Retcode = getObjectExtensionInfoAggregatedArray(
+          getExtensions().size(), getExtensions().data(), Device, ParamName,
+          ParamValueSize, ParamValue, ParamValueSizeRet, QueryFn);
       break;
     }
 #endif
     default: {
       // Assuming that yet unknown extension have a single value to query
       // and are not aggregated.
-      retcode = GetObjectExtensionInfoSingleValue(
-          getExtensions().size(), getExtensions().data(), device, param_name,
-          param_value_size, param_value, param_value_size_ret, query_fn);
+      Retcode = getObjectExtensionInfoSingleValue(
+          getExtensions().size(), getExtensions().data(), Device, ParamName,
+          ParamValueSize, ParamValue, ParamValueSizeRet, QueryFn);
       break;
     }
   }
 
-  return retcode;
+  return Retcode;
 }
 
-cl_int extension::GetContextInfo(cl_context context, cl_context_info param_name,
-                                 size_t param_value_size, void *param_value,
-                                 size_t *param_value_size_ret) {
-  auto query_fn = [](const extension *extension, cl_context object,
-                     cl_context_info param_name, size_t param_value_size,
-                     void *param_value, size_t *param_value_size_ret) {
-    return extension->GetContextInfo(object, param_name, param_value_size,
-                                     param_value, param_value_size_ret);
+cl_int extension::GetContextInfo(cl_context Context, cl_context_info ParamName,
+                                 size_t ParamValueSize, void *ParamValue,
+                                 size_t *ParamValueSizeRet) {
+  auto QueryFn = [](const extension *Extension, cl_context Object,
+                     cl_context_info ParamName, size_t ParamValueSize,
+                     void *ParamValue, size_t *ParamValueSizeRet) {
+    return Extension->GetContextInfo(Object, ParamName, ParamValueSize,
+                                     ParamValue, ParamValueSizeRet);
   };
 
-  return GetObjectExtensionInfoSingleValue(
-      getExtensions().size(), getExtensions().data(), context, param_name,
-      param_value_size, param_value, param_value_size_ret, query_fn);
+  return getObjectExtensionInfoSingleValue(
+      getExtensions().size(), getExtensions().data(), Context, ParamName,
+      ParamValueSize, ParamValue, ParamValueSizeRet, QueryFn);
 }
 
-cl_int extension::ApplyPropertyToCommandQueue(cl_command_queue command_queue,
-                                              cl_queue_properties_khr property,
-                                              cl_queue_properties_khr value) {
-  for (auto extension : getExtensions()) {
-    if (auto result = extension->ApplyPropertyToCommandQueue(command_queue,
-                                                             property, value)) {
-      return *result;
+cl_int extension::ApplyPropertyToCommandQueue(cl_command_queue CommandQueue,
+                                              cl_queue_properties_khr Property,
+                                              cl_queue_properties_khr Value) {
+  for (const auto *Extension : getExtensions()) {
+    if (auto Result = Extension->ApplyPropertyToCommandQueue(CommandQueue,
+                                                             Property, Value)) {
+      return *Result;
     }
   }
   return CL_INVALID_VALUE;
 }
 
-cl_int extension::GetCommandQueueInfo(cl_command_queue command_queue,
-                                      cl_command_queue_info param_name,
-                                      size_t param_value_size,
-                                      void *param_value,
-                                      size_t *param_value_size_ret) {
-  auto query_fn = [](const extension *extension, cl_command_queue object,
-                     cl_command_queue_info param_name, size_t param_value_size,
-                     void *param_value, size_t *param_value_size_ret) {
-    return extension->GetCommandQueueInfo(object, param_name, param_value_size,
-                                          param_value, param_value_size_ret);
+cl_int extension::GetCommandQueueInfo(cl_command_queue CommandQueue,
+                                      cl_command_queue_info ParamName,
+                                      size_t ParamValueSize,
+                                      void *ParamValue,
+                                      size_t *ParamValueSizeRet) {
+  auto QueryFn = [](const extension *Extension, cl_command_queue Object,
+                     cl_command_queue_info ParamName, size_t ParamValueSize,
+                     void *ParamValue, size_t *ParamValueSizeRet) {
+    return Extension->GetCommandQueueInfo(Object, ParamName, ParamValueSize,
+                                          ParamValue, ParamValueSizeRet);
   };
 
-  return GetObjectExtensionInfoSingleValue(
-      getExtensions().size(), getExtensions().data(), command_queue, param_name,
-      param_value_size, param_value, param_value_size_ret, query_fn);
+  return getObjectExtensionInfoSingleValue(
+      getExtensions().size(), getExtensions().data(), CommandQueue, ParamName,
+      ParamValueSize, ParamValue, ParamValueSizeRet, QueryFn);
 }
 
-cl_int extension::GetImageInfo(cl_mem image, cl_image_info param_name,
-                               size_t param_value_size, void *param_value,
-                               size_t *param_value_size_ret) {
-  auto query_fn = [](const extension *extension, cl_mem object,
-                     cl_image_info param_name, size_t param_value_size,
-                     void *param_value, size_t *param_value_size_ret) {
-    return extension->GetImageInfo(object, param_name, param_value_size,
-                                   param_value, param_value_size_ret);
+cl_int extension::GetImageInfo(cl_mem Image, cl_image_info ParamName,
+                               size_t ParamValueSize, void *ParamValue,
+                               size_t *ParamValueSizeRet) {
+  auto QueryFn = [](const extension *Extension, cl_mem Object,
+                     cl_image_info ParamName, size_t ParamValueSize,
+                     void *ParamValue, size_t *ParamValueSizeRet) {
+    return Extension->GetImageInfo(Object, ParamName, ParamValueSize,
+                                   ParamValue, ParamValueSizeRet);
   };
 
-  return GetObjectExtensionInfoSingleValue(
-      getExtensions().size(), getExtensions().data(), image, param_name,
-      param_value_size, param_value, param_value_size_ret, query_fn);
+  return getObjectExtensionInfoSingleValue(
+      getExtensions().size(), getExtensions().data(), Image, ParamName,
+      ParamValueSize, ParamValue, ParamValueSizeRet, QueryFn);
 }
 
-cl_int extension::GetMemObjectInfo(cl_mem memobj, cl_mem_info param_name,
-                                   size_t param_value_size, void *param_value,
-                                   size_t *param_value_size_ret) {
-  auto query_fn = [](const extension *extension, cl_mem object,
-                     cl_mem_info param_name, size_t param_value_size,
-                     void *param_value, size_t *param_value_size_ret) {
-    return extension->GetMemObjectInfo(object, param_name, param_value_size,
-                                       param_value, param_value_size_ret);
+cl_int extension::GetMemObjectInfo(cl_mem Memobj, cl_mem_info ParamName,
+                                   size_t ParamValueSize, void *ParamValue,
+                                   size_t *ParamValueSizeRet) {
+  auto QueryFn = [](const extension *Extension, cl_mem Object,
+                     cl_mem_info ParamName, size_t ParamValueSize,
+                     void *ParamValue, size_t *ParamValueSizeRet) {
+    return Extension->GetMemObjectInfo(Object, ParamName, ParamValueSize,
+                                       ParamValue, ParamValueSizeRet);
   };
 
-  return GetObjectExtensionInfoSingleValue(
-      getExtensions().size(), getExtensions().data(), memobj, param_name,
-      param_value_size, param_value, param_value_size_ret, query_fn);
+  return getObjectExtensionInfoSingleValue(
+      getExtensions().size(), getExtensions().data(), Memobj, ParamName,
+      ParamValueSize, ParamValue, ParamValueSizeRet, QueryFn);
 }
 
-cl_int extension::GetSamplerInfo(cl_sampler sampler, cl_sampler_info param_name,
-                                 size_t param_value_size, void *param_value,
-                                 size_t *param_value_size_ret) {
-  auto query_fn = [](const extension *extension, cl_sampler object,
-                     cl_sampler_info param_name, size_t param_value_size,
-                     void *param_value, size_t *param_value_size_ret) {
-    return extension->GetSamplerInfo(object, param_name, param_value_size,
-                                     param_value, param_value_size_ret);
+cl_int extension::GetSamplerInfo(cl_sampler Sampler, cl_sampler_info ParamName,
+                                 size_t ParamValueSize, void *ParamValue,
+                                 size_t *ParamValueSizeRet) {
+  auto QueryFn = [](const extension *Extension, cl_sampler Object,
+                     cl_sampler_info ParamName, size_t ParamValueSize,
+                     void *ParamValue, size_t *ParamValueSizeRet) {
+    return Extension->GetSamplerInfo(Object, ParamName, ParamValueSize,
+                                     ParamValue, ParamValueSizeRet);
   };
 
-  return GetObjectExtensionInfoSingleValue(
-      getExtensions().size(), getExtensions().data(), sampler, param_name,
-      param_value_size, param_value, param_value_size_ret, query_fn);
+  return getObjectExtensionInfoSingleValue(
+      getExtensions().size(), getExtensions().data(), Sampler, ParamName,
+      ParamValueSize, ParamValue, ParamValueSizeRet, QueryFn);
 }
 
-cl_int extension::GetProgramInfo(cl_program program, cl_program_info param_name,
-                                 size_t param_value_size, void *param_value,
-                                 size_t *param_value_size_ret) {
-  auto query_fn = [](const extension *extension, cl_program object,
-                     cl_program_info param_name, size_t param_value_size,
-                     void *param_value, size_t *param_value_size_ret) {
-    return extension->GetProgramInfo(object, param_name, param_value_size,
-                                     param_value, param_value_size_ret);
+cl_int extension::GetProgramInfo(cl_program Program, cl_program_info ParamName,
+                                 size_t ParamValueSize, void *ParamValue,
+                                 size_t *ParamValueSizeRet) {
+  auto QueryFn = [](const extension *Extension, cl_program Object,
+                     cl_program_info ParamName, size_t ParamValueSize,
+                     void *ParamValue, size_t *ParamValueSizeRet) {
+    return Extension->GetProgramInfo(Object, ParamName, ParamValueSize,
+                                     ParamValue, ParamValueSizeRet);
   };
 
-  return GetObjectExtensionInfoSingleValue(
-      getExtensions().size(), getExtensions().data(), program, param_name,
-      param_value_size, param_value, param_value_size_ret, query_fn);
+  return getObjectExtensionInfoSingleValue(
+      getExtensions().size(), getExtensions().data(), Program, ParamName,
+      ParamValueSize, ParamValue, ParamValueSizeRet, QueryFn);
 }
 
-cl_int extension::GetProgramBuildInfo(cl_program program, cl_device_id device,
-                                      cl_program_build_info param_name,
-                                      size_t param_value_size,
-                                      void *param_value,
-                                      size_t *param_value_size_ret) {
-  auto query_fn = [](const extension *extension, cl_program object,
-                     cl_device_id detail, cl_program_build_info param_name,
-                     size_t param_value_size, void *param_value,
-                     size_t *param_value_size_ret) {
-    return extension->GetProgramBuildInfo(object, detail, param_name,
-                                          param_value_size, param_value,
-                                          param_value_size_ret);
+cl_int extension::GetProgramBuildInfo(cl_program Program, cl_device_id Device,
+                                      cl_program_build_info ParamName,
+                                      size_t ParamValueSize,
+                                      void *ParamValue,
+                                      size_t *ParamValueSizeRet) {
+  auto QueryFn = [](const extension *Extension, cl_program Object,
+                     cl_device_id Detail, cl_program_build_info ParamName,
+                     size_t ParamValueSize, void *ParamValue,
+                     size_t *ParamValueSizeRet) {
+    return Extension->GetProgramBuildInfo(Object, Detail, ParamName,
+                                          ParamValueSize, ParamValue,
+                                          ParamValueSizeRet);
   };
 
-  return GetObjectDetailExtensionInfoSingleValue(
-      getExtensions().size(), getExtensions().data(), program, device,
-      param_name, param_value_size, param_value, param_value_size_ret,
-      query_fn);
+  return getObjectDetailExtensionInfoSingleValue(
+      getExtensions().size(), getExtensions().data(), Program, Device,
+      ParamName, ParamValueSize, ParamValue, ParamValueSizeRet,
+      QueryFn);
 }
 
-cl_int extension::GetKernelInfo(cl_kernel kernel, cl_kernel_info param_name,
-                                size_t param_value_size, void *param_value,
-                                size_t *param_value_size_ret) {
-  auto query_fn = [](const extension *extension, cl_kernel object,
-                     cl_kernel_info param_name, size_t param_value_size,
-                     void *param_value, size_t *param_value_size_ret) {
-    return extension->GetKernelInfo(object, param_name, param_value_size,
-                                    param_value, param_value_size_ret);
+cl_int extension::GetKernelInfo(cl_kernel Kernel, cl_kernel_info ParamName,
+                                size_t ParamValueSize, void *ParamValue,
+                                size_t *ParamValueSizeRet) {
+  auto QueryFn = [](const extension *Extension, cl_kernel Object,
+                     cl_kernel_info ParamName, size_t ParamValueSize,
+                     void *ParamValue, size_t *ParamValueSizeRet) {
+    return Extension->GetKernelInfo(Object, ParamName, ParamValueSize,
+                                    ParamValue, ParamValueSizeRet);
   };
 
-  return GetObjectExtensionInfoSingleValue(
-      getExtensions().size(), getExtensions().data(), kernel, param_name,
-      param_value_size, param_value, param_value_size_ret, query_fn);
+  return getObjectExtensionInfoSingleValue(
+      getExtensions().size(), getExtensions().data(), Kernel, ParamName,
+      ParamValueSize, ParamValue, ParamValueSizeRet, QueryFn);
 }
 
-cl_int extension::GetKernelWorkGroupInfo(cl_kernel kernel, cl_device_id device,
-                                         cl_kernel_work_group_info param_name,
-                                         size_t param_value_size,
-                                         void *param_value,
-                                         size_t *param_value_size_ret) {
-  auto query_fn = [](const extension *extension, cl_kernel object,
-                     cl_device_id detail, cl_kernel_work_group_info param_name,
-                     size_t param_value_size, void *param_value,
-                     size_t *param_value_size_ret) {
-    return extension->GetKernelWorkGroupInfo(object, detail, param_name,
-                                             param_value_size, param_value,
-                                             param_value_size_ret);
+cl_int extension::GetKernelWorkGroupInfo(cl_kernel Kernel, cl_device_id Device,
+                                         cl_kernel_work_group_info ParamName,
+                                         size_t ParamValueSize,
+                                         void *ParamValue,
+                                         size_t *ParamValueSizeRet) {
+  auto QueryFn = [](const extension *Extension, cl_kernel Object,
+                     cl_device_id Detail, cl_kernel_work_group_info ParamName,
+                     size_t ParamValueSize, void *ParamValue,
+                     size_t *ParamValueSizeRet) {
+    return Extension->GetKernelWorkGroupInfo(Object, Detail, ParamName,
+                                             ParamValueSize, ParamValue,
+                                             ParamValueSizeRet);
   };
 
-  return GetObjectDetailExtensionInfoSingleValue(
-      getExtensions().size(), getExtensions().data(), kernel, device,
-      param_name, param_value_size, param_value, param_value_size_ret,
-      query_fn);
+  return getObjectDetailExtensionInfoSingleValue(
+      getExtensions().size(), getExtensions().data(), Kernel, Device,
+      ParamName, ParamValueSize, ParamValue, ParamValueSizeRet,
+      QueryFn);
 }
 
-cl_int extension::SetKernelArg(cl_kernel kernel, cl_uint arg_index,
-                               size_t arg_size, const void *arg_value) {
-  for (auto extension : getExtensions()) {
-    auto error =
-        extension->SetKernelArg(kernel, arg_index, arg_size, arg_value);
-    if (error != CL_INVALID_KERNEL) {
-      return error;
+cl_int extension::SetKernelArg(cl_kernel Kernel, cl_uint ArgIndex,
+                               size_t ArgSize, const void *ArgValue) {
+  for (const auto *Extension : getExtensions()) {
+    auto Error =
+        Extension->SetKernelArg(Kernel, ArgIndex, ArgSize, ArgValue);
+    if (Error != CL_INVALID_KERNEL) {
+      return Error;
     }
   }
   return CL_INVALID_KERNEL;
 }
 
-cl_int extension::GetKernelArgInfo(cl_kernel kernel, cl_uint arg_indx,
-                                   cl_kernel_arg_info param_name,
-                                   size_t param_value_size, void *param_value,
-                                   size_t *param_value_size_ret) {
-  auto query_fn = [](const extension *extension, cl_kernel object,
-                     cl_uint detail, cl_kernel_arg_info param_name,
-                     size_t param_value_size, void *param_value,
-                     size_t *param_value_size_ret) {
-    return extension->GetKernelArgInfo(object, detail, param_name,
-                                       param_value_size, param_value,
-                                       param_value_size_ret);
+cl_int extension::GetKernelArgInfo(cl_kernel Kernel, cl_uint ArgIndx,
+                                   cl_kernel_arg_info ParamName,
+                                   size_t ParamValueSize, void *ParamValue,
+                                   size_t *ParamValueSizeRet) {
+  auto QueryFn = [](const extension *Extension, cl_kernel Object,
+                     cl_uint Detail, cl_kernel_arg_info ParamName,
+                     size_t ParamValueSize, void *ParamValue,
+                     size_t *ParamValueSizeRet) {
+    return Extension->GetKernelArgInfo(Object, Detail, ParamName,
+                                       ParamValueSize, ParamValue,
+                                       ParamValueSizeRet);
   };
 
-  return GetObjectDetailExtensionInfoSingleValue(
-      getExtensions().size(), getExtensions().data(), kernel, arg_indx,
-      param_name, param_value_size, param_value, param_value_size_ret,
-      query_fn);
+  return getObjectDetailExtensionInfoSingleValue(
+      getExtensions().size(), getExtensions().data(), Kernel, ArgIndx,
+      ParamName, ParamValueSize, ParamValue, ParamValueSizeRet,
+      QueryFn);
 }
 
 #if defined(CL_VERSION_3_0)
 cl_int extension::GetKernelSubGroupInfo(
-    cl_kernel kernel, cl_device_id device, cl_kernel_sub_group_info param_name,
-    size_t input_value_size, const void *input_value, size_t param_value_size,
-    void *param_value, size_t *param_value_size_ret) {
-  auto query_fn = [](const extension *extension, cl_kernel object,
-                     cl_device_id detail, cl_kernel_sub_group_info param_name,
-                     size_t input_value_size, const void *input_value,
-                     size_t param_value_size, void *param_value,
-                     size_t *param_value_size_ret) {
-    return extension->GetKernelSubGroupInfo(
-        object, detail, param_name, input_value_size, input_value,
-        param_value_size, param_value, param_value_size_ret);
+    cl_kernel Kernel, cl_device_id Device, cl_kernel_sub_group_info ParamName,
+    size_t InputValueSize, const void *InputValue, size_t ParamValueSize,
+    void *ParamValue, size_t *ParamValueSizeRet) {
+  auto QueryFn = [](const extension *Extension, cl_kernel Object,
+                     cl_device_id Detail, cl_kernel_sub_group_info ParamName,
+                     size_t InputValueSize, const void *InputValue,
+                     size_t ParamValueSize, void *ParamValue,
+                     size_t *ParamValueSizeRet) {
+    return Extension->GetKernelSubGroupInfo(
+        Object, Detail, ParamName, InputValueSize, InputValue,
+        ParamValueSize, ParamValue, ParamValueSizeRet);
   };
 
-  return GetObjectDetailExtensionInfoSingleInputValue(
-      getExtensions().size(), getExtensions().data(), kernel, device,
-      param_name, input_value_size, input_value, param_value_size, param_value,
-      param_value_size_ret, query_fn);
+  return getObjectDetailExtensionInfoSingleInputValue(
+      getExtensions().size(), getExtensions().data(), Kernel, Device,
+      ParamName, InputValueSize, InputValue, ParamValueSize, ParamValue,
+      ParamValueSizeRet, QueryFn);
 }
 #endif
 
 #if (defined(CL_VERSION_3_0) || \
      defined(OCL_EXTENSION_cl_codeplay_kernel_exec_info))
-cl_int extension::SetKernelExecInfo(cl_kernel kernel,
-                                    cl_kernel_exec_info_codeplay param_name,
-                                    size_t param_value_size,
-                                    const void *param_value) {
-  for (auto extension : getExtensions()) {
-    auto error = extension->SetKernelExecInfo(kernel, param_name,
-                                              param_value_size, param_value);
-    if (error != CL_INVALID_KERNEL) {
-      return error;
+cl_int extension::SetKernelExecInfo(cl_kernel Kernel,
+                                    cl_kernel_exec_info_codeplay ParamName,
+                                    size_t ParamValueSize,
+                                    const void *ParamValue) {
+  for (const auto *Extension : getExtensions()) {
+    auto Error = Extension->SetKernelExecInfo(Kernel, ParamName,
+                                              ParamValueSize, ParamValue);
+    if (Error != CL_INVALID_KERNEL) {
+      return Error;
     }
   }
   return CL_INVALID_KERNEL;
 }
 #endif
 
-cl_int extension::GetEventInfo(cl_event event, cl_event_info param_name,
-                               size_t param_value_size, void *param_value,
-                               size_t *param_value_size_ret) {
-  auto query_fn = [](const extension *extension, cl_event object,
-                     cl_event_info param_name, size_t param_value_size,
-                     void *param_value, size_t *param_value_size_ret) {
-    return extension->GetEventInfo(object, param_name, param_value_size,
-                                   param_value, param_value_size_ret);
+cl_int extension::GetEventInfo(cl_event Event, cl_event_info ParamName,
+                               size_t ParamValueSize, void *ParamValue,
+                               size_t *ParamValueSizeRet) {
+  auto QueryFn = [](const extension *Extension, cl_event Object,
+                     cl_event_info ParamName, size_t ParamValueSize,
+                     void *ParamValue, size_t *ParamValueSizeRet) {
+    return Extension->GetEventInfo(Object, ParamName, ParamValueSize,
+                                   ParamValue, ParamValueSizeRet);
   };
 
-  return GetObjectExtensionInfoSingleValue(
-      getExtensions().size(), getExtensions().data(), event, param_name,
-      param_value_size, param_value, param_value_size_ret, query_fn);
+  return getObjectExtensionInfoSingleValue(
+      getExtensions().size(), getExtensions().data(), Event, ParamName,
+      ParamValueSize, ParamValue, ParamValueSizeRet, QueryFn);
 }
 
-cl_int extension::GetEventProfilingInfo(cl_event event,
-                                        cl_profiling_info param_name,
-                                        size_t param_value_size,
-                                        void *param_value,
-                                        size_t *param_value_size_ret) {
-  auto query_fn = [](const extension *extension, cl_event object,
-                     cl_profiling_info param_name, size_t param_value_size,
-                     void *param_value, size_t *param_value_size_ret) {
-    return extension->GetEventProfilingInfo(object, param_name,
-                                            param_value_size, param_value,
-                                            param_value_size_ret);
+cl_int extension::GetEventProfilingInfo(cl_event Event,
+                                        cl_profiling_info ParamName,
+                                        size_t ParamValueSize,
+                                        void *ParamValue,
+                                        size_t *ParamValueSizeRet) {
+  auto QueryFn = [](const extension *Extension, cl_event Object,
+                     cl_profiling_info ParamName, size_t ParamValueSize,
+                     void *ParamValue, size_t *ParamValueSizeRet) {
+    return Extension->GetEventProfilingInfo(Object, ParamName,
+                                            ParamValueSize, ParamValue,
+                                            ParamValueSizeRet);
   };
 
-  return GetObjectExtensionInfoSingleValue(
-      getExtensions().size(), getExtensions().data(), event, param_name,
-      param_value_size, param_value, param_value_size_ret, query_fn);
+  return getObjectExtensionInfoSingleValue(
+      getExtensions().size(), getExtensions().data(), Event, ParamName,
+      ParamValueSize, ParamValue, ParamValueSizeRet, QueryFn);
 }
 
-void *extension::GetExtensionFunctionAddressForPlatform(cl_platform_id platform,
-                                                        const char *func_name) {
-  return ::GetExtensionFunctionAddressForPlatform(
-      getExtensions().size(), getExtensions().data(), platform, func_name);
+void *extension::GetExtensionFunctionAddressForPlatform(cl_platform_id Platform,
+                                                        const char *FuncName) {
+  return ::getExtensionFunctionAddressForPlatform(
+      getExtensions().size(), getExtensions().data(), Platform, FuncName);
 }
 
 [[nodiscard]] cl_int extension::GetRuntimeExtensionsForDevice(
-    cl_device_id device, cargo::string_view &extensions_ret) {
-  static std::string extensions{};
-  static std::once_flag initialized_flag{};
-  static cl_int retcode = CL_SUCCESS;
+    cl_device_id Device, cargo::string_view &ExtensionsRet) {
+  static std::string Extensions{};
+  static std::once_flag InitializedFlag{};
+  static cl_int Retcode = CL_SUCCESS;
 
-  std::call_once(initialized_flag, [&]() {
-    auto query_fn = [](const extension *extension, cl_device_id object,
-                       cl_device_info param_name, size_t param_value_size,
-                       void *param_value, size_t *param_value_size_ret) {
-      return extension->GetDeviceInfo(object, param_name, param_value_size,
-                                      param_value, param_value_size_ret);
+  std::call_once(InitializedFlag, [&]() {
+    auto QueryFn = [](const extension *Extension, cl_device_id Object,
+                       cl_device_info ParamName, size_t ParamValueSize,
+                       void *ParamValue, size_t *ParamValueSizeRet) {
+      return Extension->GetDeviceInfo(Object, ParamName, ParamValueSize,
+                                      ParamValue, ParamValueSizeRet);
     };
 
-    size_t ext_string_length = 0;
-    retcode = GetObjectExtensionInfoAggregatedCString(
-        getRuntimeExtensions().size(), getRuntimeExtensions().data(), device,
-        CL_DEVICE_EXTENSIONS, 0, nullptr, &ext_string_length, ' ', query_fn);
+    size_t ExtStringLength = 0;
+    Retcode = getObjectExtensionInfoAggregatedCString(
+        getRuntimeExtensions().size(), getRuntimeExtensions().data(), Device,
+        CL_DEVICE_EXTENSIONS, 0, nullptr, &ExtStringLength, ' ', QueryFn);
 
     // CL_INVALID_VALUE indicates that the device supports no extensions
-    if (CL_INVALID_VALUE == retcode) {
-      retcode = CL_SUCCESS;
+    if (CL_INVALID_VALUE == Retcode) {
+      Retcode = CL_SUCCESS;
       return;
     }
-    if (CL_SUCCESS != retcode) {
+    if (CL_SUCCESS != Retcode) {
       return;
     }
 
-    extensions = std::string(ext_string_length, '\0');
-    retcode = GetObjectExtensionInfoAggregatedCString(
-        getRuntimeExtensions().size(), getRuntimeExtensions().data(), device,
-        CL_DEVICE_EXTENSIONS, ext_string_length, extensions.data(), nullptr,
-        ' ', query_fn);
-    if (CL_SUCCESS != retcode) {
+    Extensions = std::string(ExtStringLength, '\0');
+    Retcode = getObjectExtensionInfoAggregatedCString(
+        getRuntimeExtensions().size(), getRuntimeExtensions().data(), Device,
+        CL_DEVICE_EXTENSIONS, ExtStringLength, Extensions.data(), nullptr,
+        ' ', QueryFn);
+    if (CL_SUCCESS != Retcode) {
       return;
     }
   });
 
-  if (CL_SUCCESS == retcode) {
-    extensions_ret = cargo::string_view(extensions.data(), extensions.size());
+  if (CL_SUCCESS == Retcode) {
+    ExtensionsRet = cargo::string_view(Extensions.data(), Extensions.size());
   }
 
-  return retcode;
+  return Retcode;
 }
 
 [[nodiscard]] cl_int extension::GetCompilerExtensionsForDevice(
-    cl_device_id device, cargo::string_view &extensions_ret) {
-  static std::string extensions{};
-  static std::once_flag initialized_flag{};
-  static cl_int retcode = CL_SUCCESS;
+    cl_device_id Device, cargo::string_view &ExtensionsRet) {
+  static std::string Extensions{};
+  static std::once_flag InitializedFlag{};
+  static cl_int Retcode = CL_SUCCESS;
 
-  std::call_once(initialized_flag, [&]() {
-    auto query_fn = [](const extension *extension, cl_device_id object,
-                       cl_device_info param_name, size_t param_value_size,
-                       void *param_value, size_t *param_value_size_ret) {
-      return extension->GetDeviceInfo(object, param_name, param_value_size,
-                                      param_value, param_value_size_ret);
+  std::call_once(InitializedFlag, [&]() {
+    auto QueryFn = [](const extension *Extension, cl_device_id Object,
+                       cl_device_info ParamName, size_t ParamValueSize,
+                       void *ParamValue, size_t *ParamValueSizeRet) {
+      return Extension->GetDeviceInfo(Object, ParamName, ParamValueSize,
+                                      ParamValue, ParamValueSizeRet);
     };
 
-    size_t ext_string_length = 0;
-    retcode = GetObjectExtensionInfoAggregatedCString(
-        getCompilerExtensions().size(), getCompilerExtensions().data(), device,
-        CL_DEVICE_EXTENSIONS, 0, nullptr, &ext_string_length, ' ', query_fn);
+    size_t ExtStringLength = 0;
+    Retcode = getObjectExtensionInfoAggregatedCString(
+        getCompilerExtensions().size(), getCompilerExtensions().data(), Device,
+        CL_DEVICE_EXTENSIONS, 0, nullptr, &ExtStringLength, ' ', QueryFn);
 
     // CL_INVALID_VALUE indicates that the device supports no etensions
-    if (CL_INVALID_VALUE == retcode) {
-      retcode = CL_SUCCESS;
+    if (CL_INVALID_VALUE == Retcode) {
+      Retcode = CL_SUCCESS;
       return;
     }
-    if (CL_SUCCESS != retcode) {
+    if (CL_SUCCESS != Retcode) {
       return;
     }
 
-    extensions = std::string(ext_string_length, '\0');
-    retcode = GetObjectExtensionInfoAggregatedCString(
-        getCompilerExtensions().size(), getCompilerExtensions().data(), device,
-        CL_DEVICE_EXTENSIONS, ext_string_length, extensions.data(), nullptr,
-        ' ', query_fn);
-    if (CL_SUCCESS != retcode) {
+    Extensions = std::string(ExtStringLength, '\0');
+    Retcode = getObjectExtensionInfoAggregatedCString(
+        getCompilerExtensions().size(), getCompilerExtensions().data(), Device,
+        CL_DEVICE_EXTENSIONS, ExtStringLength, Extensions.data(), nullptr,
+        ' ', QueryFn);
+    if (CL_SUCCESS != Retcode) {
       return;
     }
   });
 
-  if (CL_SUCCESS == retcode) {
-    extensions_ret = cargo::string_view(extensions.data(), extensions.size());
+  if (CL_SUCCESS == Retcode) {
+    ExtensionsRet = cargo::string_view(Extensions.data(), Extensions.size());
   }
 
-  return retcode;
+  return Retcode;
 }

--- a/source/cl/source/program.cpp
+++ b/source/cl/source/program.cpp
@@ -43,9 +43,9 @@ cl_int convertModuleStateToCL(compiler::ModuleState state) {
       return CL_PROGRAM_BINARY_TYPE_LIBRARY;
     case compiler::ModuleState::EXECUTABLE:
       return CL_PROGRAM_BINARY_TYPE_EXECUTABLE;
-    default:
-      return CL_PROGRAM_BINARY_TYPE_NONE;
   }
+
+  return CL_PROGRAM_BINARY_TYPE_NONE;
 }
 }  // namespace
 

--- a/source/cl/test/UnitCL/include/EventWaitList.h
+++ b/source/cl/test/UnitCL/include/EventWaitList.h
@@ -22,6 +22,8 @@
 /// @brief Base class for tests requiring event list testing.
 class TestWithEventWaitList {
  protected:
+  ~TestWithEventWaitList() = default;
+
   /// @brief Method performing the actual API calls when testing for event list
   /// error codes.
   ///

--- a/source/cl/test/UnitCL/include/kts/arguments.h
+++ b/source/cl/test/UnitCL/include/kts/arguments.h
@@ -92,9 +92,9 @@ class Argument final : public ArgumentBase {
   Primitive *GetPrimitive() const { return primitive_.get(); }
   void SetPrimitive(Primitive *new_prim) { primitive_.reset(new_prim); }
 
-  virtual uint8_t *GetBufferStoragePtr() { return storage_.data(); }
-  virtual size_t GetBufferStorageSize() { return storage_.size(); }
-  virtual void SetBufferStorageSize(size_t size) { storage_.resize(size); }
+  uint8_t *GetBufferStoragePtr() override { return storage_.data(); }
+  size_t GetBufferStorageSize() override { return storage_.size(); }
+  void SetBufferStorageSize(size_t size) override { storage_.resize(size); }
 
   const SamplerDesc &GetSamplerDesc() const { return sampler_; }
   void SetSamplerDesc(const SamplerDesc &new_sampler) {
@@ -153,8 +153,8 @@ class ArgumentList final {
 struct PointerPrimitive : public Primitive {
   PointerPrimitive(size_t size) : size_(size) {}
 
-  virtual void *GetAddress() { return nullptr; }
-  virtual size_t GetSize() { return size_; }
+  void *GetAddress() override { return nullptr; }
+  size_t GetSize() override { return size_; }
 
   size_t size_;
 };

--- a/source/cl/test/UnitCL/include/kts/execution.h
+++ b/source/cl/test/UnitCL/include/kts/execution.h
@@ -51,9 +51,9 @@ inline std::string to_string(const SourceType &source_type) {
       return "OfflineOpenCLC";
     case kts::ucl::SourceType::OFFLINESPIRV:
       return "OfflineSPIRV";
-    default:
-      UCL_ABORT("invalid SourceType: %d\n", source_type);
   }
+
+  UCL_ABORT("invalid SourceType: %d\n", source_type);
 }
 
 const std::array<SourceType, 4> &getSourceTypes();

--- a/source/cl/test/UnitCL/source/FeatureMacros.cpp
+++ b/source/cl/test/UnitCL/source/FeatureMacros.cpp
@@ -359,11 +359,11 @@ INSTANTIATE_TEST_CASE_P(
         cl_name_version{CL_MAKE_VERSION(3, 0, 0), "__opencl_c_3d_image_writes"},
         cl_name_version{CL_MAKE_VERSION(3, 0, 0),
                         "__opencl_c_program_scope_global_variables"}),
-    [](const ::testing::TestParamInfo<FeatureMacroTest::ParamType> &info) {
-      std::string output_name = info.param.name;
+    [](const ::testing::TestParamInfo<FeatureMacroTest::ParamType> &Info) {
+      std::string OutputName = Info.param.name;
       // Google test doesn't allow for underscores in test names.
-      output_name.erase(
-          std::remove(std::begin(output_name), std::end(output_name), '_'),
-          std::end(output_name));
-      return output_name;
+      OutputName.erase(
+          std::remove(std::begin(OutputName), std::end(OutputName), '_'),
+          std::end(OutputName));
+      return OutputName;
     });

--- a/source/cl/test/UnitCL/source/clBuildProgram.cpp
+++ b/source/cl/test/UnitCL/source/clBuildProgram.cpp
@@ -324,7 +324,7 @@ TEST_F(clBuildProgramBadTest, InvalidOperationPreviousBuildFailed) {
 typedef std::pair<cl_int, const char *> Pair;
 
 struct BuildOptionsTest : ucl::ContextTest, testing::WithParamInterface<Pair> {
-  void SetUp() {
+  void SetUp() override {
     UCL_RETURN_ON_FATAL_FAILURE(ContextTest::SetUp());
     if (!getDeviceCompilerAvailable()) {
       GTEST_SKIP();
@@ -337,7 +337,7 @@ struct BuildOptionsTest : ucl::ContextTest, testing::WithParamInterface<Pair> {
     ASSERT_SUCCESS(status);
   }
 
-  void TearDown() {
+  void TearDown() override {
     if (program) {
       EXPECT_SUCCESS(clReleaseProgram(program));
     }
@@ -393,7 +393,7 @@ class clBuildProgramMacroTest : public ucl::CommandQueueTest {
  protected:
   enum { SIZE = sizeof(cl_int) };
 
-  void SetUp() {
+  void SetUp() override {
     UCL_RETURN_ON_FATAL_FAILURE(CommandQueueTest::SetUp());
     if (!getDeviceCompilerAvailable()) {
       GTEST_SKIP();
@@ -421,7 +421,7 @@ class clBuildProgramMacroTest : public ucl::CommandQueueTest {
     ASSERT_SUCCESS(status);
   }
 
-  void TearDown() {
+  void TearDown() override {
     if (macro_value) {
       EXPECT_SUCCESS(clReleaseMemObject(macro_value));
     }
@@ -518,7 +518,7 @@ TEST_F(clBuildProgramMacroTest, ValueDefinedThenSpace) {
 
 class clBuildProgramTwiceTest : public ucl::CommandQueueTest {
  protected:
-  void SetUp() {
+  void SetUp() override {
     UCL_RETURN_ON_FATAL_FAILURE(CommandQueueTest::SetUp());
     if (!getDeviceCompilerAvailable()) {
       GTEST_SKIP();
@@ -538,7 +538,7 @@ class clBuildProgramTwiceTest : public ucl::CommandQueueTest {
     ASSERT_SUCCESS(status);
   }
 
-  void TearDown() {
+  void TearDown() override {
     if (macro_value) {
       EXPECT_SUCCESS(clReleaseMemObject(macro_value));
     }
@@ -615,7 +615,7 @@ TEST_F(clBuildProgramTwiceTest, RetainKernel) {
 
 class clBuildProgramIncludePathTest : public ucl::CommandQueueTest {
  protected:
-  void SetUp() {
+  void SetUp() override {
     UCL_RETURN_ON_FATAL_FAILURE(CommandQueueTest::SetUp());
     if (!getDeviceCompilerAvailable()) {
       GTEST_SKIP();
@@ -637,7 +637,7 @@ class clBuildProgramIncludePathTest : public ucl::CommandQueueTest {
         clBuildProgram(program, 0, nullptr, options.c_str(), nullptr, nullptr));
   }
 
-  void TearDown() {
+  void TearDown() override {
     if (program) {
       EXPECT_SUCCESS(clReleaseProgram(program));
     }

--- a/source/cl/test/UnitCL/source/clCloneKernel.cpp
+++ b/source/cl/test/UnitCL/source/clCloneKernel.cpp
@@ -21,7 +21,7 @@
 #include <cstring>
 
 struct clCloneKernelTest : ucl::ContextTest {
-  virtual void SetUp() {
+  void SetUp() override {
     UCL_RETURN_ON_FATAL_FAILURE(ucl::ContextTest::SetUp());
     if (!UCL::isDeviceVersionAtLeast({3, 0})) {
       GTEST_SKIP();
@@ -50,7 +50,7 @@ kernel void test(global int* out) {
     return error;
   }
 
-  virtual void TearDown() {
+  void TearDown() override {
     if (clone_kernel) {
       EXPECT_SUCCESS(clReleaseKernel(clone_kernel));
     }
@@ -103,7 +103,7 @@ TEST_F(clCloneKernelTest, InvalidKernel) {
 }
 
 struct clCloneKernelRunTest : clCloneKernelTest {
-  virtual void SetUp() {
+  void SetUp() override {
     UCL_RETURN_ON_FATAL_FAILURE(clCloneKernelTest::SetUp());
     if (!UCL::hasCompilerSupport(device)) {
       GTEST_SKIP();
@@ -117,7 +117,7 @@ struct clCloneKernelRunTest : clCloneKernelTest {
     ASSERT_SUCCESS(error);
   }
 
-  virtual void TearDown() {
+  void TearDown() override {
     if (buffer) {
       EXPECT_SUCCESS(clReleaseMemObject(buffer));
     }

--- a/source/cl/test/UnitCL/source/clCompileProgram.cpp
+++ b/source/cl/test/UnitCL/source/clCompileProgram.cpp
@@ -399,7 +399,7 @@ typedef std::pair<cl_int, const char *> Pair;
 
 struct CompileOptionsTest : ucl::ContextTest,
                             testing::WithParamInterface<Pair> {
-  void SetUp() {
+  void SetUp() override {
     UCL_RETURN_ON_FATAL_FAILURE(ContextTest::SetUp());
     if (UCL::isInterceptLayerPresent()) {
       GTEST_SKIP();  // Injection creates programs from binaries, can't compile.
@@ -414,7 +414,7 @@ struct CompileOptionsTest : ucl::ContextTest,
     ASSERT_SUCCESS(status);
   }
 
-  void TearDown() {
+  void TearDown() override {
     if (program) {
       EXPECT_SUCCESS(clReleaseProgram(program));
     }
@@ -465,7 +465,7 @@ class clCompileProgramMacroTest : public ucl::CommandQueueTest {
  protected:
   enum { SIZE = sizeof(cl_int) };
 
-  void SetUp() {
+  void SetUp() override {
     UCL_RETURN_ON_FATAL_FAILURE(CommandQueueTest::SetUp());
     if (!getDeviceCompilerAvailable()) {
       GTEST_SKIP();
@@ -491,7 +491,7 @@ class clCompileProgramMacroTest : public ucl::CommandQueueTest {
     ASSERT_SUCCESS(status);
   }
 
-  void TearDown() {
+  void TearDown() override {
     if (macroValue) {
       EXPECT_SUCCESS(clReleaseMemObject(macroValue));
     }
@@ -589,7 +589,7 @@ TEST_F(clCompileProgramMacroTest, ValueDefined) {
 
 class clCompileProgramIncludePathTest : public ucl::ContextTest {
  protected:
-  void SetUp() {
+  void SetUp() override {
     UCL_RETURN_ON_FATAL_FAILURE(ContextTest::SetUp());
     if (!getDeviceCompilerAvailable()) {
       GTEST_SKIP();
@@ -605,7 +605,7 @@ class clCompileProgramIncludePathTest : public ucl::ContextTest {
     UCL::checkTestIncludePath();
   }
 
-  void TearDown() {
+  void TearDown() override {
     if (program) {
       EXPECT_SUCCESS(clReleaseProgram(program));
     }

--- a/source/cl/test/UnitCL/source/clCreatePipe.cpp
+++ b/source/cl/test/UnitCL/source/clCreatePipe.cpp
@@ -18,7 +18,7 @@
 
 class clCreatePipeTest : public ucl::ContextTest {
  protected:
-  virtual void SetUp() {
+  void SetUp() override {
     UCL_RETURN_ON_FATAL_FAILURE(ucl::ContextTest::SetUp());
     if (!UCL::isDeviceVersionAtLeast({3, 0})) {
       GTEST_SKIP();

--- a/source/cl/test/UnitCL/source/clCreateProgramWithBinary.cpp
+++ b/source/cl/test/UnitCL/source/clCreateProgramWithBinary.cpp
@@ -24,7 +24,7 @@
 
 class clCreateProgramWithBinaryTest : public ucl::ContextTest {
  protected:
-  void SetUp() {
+  void SetUp() override {
     UCL_RETURN_ON_FATAL_FAILURE(ContextTest::SetUp());
 #ifndef CA_CL_ENABLE_OFFLINE_KERNEL_TESTS
     // This test requires offline kernels
@@ -54,7 +54,7 @@ class clCreateProgramWithBinaryTest : public ucl::ContextTest {
     ASSERT_SUCCESS(clReleaseProgram(originalProgram));
   }
 
-  void TearDown() {
+  void TearDown() override {
     if (nullptr != binaries) {
       for (unsigned i = 0; i < 1; ++i) {
         delete[] binaries[i];

--- a/source/cl/test/UnitCL/source/clCreateSubBuffer.cpp
+++ b/source/cl/test/UnitCL/source/clCreateSubBuffer.cpp
@@ -18,7 +18,7 @@
 
 class clCreateSubBufferTest : public ucl::CommandQueueTest {
  protected:
-  void SetUp() {
+  void SetUp() override {
     UCL_RETURN_ON_FATAL_FAILURE(CommandQueueTest::SetUp());
     cl_uint mem_base_addr_align = 0;
     ASSERT_EQ(CL_SUCCESS,
@@ -31,7 +31,7 @@ class clCreateSubBufferTest : public ucl::CommandQueueTest {
     region.size = sizeof(cl_int);
   }
 
-  void TearDown() {
+  void TearDown() override {
     if (buffer) {
       EXPECT_SUCCESS(clReleaseMemObject(buffer));
     }

--- a/source/cl/test/UnitCL/source/clEnqueueBarrierWithWaitList.cpp
+++ b/source/cl/test/UnitCL/source/clEnqueueBarrierWithWaitList.cpp
@@ -20,8 +20,8 @@
 class clEnqueueBarrierWithWaitListTest : public ucl::CommandQueueTest,
                                          TestWithEventWaitList {
  protected:
-  virtual void EventWaitListAPICall(cl_int err, cl_uint num_events,
-                                    const cl_event *events, cl_event *event) {
+  void EventWaitListAPICall(cl_int err, cl_uint num_events,
+                            const cl_event *events, cl_event *event) override {
     ASSERT_EQ_ERRCODE(err, clEnqueueBarrierWithWaitList(
                                command_queue, num_events, events, event));
   }

--- a/source/cl/test/UnitCL/source/clEnqueueMapImage.cpp
+++ b/source/cl/test/UnitCL/source/clEnqueueMapImage.cpp
@@ -477,7 +477,7 @@ class clEnqueueMapImageNegativeTest1d : public clEnqueueMapImageTestBase {
 
 class clEnqueueMapImageNegativeTest1dBuffer : public clEnqueueMapImageTestBase {
  public:
-  void TearDown() {
+  void TearDown() override {
     if (buffer) {
       EXPECT_SUCCESS(clReleaseMemObject(buffer));
     }

--- a/source/cl/test/UnitCL/source/clEnqueueNDRangeKernel.cpp
+++ b/source/cl/test/UnitCL/source/clEnqueueNDRangeKernel.cpp
@@ -2122,7 +2122,7 @@ class clEnqueueNDRangeKernelZeroDimension
     : public clEnqueueNDRangeKernelTest,
       public testing::WithParamInterface<size_t> {
  protected:
-  virtual void SetUp() {
+  void SetUp() override {
     clEnqueueNDRangeKernelTest::SetUp();
     // Returning CL_INVALID_GLOBAL_WORK_SIZE for NDRanges with a zero-sized
     // dimension was deprecated in 2.1.
@@ -2164,7 +2164,7 @@ class LinearIDTest
       {{0, 0, 0}, {1, 2, 3}}};
 
  protected:
-  virtual void SetUp() {
+  void SetUp() override {
     UCL_RETURN_ON_FATAL_FAILURE(CommandQueueTest::SetUp());
     // get_local_linear_id and get_global_linear_id were
     // introduced in the OpenCL-2.0 spec.
@@ -2221,7 +2221,7 @@ class LinearIDTest
                                   nullptr, nullptr));
   }
 
-  virtual void TearDown() {
+  void TearDown() override {
     if (nullptr != output_buffer) {
       EXPECT_SUCCESS(clReleaseMemObject(output_buffer));
     }
@@ -2314,7 +2314,7 @@ INSTANTIATE_TEST_CASE_P(
 
 class GetEnqueuedLocalSizeTest : public ucl::CommandQueueTest {
  protected:
-  virtual void SetUp() override {
+  void SetUp() override {
     UCL_RETURN_ON_FATAL_FAILURE(CommandQueueTest::SetUp());
     // get_enqueued_local_size was introduced for non-uniform workgroups
     // in OpenCL-2.0.
@@ -2354,7 +2354,7 @@ class GetEnqueuedLocalSizeTest : public ucl::CommandQueueTest {
                                   nullptr, nullptr));
   }
 
-  virtual void TearDown() override {
+  void TearDown() override {
     if (nullptr != output_buffer) {
       EXPECT_SUCCESS(clReleaseMemObject(output_buffer));
     }

--- a/source/cl/test/UnitCL/source/clEnqueueSVMFree.cpp
+++ b/source/cl/test/UnitCL/source/clEnqueueSVMFree.cpp
@@ -18,7 +18,7 @@
 
 class clEnqueueSVMFreeTest : public ucl::CommandQueueTest {
  protected:
-  virtual void SetUp() {
+  void SetUp() override {
     UCL_RETURN_ON_FATAL_FAILURE(CommandQueueTest::SetUp());
     if (!UCL::isDeviceVersionAtLeast({3, 0})) {
       GTEST_SKIP();

--- a/source/cl/test/UnitCL/source/clEnqueueSVMMap.cpp
+++ b/source/cl/test/UnitCL/source/clEnqueueSVMMap.cpp
@@ -18,7 +18,7 @@
 
 class clEnqueueSVMMapTest : public ucl::CommandQueueTest {
  protected:
-  virtual void SetUp() {
+  void SetUp() override {
     UCL_RETURN_ON_FATAL_FAILURE(CommandQueueTest::SetUp());
     if (!UCL::isDeviceVersionAtLeast({3, 0})) {
       GTEST_SKIP();

--- a/source/cl/test/UnitCL/source/clEnqueueSVMMemFill.cpp
+++ b/source/cl/test/UnitCL/source/clEnqueueSVMMemFill.cpp
@@ -18,7 +18,7 @@
 
 class clEnqueueSVMMemFillTest : public ucl::CommandQueueTest {
  protected:
-  virtual void SetUp() {
+  void SetUp() override {
     UCL_RETURN_ON_FATAL_FAILURE(CommandQueueTest::SetUp());
     if (!UCL::isDeviceVersionAtLeast({3, 0})) {
       GTEST_SKIP();

--- a/source/cl/test/UnitCL/source/clEnqueueSVMMemcpy.cpp
+++ b/source/cl/test/UnitCL/source/clEnqueueSVMMemcpy.cpp
@@ -18,7 +18,7 @@
 
 class clEnqueueSVMMemcpyTest : public ucl::CommandQueueTest {
  protected:
-  virtual void SetUp() {
+  void SetUp() override {
     UCL_RETURN_ON_FATAL_FAILURE(CommandQueueTest::SetUp());
     if (!UCL::isDeviceVersionAtLeast({3, 0})) {
       GTEST_SKIP();

--- a/source/cl/test/UnitCL/source/clEnqueueSVMMigrateMem.cpp
+++ b/source/cl/test/UnitCL/source/clEnqueueSVMMigrateMem.cpp
@@ -18,7 +18,7 @@
 
 class clEnqueueSVMMigrateMemTest : public ucl::CommandQueueTest {
  protected:
-  virtual void SetUp() {
+  void SetUp() override {
     UCL_RETURN_ON_FATAL_FAILURE(CommandQueueTest::SetUp());
     if (!UCL::isDeviceVersionAtLeast({3, 0})) {
       GTEST_SKIP();

--- a/source/cl/test/UnitCL/source/clEnqueueSVMUnmap.cpp
+++ b/source/cl/test/UnitCL/source/clEnqueueSVMUnmap.cpp
@@ -18,7 +18,7 @@
 
 class clEnqueueSVMUnmapTest : public ucl::CommandQueueTest {
  protected:
-  virtual void SetUp() {
+  void SetUp() override {
     UCL_RETURN_ON_FATAL_FAILURE(CommandQueueTest::SetUp());
     if (!UCL::isDeviceVersionAtLeast({3, 0})) {
       GTEST_SKIP();

--- a/source/cl/test/UnitCL/source/clGetDeviceAndHostTimer.cpp
+++ b/source/cl/test/UnitCL/source/clGetDeviceAndHostTimer.cpp
@@ -18,7 +18,7 @@
 
 class clGetDeviceAndHostTimerTest : public ucl::DeviceTest {
  protected:
-  virtual void SetUp() {
+  void SetUp() override {
     UCL_RETURN_ON_FATAL_FAILURE(DeviceTest::SetUp());
     if (!UCL::isDeviceVersionAtLeast({3, 0})) {
       GTEST_SKIP();

--- a/source/cl/test/UnitCL/source/clGetDeviceInfo.cpp
+++ b/source/cl/test/UnitCL/source/clGetDeviceInfo.cpp
@@ -1503,8 +1503,8 @@ INSTANTIATE_TEST_CASE_P(
         std::make_tuple(sizeof(size_t),
                         CL_DEVICE_PREFERRED_WORK_GROUP_SIZE_MULTIPLE)),
     [](const testing::TestParamInfo<
-        clGetDeviceInfoTestScalarQueryOpenCL30::ParamType> &info) {
-      return UCL::deviceQueryToString(std::get<1>(info.param));
+        clGetDeviceInfoTestScalarQueryOpenCL30::ParamType> &Info) {
+      return UCL::deviceQueryToString(std::get<1>(Info.param));
     });
 
 class clGetDeviceInfoTestVectorQueryOpenCL30
@@ -1570,8 +1570,8 @@ INSTANTIATE_TEST_CASE_P(
                     CL_DEVICE_OPENCL_C_FEATURES,
                     CL_DEVICE_LATEST_CONFORMANCE_VERSION_PASSED),
     [](const testing::TestParamInfo<
-        clGetDeviceInfoTestVectorQueryOpenCL30::ParamType> &info) {
-      return UCL::deviceQueryToString(std::get<0>(info.param));
+        clGetDeviceInfoTestVectorQueryOpenCL30::ParamType> &Info) {
+      return UCL::deviceQueryToString(std::get<0>(Info.param));
     });
 
 TEST_F(clGetDeviceInfoTest, MinimumRequiredAtomicMemoryCapabilities) {
@@ -1818,8 +1818,6 @@ TEST_F(clGetDeviceInfoTest, ValidateExtensionsWithVersion) {
   // Construct an array of strings so we can easily traverse the space separated
   // list.
   auto split_extensions = cargo::split(device_extensions, " ");
-  // Check that the lists have the same size for an early exit.
-  ASSERT_EQ(split_extensions.size(), device_extensions_with_version.size());
   // Construct second array of strings from versioned extensions.
   std::vector<cargo::string_view> split_version_extensions{};
   for (const auto &ext : device_extensions_with_version) {
@@ -1922,9 +1920,6 @@ TEST_F(clGetDeviceInfoTest, ValidateBuiltInKernelsWithVersion) {
   // Construct an array of strings so we can easily traverse the space separated
   // list.
   auto split_built_in_kernels = cargo::split(device_built_in_kernels, ";");
-  // Check that the lists have the same size for an early exit.
-  ASSERT_EQ(split_built_in_kernels.size(),
-            device_built_in_kernels_with_version.size());
   // Construct second array of strings from versioned extensions.
   std::vector<cargo::string_view> split_built_in_kernels_with_version{};
   for (const auto &ext : device_built_in_kernels_with_version) {
@@ -2009,8 +2004,6 @@ TEST_F(clGetDeviceInfoTest, ValidateILSWithVersion) {
   // Construct an array of strings so we can easily traverse the space separated
   // list.
   auto split_device_il_version = cargo::split(device_il_version, " ");
-  // Check that the lists have the same size for an early exit.
-  ASSERT_EQ(split_device_il_version.size(), device_ils_with_version.size());
   // Check that every element in IL_VERSION is in ILS_WITH_VERSION.
   for (auto &il_version : split_device_il_version) {
     const std::regex ils_version_regex{R"(([\w-]+)_(\d+)\.(\d+))"};
@@ -2027,9 +2020,9 @@ TEST_F(clGetDeviceInfoTest, ValidateILSWithVersion) {
     ASSERT_NE(
         std::find_if(device_ils_with_version.begin(),
                      device_ils_with_version.end(),
-                     [&name_version](cl_name_version_khr nv) {
-                       return (std::strcmp(name_version.name, nv.name) == 0) &&
-                              name_version.version == nv.version;
+                     [&name_version](cl_name_version_khr Nv) {
+                       return name_version.version == Nv.version &&
+                              (std::strcmp(name_version.name, Nv.name) == 0);
                      }),
         device_ils_with_version.end())
         << "Missing IL in CL_DEVICE_ILS_WITH_VERSION";
@@ -2083,13 +2076,12 @@ TEST_F(clGetDeviceInfoTest, ValidateOpenCLCAllVersions) {
       std::atoi(sm.str(1).c_str()), std::atoi(sm.str(2).c_str()), 0);
   // Check its contained in the array returned by
   // CL_DEVICE_OPENCL_C_ALL_VERSIONS.
-  ASSERT_NE(
-      std::find_if(std::begin(opencl_c_all_versions),
-                   std::end(opencl_c_all_versions),
-                   [&extracted_version](cl_name_version_khr name_version) {
-                     return name_version.version == extracted_version;
-                   }),
-      std::end(opencl_c_all_versions));
+  ASSERT_NE(std::find_if(std::begin(opencl_c_all_versions),
+                         std::end(opencl_c_all_versions),
+                         [&extracted_version](cl_name_version_khr NameVersion) {
+                           return NameVersion.version == extracted_version;
+                         }),
+            std::end(opencl_c_all_versions));
 }
 
 TEST_F(clGetDeviceInfoTest, ValidateOpenCLCAllVersionsCompatibility) {
@@ -2124,8 +2116,8 @@ TEST_F(clGetDeviceInfoTest, ValidateOpenCLCAllVersionsCompatibility) {
         // for an OpenCL 3.0 device.
         EXPECT_NE(std::find_if(std::begin(opencl_c_all_versions),
                                std::end(opencl_c_all_versions),
-                               [](cl_name_version_khr nv) {
-                                 return nv.version ==
+                               [](cl_name_version_khr Nv) {
+                                 return Nv.version ==
                                         CL_MAKE_VERSION_KHR(1, 2, 0);
                                }),
                   std::end(opencl_c_all_versions));
@@ -2138,29 +2130,29 @@ TEST_F(clGetDeviceInfoTest, ValidateOpenCLCAllVersionsCompatibility) {
         // device.
         EXPECT_NE(std::find_if(std::begin(opencl_c_all_versions),
                                std::end(opencl_c_all_versions),
-                               [](cl_name_version_khr nv) {
-                                 return nv.version ==
+                               [](cl_name_version_khr Nv) {
+                                 return Nv.version ==
                                         CL_MAKE_VERSION_KHR(2, 0, 0);
                                }),
                   std::end(opencl_c_all_versions));
         EXPECT_NE(std::find_if(std::begin(opencl_c_all_versions),
                                std::end(opencl_c_all_versions),
-                               [](cl_name_version_khr nv) {
-                                 return nv.version ==
+                               [](cl_name_version_khr Nv) {
+                                 return Nv.version ==
                                         CL_MAKE_VERSION_KHR(1, 2, 0);
                                }),
                   std::end(opencl_c_all_versions));
         EXPECT_NE(std::find_if(std::begin(opencl_c_all_versions),
                                std::end(opencl_c_all_versions),
-                               [](cl_name_version_khr nv) {
-                                 return nv.version ==
+                               [](cl_name_version_khr Nv) {
+                                 return Nv.version ==
                                         CL_MAKE_VERSION_KHR(1, 1, 0);
                                }),
                   std::end(opencl_c_all_versions));
         EXPECT_NE(std::find_if(std::begin(opencl_c_all_versions),
                                std::end(opencl_c_all_versions),
-                               [](cl_name_version_khr nv) {
-                                 return nv.version ==
+                               [](cl_name_version_khr Nv) {
+                                 return Nv.version ==
                                         CL_MAKE_VERSION_KHR(1, 0, 0);
                                }),
                   std::end(opencl_c_all_versions));
@@ -2170,15 +2162,15 @@ TEST_F(clGetDeviceInfoTest, ValidateOpenCLCAllVersionsCompatibility) {
         // for an OpenCL 1.2 device.
         EXPECT_NE(std::find_if(std::begin(opencl_c_all_versions),
                                std::end(opencl_c_all_versions),
-                               [](cl_name_version_khr nv) {
-                                 return nv.version ==
+                               [](cl_name_version_khr Nv) {
+                                 return Nv.version ==
                                         CL_MAKE_VERSION_KHR(1, 1, 0);
                                }),
                   std::end(opencl_c_all_versions));
         EXPECT_NE(std::find_if(std::begin(opencl_c_all_versions),
                                std::end(opencl_c_all_versions),
-                               [](cl_name_version_khr nv) {
-                                 return nv.version ==
+                               [](cl_name_version_khr Nv) {
+                                 return Nv.version ==
                                         CL_MAKE_VERSION_KHR(1, 0, 0);
                                }),
                   std::end(opencl_c_all_versions));
@@ -2188,8 +2180,8 @@ TEST_F(clGetDeviceInfoTest, ValidateOpenCLCAllVersionsCompatibility) {
         // OpenCL 1.1 device.
         EXPECT_NE(std::find_if(std::begin(opencl_c_all_versions),
                                std::end(opencl_c_all_versions),
-                               [](cl_name_version_khr nv) {
-                                 return nv.version ==
+                               [](cl_name_version_khr Nv) {
+                                 return Nv.version ==
                                         CL_MAKE_VERSION_KHR(1, 0, 0);
                                }),
                   std::end(opencl_c_all_versions));

--- a/source/cl/test/UnitCL/source/clGetEventProfilingInfo.cpp
+++ b/source/cl/test/UnitCL/source/clGetEventProfilingInfo.cpp
@@ -290,8 +290,8 @@ INSTANTIATE_TEST_CASE_P(
     testing::Values(std::make_tuple(sizeof(cl_ulong),
                                     CL_PROFILING_COMMAND_COMPLETE)),
     [](const testing::TestParamInfo<
-        clGetEventProfilingInfoTestScalarQueryOpenCL30::ParamType> &info) {
-      return UCL::profilingQueryToString(std::get<1>(info.param));
+        clGetEventProfilingInfoTestScalarQueryOpenCL30::ParamType> &Info) {
+      return UCL::profilingQueryToString(std::get<1>(Info.param));
     });
 
 TEST_F(clGetEventProfilingInfoTestScalarQueryOpenCL30,

--- a/source/cl/test/UnitCL/source/clGetHostTimer.cpp
+++ b/source/cl/test/UnitCL/source/clGetHostTimer.cpp
@@ -18,7 +18,7 @@
 
 class clGetHostTimerTest : public ucl::DeviceTest {
  protected:
-  virtual void SetUp() {
+  void SetUp() override {
     UCL_RETURN_ON_FATAL_FAILURE(DeviceTest::SetUp());
     if (!UCL::isDeviceVersionAtLeast({3, 0})) {
       GTEST_SKIP();

--- a/source/cl/test/UnitCL/source/clGetKernelInfo.cpp
+++ b/source/cl/test/UnitCL/source/clGetKernelInfo.cpp
@@ -34,7 +34,7 @@ std::string work_group_size_hint(const std::array<size_t, 3> sizes) {
 
 class clGetKernelInfoTest : public ucl::ContextTest {
  protected:
-  void SetUp() {
+  void SetUp() override {
     UCL_RETURN_ON_FATAL_FAILURE(ContextTest::SetUp());
     if (!getDeviceCompilerAvailable()) {
       GTEST_SKIP();
@@ -71,7 +71,7 @@ class clGetKernelInfoTest : public ucl::ContextTest {
     ASSERT_SUCCESS(errcode);
   }
 
-  void TearDown() {
+  void TearDown() override {
     if (kernel) {
       ASSERT_SUCCESS(clReleaseKernel(kernel));
     }
@@ -290,7 +290,7 @@ typedef std::pair<const char *, std::vector<const char *>> InputPair;
 
 struct clGetKernelInfoAttributeTest : ucl::ContextTest,
                                       testing::WithParamInterface<InputPair> {
-  void SetUp() {
+  void SetUp() override {
     UCL_RETURN_ON_FATAL_FAILURE(ContextTest::SetUp());
     if (UCL::isInterceptLayerPresent()) {
       GTEST_SKIP();  // Injection doesn't propogate kernel attributes.
@@ -312,7 +312,7 @@ struct clGetKernelInfoAttributeTest : ucl::ContextTest,
     ASSERT_SUCCESS(errcode);
   }
 
-  void TearDown() {
+  void TearDown() override {
     if (kernel) {
       ASSERT_SUCCESS(clReleaseKernel(kernel));
     }

--- a/source/cl/test/UnitCL/source/clGetKernelWorkGroupInfo.cpp
+++ b/source/cl/test/UnitCL/source/clGetKernelWorkGroupInfo.cpp
@@ -20,7 +20,7 @@
 
 class clGetKernelWorkGroupInfoTest : public ucl::ContextTest {
  protected:
-  void SetUp() {
+  void SetUp() override {
     UCL_RETURN_ON_FATAL_FAILURE(ContextTest::SetUp());
     if (!getDeviceCompilerAvailable()) {
       GTEST_SKIP();
@@ -89,7 +89,7 @@ class clGetKernelWorkGroupInfoTest : public ucl::ContextTest {
     ASSERT_SUCCESS(status);
   }
 
-  void TearDown() {
+  void TearDown() override {
     if (kernel_nolocal) {
       ASSERT_SUCCESS(clReleaseKernel(kernel_nolocal));
     }

--- a/source/cl/test/UnitCL/source/clGetMemObjectInfo.cpp
+++ b/source/cl/test/UnitCL/source/clGetMemObjectInfo.cpp
@@ -378,7 +378,7 @@ INSTANTIATE_TEST_CASE_P(
     MemObjectQuery, clGetMemObjectInfoUsesSVMPointerTest,
     testing::Values(std::make_tuple(sizeof(cl_bool), CL_MEM_USES_SVM_POINTER)),
     [](const testing::TestParamInfo<
-        clGetMemObjectInfoUsesSVMPointerTest::ParamType> &info) {
-      return UCL::memObjectQueryToString(std::get<1>(info.param));
+        clGetMemObjectInfoUsesSVMPointerTest::ParamType> &Info) {
+      return UCL::memObjectQueryToString(std::get<1>(Info.param));
     });
 #endif

--- a/source/cl/test/UnitCL/source/clGetPipeInfo.cpp
+++ b/source/cl/test/UnitCL/source/clGetPipeInfo.cpp
@@ -18,7 +18,7 @@
 
 class clGetPipeInfoTest : public ucl::ContextTest {
  protected:
-  virtual void SetUp() {
+  void SetUp() override {
     UCL_RETURN_ON_FATAL_FAILURE(ContextTest::SetUp());
     cl_int error{};
     buffer = clCreateBuffer(context, 0, 42, nullptr, &error);
@@ -29,7 +29,7 @@ class clGetPipeInfoTest : public ucl::ContextTest {
     }
   }
 
-  virtual void TearDown() {
+  void TearDown() override {
     if (buffer) {
       EXPECT_SUCCESS(clReleaseMemObject(buffer));
     }

--- a/source/cl/test/UnitCL/source/clGetPlatformInfo.cpp
+++ b/source/cl/test/UnitCL/source/clGetPlatformInfo.cpp
@@ -156,8 +156,8 @@ INSTANTIATE_TEST_CASE_P(
         std::make_tuple(sizeof(cl_version), CL_PLATFORM_NUMERIC_VERSION),
         std::make_tuple(sizeof(cl_ulong), CL_PLATFORM_HOST_TIMER_RESOLUTION)),
     [](const testing::TestParamInfo<clGetPlatformInfoTestOpenCL30::ParamType>
-           &info) {
-      return UCL::platformQueryToString(std::get<1>(info.param));
+           &Info) {
+      return UCL::platformQueryToString(std::get<1>(Info.param));
     });
 
 TEST_F(clGetPlatformInfoTestOpenCL30, VerifyNumericVersion) {
@@ -259,8 +259,6 @@ TEST_F(clGetPlatformInfoTest, ValidateExtensionsWithVersion) {
   // Construct an array of strings so we can easily traverse the space separated
   // list.
   auto split_extensions = cargo::split(platform_extentions, " ");
-  // Check that the lists have the same size for an early exit.
-  ASSERT_EQ(split_extensions.size(), platform_extentions_with_version.size());
   // Construct second array of strings from versioned extensions.
   std::vector<cargo::string_view> split_version_extensions{};
   for (const auto &ext : platform_extentions_with_version) {

--- a/source/cl/test/UnitCL/source/clGetProgramBuildInfo.cpp
+++ b/source/cl/test/UnitCL/source/clGetProgramBuildInfo.cpp
@@ -452,7 +452,7 @@ INSTANTIATE_TEST_CASE_P(
     testing::Values(std::make_tuple(
         sizeof(size_t), CL_PROGRAM_BUILD_GLOBAL_VARIABLE_TOTAL_SIZE)),
     [](const testing::TestParamInfo<
-        clGetProgramBuildInfoTestScalarQueryOpenCL30::ParamType> &info) {
-      return UCL::programBuildQueryToString(std::get<1>(info.param));
+        clGetProgramBuildInfoTestScalarQueryOpenCL30::ParamType> &Info) {
+      return UCL::programBuildQueryToString(std::get<1>(Info.param));
     });
 #endif

--- a/source/cl/test/UnitCL/source/clGetProgramInfo.cpp
+++ b/source/cl/test/UnitCL/source/clGetProgramInfo.cpp
@@ -421,7 +421,7 @@ TEST_F(clGetProgramInfoCompiledProgram,
 struct clGetProgramInfoInvalidProgramTest : ucl::ContextTest {
   cl_program program = nullptr;
 
-  void SetUp() {
+  void SetUp() override {
     UCL_RETURN_ON_FATAL_FAILURE(ContextTest::SetUp());
 
     if (!getDeviceCompilerAvailable()) {
@@ -442,7 +442,7 @@ void kernel foo(global int * a, global int * b) {
         clBuildProgram(program, 0, nullptr, nullptr, nullptr, nullptr));
   }
 
-  void TearDown() {
+  void TearDown() override {
     if (program) {
       EXPECT_SUCCESS(clReleaseProgram(program));
     }
@@ -477,7 +477,7 @@ TEST_F(clGetProgramInfoInvalidProgramTest, ProgramInfo) {
 struct clGetProgramInfoBuiltinTest : ucl::ContextTest {
   cl_program program = nullptr;
 
-  void SetUp() {
+  void SetUp() override {
     UCL_RETURN_ON_FATAL_FAILURE(ContextTest::SetUp());
 
     size_t size;
@@ -505,7 +505,7 @@ struct clGetProgramInfoBuiltinTest : ucl::ContextTest {
     ASSERT_SUCCESS(error);
   }
 
-  void TearDown() {
+  void TearDown() override {
     if (program) {
       EXPECT_SUCCESS(clReleaseProgram(program));
     }
@@ -618,7 +618,7 @@ INSTANTIATE_TEST_CASE_P(
                       std::make_tuple(sizeof(cl_bool),
                                       CL_PROGRAM_SCOPE_GLOBAL_DTORS_PRESENT)),
     [](const testing::TestParamInfo<clGetProgramInfoTestParam::ParamType>
-           &info) {
-      return UCL::programQueryToString(std::get<1>(info.param));
+           &Info) {
+      return UCL::programQueryToString(std::get<1>(Info.param));
     });
 #endif

--- a/source/cl/test/UnitCL/source/clGetSamplerInfo.cpp
+++ b/source/cl/test/UnitCL/source/clGetSamplerInfo.cpp
@@ -151,7 +151,7 @@ static std::ostream &operator<<(std::ostream &out, sampler_args params) {
 }
 
 struct ValueTest : ucl::ContextTest, testing::WithParamInterface<sampler_args> {
-  void SetUp() {
+  void SetUp() override {
     UCL_RETURN_ON_FATAL_FAILURE(ContextTest::SetUp());
     if (!getDeviceImageSupport()) {
       GTEST_SKIP();
@@ -164,7 +164,7 @@ struct ValueTest : ucl::ContextTest, testing::WithParamInterface<sampler_args> {
     ASSERT_SUCCESS(status);
   }
 
-  void TearDown() {
+  void TearDown() override {
     if (sampler) {
       EXPECT_SUCCESS(clReleaseSampler(sampler));
     }

--- a/source/cl/test/UnitCL/source/clGetSupportedImageFormats.cpp
+++ b/source/cl/test/UnitCL/source/clGetSupportedImageFormats.cpp
@@ -192,7 +192,7 @@ TEST_F(clGetSupportedImageFormatsTest, InvalidContext) {
 struct clGetSupportedImageFormatsFlagsTest
     : ucl::ContextTest,
       testing::WithParamInterface<cl_mem_flags> {
-  void SetUp() {
+  void SetUp() override {
     UCL_RETURN_ON_FATAL_FAILURE(ContextTest::SetUp());
     if (!getDeviceImageSupport()) {
       GTEST_SKIP();

--- a/source/cl/test/UnitCL/source/clLinkProgram.cpp
+++ b/source/cl/test/UnitCL/source/clLinkProgram.cpp
@@ -339,7 +339,7 @@ TEST_F(clLinkProgramCompilerlessTest, CompilerUnavailable) {
 typedef std::pair<cl_int, const char *> Pair;
 
 struct LinkOptionsTest : ucl::ContextTest, testing::WithParamInterface<Pair> {
-  void SetUp() {
+  void SetUp() override {
     UCL_RETURN_ON_FATAL_FAILURE(ContextTest::SetUp());
     if (UCL::isInterceptLayerPresent()) {
       GTEST_SKIP();  // Injection creates programs from binaries, can't link.
@@ -357,7 +357,7 @@ struct LinkOptionsTest : ucl::ContextTest, testing::WithParamInterface<Pair> {
                                     nullptr, nullptr, nullptr));
   }
 
-  void TearDown() {
+  void TearDown() override {
     if (linked_program) {
       EXPECT_SUCCESS(clReleaseProgram(linked_program));
     }
@@ -411,7 +411,7 @@ INSTANTIATE_TEST_CASE_P(
 
 struct LinkLibraryOptionsTest : ucl::ContextTest,
                                 testing::WithParamInterface<Pair> {
-  void SetUp() {
+  void SetUp() override {
     UCL_RETURN_ON_FATAL_FAILURE(ContextTest::SetUp());
     if (UCL::isInterceptLayerPresent()) {
       GTEST_SKIP();  // Injection creates programs from binaries, can't link.
@@ -428,7 +428,7 @@ struct LinkLibraryOptionsTest : ucl::ContextTest,
                                     nullptr, nullptr, nullptr));
   }
 
-  void TearDown() {
+  void TearDown() override {
     if (linked_program) {
       EXPECT_SUCCESS(clReleaseProgram(linked_program));
     }

--- a/source/cl/test/UnitCL/source/clReleaseSampler.cpp
+++ b/source/cl/test/UnitCL/source/clReleaseSampler.cpp
@@ -18,7 +18,7 @@
 
 class clReleaseSamplerTest : public ucl::ContextTest {
  protected:
-  void SetUp() {
+  void SetUp() override {
     UCL_RETURN_ON_FATAL_FAILURE(ContextTest::SetUp());
     if (!getDeviceImageSupport()) {
       GTEST_SKIP();

--- a/source/cl/test/UnitCL/source/clSVMAlloc.cpp
+++ b/source/cl/test/UnitCL/source/clSVMAlloc.cpp
@@ -18,7 +18,7 @@
 
 class clSVMAllocTest : public ucl::ContextTest {
  protected:
-  virtual void SetUp() {
+  void SetUp() override {
     UCL_RETURN_ON_FATAL_FAILURE(ucl::ContextTest::SetUp());
     if (!UCL::isDeviceVersionAtLeast({3, 0})) {
       GTEST_SKIP();

--- a/source/cl/test/UnitCL/source/clSVMFree.cpp
+++ b/source/cl/test/UnitCL/source/clSVMFree.cpp
@@ -18,7 +18,7 @@
 
 class clSVMFreeTest : public ucl::ContextTest {
  protected:
-  virtual void SetUp() {
+  void SetUp() override {
     UCL_RETURN_ON_FATAL_FAILURE(ucl::ContextTest::SetUp());
     if (!UCL::isDeviceVersionAtLeast({3, 0})) {
       GTEST_SKIP();

--- a/source/cl/test/UnitCL/source/clSetDefaultDeviceCommandQueue.cpp
+++ b/source/cl/test/UnitCL/source/clSetDefaultDeviceCommandQueue.cpp
@@ -18,7 +18,7 @@
 
 class clSetDefaultDeviceCommandQueueTest : public ucl::ContextTest {
  protected:
-  virtual void SetUp() {
+  void SetUp() override {
     UCL_RETURN_ON_FATAL_FAILURE(ucl::ContextTest::SetUp());
     if (!UCL::isDeviceVersionAtLeast({3, 0})) {
       GTEST_SKIP();

--- a/source/cl/test/UnitCL/source/clSetKernelArgSVMPointer.cpp
+++ b/source/cl/test/UnitCL/source/clSetKernelArgSVMPointer.cpp
@@ -20,7 +20,7 @@
 
 class clSetKernelArgSVMPointerTest : public ucl::ContextTest {
  protected:
-  virtual void SetUp() {
+  void SetUp() override {
     UCL_RETURN_ON_FATAL_FAILURE(ucl::ContextTest::SetUp());
     if (!UCL::isDeviceVersionAtLeast({3, 0})) {
       GTEST_SKIP();
@@ -47,7 +47,7 @@ kernel void test(global int* out) {
     ASSERT_NE(kernel, nullptr);
   }
 
-  virtual void TearDown() {
+  void TearDown() override {
     if (program) {
       EXPECT_SUCCESS(clReleaseProgram(program));
       EXPECT_SUCCESS(clReleaseKernel(kernel));

--- a/source/cl/test/UnitCL/source/clSetKernelExecInfo.cpp
+++ b/source/cl/test/UnitCL/source/clSetKernelExecInfo.cpp
@@ -20,7 +20,7 @@
 
 class clSetKernelExecInfoTest : public ucl::ContextTest {
  protected:
-  virtual void SetUp() {
+  void SetUp() override {
     UCL_RETURN_ON_FATAL_FAILURE(ucl::ContextTest::SetUp());
     if (!UCL::isDeviceVersionAtLeast({3, 0})) {
       GTEST_SKIP();
@@ -47,7 +47,7 @@ kernel void test(global int* out) {
     ASSERT_NE(kernel, nullptr);
   }
 
-  virtual void TearDown() {
+  void TearDown() override {
     if (program) {
       EXPECT_SUCCESS(clReleaseProgram(program));
       EXPECT_SUCCESS(clReleaseKernel(kernel));

--- a/source/cl/test/UnitCL/source/clSetProgramReleaseCallback.cpp
+++ b/source/cl/test/UnitCL/source/clSetProgramReleaseCallback.cpp
@@ -20,7 +20,7 @@
 
 class clSetProgramReleaseCallbackTest : public ucl::ContextTest {
  protected:
-  virtual void SetUp() {
+  void SetUp() override {
     UCL_RETURN_ON_FATAL_FAILURE(ucl::ContextTest::SetUp());
     if (!UCL::isDeviceVersionAtLeast({3, 0})) {
       GTEST_SKIP();
@@ -39,7 +39,7 @@ kernel void test(global int* out) {
     ASSERT_NE(program, nullptr);
   }
 
-  virtual void TearDown() {
+  void TearDown() override {
     if (program) {
       EXPECT_SUCCESS(clReleaseProgram(program));
     }

--- a/source/cl/test/UnitCL/source/clSetUserEventStatus.cpp
+++ b/source/cl/test/UnitCL/source/clSetUserEventStatus.cpp
@@ -54,8 +54,8 @@ TEST_F(clSetUserEventStatusTest, FromAnotherEventsCallback) {
 
   ASSERT_SUCCESS(clSetEventCallback(
       markerEvent, CL_COMPLETE,
-      [](cl_event, cl_int, void *user_data) CL_LAMBDA_CALLBACK {
-        clSetUserEventStatus(static_cast<cl_event>(user_data), CL_COMPLETE);
+      [](cl_event, cl_int, void *UserData) CL_LAMBDA_CALLBACK {
+        clSetUserEventStatus(static_cast<cl_event>(UserData), CL_COMPLETE);
       },
       event));
 
@@ -149,8 +149,8 @@ TEST_F(clSetUserEventStatusTest, EnsureTerminatedDependentCommandDidNothing) {
 TEST_F(clSetUserEventStatusTest, ReleaseUserEventInItsCallback) {
   cl_int releaseStatus;
 
-  auto func = [](cl_event event, cl_int, void *user_data) CL_LAMBDA_CALLBACK {
-    *static_cast<cl_int *>(user_data) = clReleaseEvent(event);
+  auto func = [](cl_event event, cl_int, void *UserData) CL_LAMBDA_CALLBACK {
+    *static_cast<cl_int *>(UserData) = clReleaseEvent(event);
   };
 
   ASSERT_SUCCESS(clSetEventCallback(event, CL_COMPLETE, func, &releaseStatus));

--- a/source/vk/test/UnitVK/CMakeLists.txt
+++ b/source/vk/test/UnitVK/CMakeLists.txt
@@ -111,6 +111,7 @@ set(UVK_SHADER_NAMES
   delay
   write_back
   turns)
+list(SORT UVK_SHADER_NAMES)
 
 if(${UNITVK_USE_LOADER})
   # Find Vulkan loader lib

--- a/source/vk/test/UnitVK/include/UnitVK.h
+++ b/source/vk/test/UnitVK/include/UnitVK.h
@@ -169,7 +169,7 @@ class InstanceTest : public testing::Test {
     instanceCreateInfo.pApplicationInfo = &applicationInfo;
   }
 
-  virtual void SetUp() {
+  void SetUp() override {
     const std::array<const char *, 5> validationLayers{
         {"VK_LAYER_GOOGLE_threading", "VK_LAYER_LUNARG_parameter_validation",
          "VK_LAYER_LUNARG_object_tracker", "VK_LAYER_LUNARG_core_validation",
@@ -234,7 +234,7 @@ class InstanceTest : public testing::Test {
                      vkCreateInstance(&instanceCreateInfo, nullptr, &instance));
   }
 
-  virtual void TearDown() {
+  void TearDown() override {
     if (instance) {
       vkDestroyInstance(instance, nullptr);
       instance = VK_NULL_HANDLE;
@@ -264,7 +264,7 @@ class PhysicalDeviceTest : public InstanceTest {
  public:
   PhysicalDeviceTest() : physicalDevice(VK_NULL_HANDLE) {}
 
-  virtual void SetUp() {
+  void SetUp() override {
     if (!instance) {
       RETURN_ON_FATAL_FAILURE(InstanceTest::SetUp());
     }
@@ -293,7 +293,7 @@ class PhysicalDeviceTest : public InstanceTest {
     queueFamilyIndex = 0;
   }
 
-  virtual void TearDown() { InstanceTest::TearDown(); }
+  void TearDown() override { InstanceTest::TearDown(); }
 
   VkPhysicalDevice physicalDevice;
   uint32_t queueFamilyIndex;
@@ -304,7 +304,7 @@ class DeviceTest : public PhysicalDeviceTest {
  public:
   DeviceTest() : device(VK_NULL_HANDLE) {}
 
-  virtual void SetUp() {
+  void SetUp() override {
     if (!physicalDevice || !instance) {
       RETURN_ON_FATAL_FAILURE(PhysicalDeviceTest::SetUp());
     }
@@ -361,7 +361,7 @@ class DeviceTest : public PhysicalDeviceTest {
         vkCreateDevice(physicalDevice, &deviceCreateInfo, nullptr, &device));
   }
 
-  virtual void TearDown() {
+  void TearDown() override {
     vkDestroyDevice(device, nullptr);
     device = nullptr;
     PhysicalDeviceTest::TearDown();
@@ -445,7 +445,7 @@ class CommandPoolTest : public virtual DeviceTest {
   CommandPoolTest(bool extension)
       : commandPool(VK_NULL_HANDLE), extension(extension) {}
 
-  virtual void SetUp() {
+  void SetUp() override {
     if (!device) {
       RETURN_ON_FATAL_FAILURE(DeviceTest::SetUp());
     }
@@ -456,7 +456,7 @@ class CommandPoolTest : public virtual DeviceTest {
                                                      nullptr, &commandPool));
   }
 
-  virtual void TearDown() {
+  void TearDown() override {
     if (commandPool) {
       vkDestroyCommandPool(device, commandPool, nullptr);
     }

--- a/source/vk/test/UnitVK/include/kts_vk.h
+++ b/source/vk/test/UnitVK/include/kts_vk.h
@@ -58,16 +58,16 @@ class Argument final : public ArgumentBase {
     sampler_desc_ = new_image;
   }
 
-  virtual uint8_t *GetBufferStoragePtr() {
+  uint8_t *GetBufferStoragePtr() override {
     assert(bufferStoragePtr_);
     return bufferStoragePtr_;
   }
   void SetBufferStoragePtr(uint8_t *ptr) { bufferStoragePtr_ = ptr; }
-  virtual size_t GetBufferStorageSize() {
+  size_t GetBufferStorageSize() override {
     assert(bufferStorageSize_);
     return bufferStorageSize_;
   }
-  virtual void SetBufferStorageSize(size_t size) {
+  void SetBufferStorageSize(size_t size) override {
     (void)size;
     // Already set when buffer_desc_ is set
     assert(size == bufferStorageSize_);
@@ -320,7 +320,7 @@ class GenericKernelTest : public ::uvk::RecordCommandBufferTest,
     VkSampler sampler;
   };
 
-  virtual void SetUp() {
+  void SetUp() override {
     RETURN_ON_FATAL_FAILURE(RecordCommandBufferTest::SetUp());
     VkPhysicalDeviceMemoryProperties memoryProperties;
 

--- a/source/vk/test/UnitVK/source/AllocateCommandBuffers.cpp
+++ b/source/vk/test/UnitVK/source/AllocateCommandBuffers.cpp
@@ -22,14 +22,14 @@ class AllocateCommandBuffers : public uvk::CommandPoolTest {
  public:
   AllocateCommandBuffers() : allocateInfo(), commandBuffer(VK_NULL_HANDLE) {}
 
-  virtual void SetUp() {
+  void SetUp() override {
     RETURN_ON_FATAL_FAILURE(CommandPoolTest::SetUp());
     allocateInfo.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO;
     allocateInfo.commandPool = commandPool;
     allocateInfo.commandBufferCount = 1;
   }
 
-  virtual void TearDown() {
+  void TearDown() override {
     if (commandBuffer) {
       vkFreeCommandBuffers(device, commandPool, 1, &commandBuffer);
     }

--- a/source/vk/test/UnitVK/source/CmdSetEvent.cpp
+++ b/source/vk/test/UnitVK/source/CmdSetEvent.cpp
@@ -22,7 +22,7 @@ class CmdSetEvent : public uvk::RecordCommandBufferTest {
  public:
   CmdSetEvent() : event(VK_NULL_HANDLE), submitInfo() {}
 
-  virtual void SetUp() {
+  void SetUp() override {
     RETURN_ON_FATAL_FAILURE(RecordCommandBufferTest::SetUp());
 
     VkEventCreateInfo createInfo = {};
@@ -38,7 +38,7 @@ class CmdSetEvent : public uvk::RecordCommandBufferTest {
     submitInfo.pCommandBuffers = &commandBuffer;
   }
 
-  virtual void TearDown() {
+  void TearDown() override {
     vkDestroyEvent(device, event, nullptr);
     RecordCommandBufferTest::TearDown();
   }

--- a/source/vk/test/UnitVK/source/CreateCommandPool.cpp
+++ b/source/vk/test/UnitVK/source/CreateCommandPool.cpp
@@ -22,12 +22,12 @@ class CreateCommandPool : public uvk::DeviceTest {
  public:
   CreateCommandPool() : createInfo(), commandPool() {}
 
-  virtual void SetUp() {
+  void SetUp() override {
     RETURN_ON_FATAL_FAILURE(DeviceTest::SetUp());
     createInfo.sType = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO;
   }
 
-  virtual void TearDown() {
+  void TearDown() override {
     if (commandPool) {
       vkDestroyCommandPool(device, commandPool, nullptr);
     }

--- a/source/vk/test/UnitVK/source/CreateComputePipelines.cpp
+++ b/source/vk/test/UnitVK/source/CreateComputePipelines.cpp
@@ -27,7 +27,7 @@ class CreateComputePipelines : public uvk::PipelineLayoutTest {
         pipelineCreateInfo(),
         pipeline(VK_NULL_HANDLE) {}
 
-  virtual void SetUp() {
+  void SetUp() override {
     RETURN_ON_FATAL_FAILURE(PipelineLayoutTest::SetUp());
 
     const uvk::ShaderCode shaderCode = uvk::getShader(uvk::Shader::nop);
@@ -48,7 +48,7 @@ class CreateComputePipelines : public uvk::PipelineLayoutTest {
     pipelineCreateInfo.stage = shaderStageCreateInfo;
   }
 
-  virtual void TearDown() {
+  void TearDown() override {
     vkDestroyShaderModule(device, shaderModule, nullptr);
     if (pipeline) {
       vkDestroyPipeline(device, pipeline, nullptr);

--- a/source/vk/test/UnitVK/source/CreateDevice.cpp
+++ b/source/vk/test/UnitVK/source/CreateDevice.cpp
@@ -22,7 +22,7 @@ class CreateDevice : public uvk::PhysicalDeviceTest {
  public:
   CreateDevice()
       : deviceCreateInfo(), queueCreateInfo(), device(VK_NULL_HANDLE) {}
-  virtual void SetUp() {
+  void SetUp() override {
     RETURN_ON_FATAL_FAILURE(PhysicalDeviceTest::SetUp());
 
     const float queuePriority = 1;
@@ -36,7 +36,7 @@ class CreateDevice : public uvk::PhysicalDeviceTest {
     deviceCreateInfo.pQueueCreateInfos = &queueCreateInfo;
   }
 
-  virtual void TearDown() {
+  void TearDown() override {
     if (device) {
       vkDestroyDevice(device, nullptr);
     }

--- a/source/vk/test/UnitVK/source/CreateInstance.cpp
+++ b/source/vk/test/UnitVK/source/CreateInstance.cpp
@@ -23,7 +23,7 @@ class CreateInstance : public ::testing::Test {
   CreateInstance()
       : applicationInfo(), createInfo(), instance(VK_NULL_HANDLE) {}
 
-  virtual void SetUp() {
+  void SetUp() override {
     applicationInfo.sType = VK_STRUCTURE_TYPE_APPLICATION_INFO;
     applicationInfo.pApplicationName = "UnitVK";
     applicationInfo.applicationVersion = VK_MAKE_VERSION(0, 1, 0);
@@ -36,7 +36,7 @@ class CreateInstance : public ::testing::Test {
     createInfo.pApplicationInfo = &applicationInfo;
   }
 
-  virtual void TearDown() {
+  void TearDown() override {
     if (instance) {
       vkDestroyInstance(instance, nullptr);
     }

--- a/source/vk/test/UnitVK/source/DestroyNullHandle.cpp
+++ b/source/vk/test/UnitVK/source/DestroyNullHandle.cpp
@@ -27,9 +27,9 @@ class DestroyNullHandle : public uvk::DescriptorPoolTest,
   // the SetUp/TearDown contain only the device test setup so we aren't
   // needlessly creating a descriptor/command pool for tests that don't need
   // them
-  virtual void SetUp() { RETURN_ON_FATAL_FAILURE(DeviceTest::SetUp()); }
+  void SetUp() override { RETURN_ON_FATAL_FAILURE(DeviceTest::SetUp()); }
 
-  virtual void TearDown() { DeviceTest::TearDown(); }
+  void TearDown() override { DeviceTest::TearDown(); }
 };
 
 TEST_F(DestroyNullHandle, Instance) {

--- a/source/vk/test/UnitVK/source/FlushMappedMemoryRanges.cpp
+++ b/source/vk/test/UnitVK/source/FlushMappedMemoryRanges.cpp
@@ -30,7 +30,7 @@ class FlushMappedMemoryRanges : public uvk::PipelineTest,
         BufferTest(sizeof(uint32_t) * bufferElements,
                    VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, true) {}
 
-  virtual void SetUp() {
+  void SetUp() override {
     // Set up the descriptor set layout
     descriptorSetLayoutBindings.clear();
 
@@ -181,7 +181,7 @@ class FlushMappedMemoryRanges : public uvk::PipelineTest,
     // we are now ready to mess with memory and execute the shader
   }
 
-  virtual void TearDown() {
+  void TearDown() override {
     vkFreeMemory(device, memory, nullptr);
     vkDestroyBuffer(device, buffer2, nullptr);
     BufferTest::TearDown();

--- a/source/vk/test/UnitVK/source/ResetDescriptorPool.cpp
+++ b/source/vk/test/UnitVK/source/ResetDescriptorPool.cpp
@@ -24,7 +24,7 @@ class ResetDescriptorPool : public uvk::DescriptorPoolTest,
   ResetDescriptorPool()
       : DescriptorSetLayoutTest(true), descriptorSet(VK_NULL_HANDLE) {}
 
-  virtual void SetUp() {
+  void SetUp() override {
     RETURN_ON_FATAL_FAILURE(DescriptorPoolTest::SetUp());
     RETURN_ON_FATAL_FAILURE(DescriptorSetLayoutTest::SetUp());
 
@@ -37,7 +37,7 @@ class ResetDescriptorPool : public uvk::DescriptorPoolTest,
     vkAllocateDescriptorSets(device, &allocInfo, &descriptorSet);
   }
 
-  virtual void TearDown() {
+  void TearDown() override {
     DescriptorSetLayoutTest::TearDown();
     DescriptorPoolTest::TearDown();
   }

--- a/source/vk/test/UnitVK/source/shaders/CMakeLists.txt
+++ b/source/vk/test/UnitVK/source/shaders/CMakeLists.txt
@@ -90,7 +90,7 @@ file(APPEND ${UVK_SHADER_CODE_HEADER}
   "  const size_t size;\n"
   "};\n"
   "\n"
-  "ShaderCode getShader(Shader id);\n"
+  "ShaderCode getShader(Shader Id);\n"
   "extern std::map<std::string, Shader> ShaderMap; \n"
   "}  // uvk\n"
   "\n"
@@ -122,8 +122,8 @@ foreach(name ${UVK_SHADER_NAMES})
     "#include \"${name}.h\"\n")
 endforeach()
 file(APPEND ${UVK_SHADER_CODE_SOURCE} "\n"
-  "uvk::ShaderCode uvk::getShader(uvk::Shader id) {\n"
-  "  switch (id) {\n"
+  "uvk::ShaderCode uvk::getShader(uvk::Shader Id) {\n"
+  "  switch (Id) {\n"
   "    case uvk::Shader::none:\n"
   "      return ShaderCode{nullptr, 0};\n")
 


### PR DESCRIPTION
# Overview

Address clang & clang-tidy warnings.

# Reason for change

When building as part of LLVM and/or with Clang, additional warnings are raised that do not show up in our regular builds.

# Description of change

This commit addresses them. For the most part, these are NFC, but there are a few exceptions.

* hal_binary_encoder's constructor was failing to initialize device.
* A few code paths which are meant to be unreachable are handled differently to fail more reliably.
* One accidentally volatile store is changed to non-volatile.

Most of the other changes are in these categories:

* switch statements on enumeration types either do not handle all enumerators, and do have a default case, or do handle all enumerators, and do not have a default case. The default cases for exhaustive switches are placed after the switch statements instead by having each case label end in a return, possibly enabled through an immediately invoked lambda expression.
* Parameters and variables which are not considered in scope of the .clang-tidy due to appearing in generated sources and/or in macro expansions from non-project headers are renamed in accordance with the clang-tidy naming rules, because the suppression of the rule does not affect these.
* Unused variables are removed, unused named parameters are anonymized.
* Virtual classes without a virtual destructor are prevented from being destroyed through a base class.
* Virtual methods which override a base class method are annotated with the override keyword, and without the virtual keyword.
* Virtual classes that are never derived from are made non-virtual instead.

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-19](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
