### PR TITLE
Remove test_language fail from our xfail list for sycl_cts

### DIFF
--- a/.github/sycl_cts/override_all.csv
+++ b/.github/sycl_cts/override_all.csv
@@ -1,4 +1,3 @@
 SYCL_CTS,test_math_builtin_api "math_builtin_float_base_*",Xfail
 SYCL_CTS,test_math_builtin_api "math_builtin_float_double_*",Xfail
 SYCL_CTS,test_event "event::wait does not report asynchronous errors",Mayfail
-SYCL_CTS,test_language,Xfail


### PR DESCRIPTION
# Overview

Remove test_language fail from our xfail list for sycl_cts

# Reason for change

This tests now passes okay.
