### PR TITLE
Address more clang & clang-tidy warnings.

### DIFF
--- a/modules/compiler/compiler_pipeline/include/compiler/utils/pass_machinery.h
+++ b/modules/compiler/compiler_pipeline/include/compiler/utils/pass_machinery.h
@@ -34,10 +34,13 @@ class TargetMachine;
 
 namespace compiler {
 namespace utils {
+extern bool VerifyEachIsEnabled;
 
 /// @brief Mirror's LLVM's DebugLogging options in its `opt` tool. Clang has
 /// a boolean on/off version.
 enum class DebugLogging { None, Normal, Verbose, Quiet };
+
+extern DebugLogging DebugPasses;
 
 /// @brief A class that manages the lifetime and initialization of all
 /// components required to set up a new-style LLVM pass manager.

--- a/modules/compiler/compiler_pipeline/source/add_kernel_wrapper_pass.cpp
+++ b/modules/compiler/compiler_pipeline/source/add_kernel_wrapper_pass.cpp
@@ -129,7 +129,7 @@ PreservedAnalyses compiler::utils::AddKernelWrapperPass::run(
 
   for (auto &F : M.functions()) {
     // We only operate on previously-unseen kernel functions.
-    if (!isKernel(F) || NewKernels.count(&F)) {
+    if (!isKernel(F) || NewKernels.contains(&F)) {
       continue;
     }
 

--- a/modules/compiler/compiler_pipeline/source/barrier_regions.cpp
+++ b/modules/compiler/compiler_pipeline/source/barrier_regions.cpp
@@ -646,7 +646,7 @@ Function *compiler::utils::Barrier::GenerateFakeKernel(
 
   for (auto *bb : region.blocks) {
     BasicBlock *new_bb = BasicBlock::Create(context, "", new_kernel);
-    if (region.barrier_blocks.count(bb)) {
+    if (region.barrier_blocks.contains(bb)) {
       ReturnInst::Create(context, nullptr, new_bb);
     } else {
       bb->getTerminator()->clone()->insertInto(new_bb, new_bb->end());
@@ -679,7 +679,7 @@ void compiler::utils::Barrier::GatherBarrierRegionBlocks(
   size_t index = 0;
   while (index < region.blocks.size()) {
     BasicBlock *BB = region.blocks[index++];
-    if (barrier_successor_set_.count(BB)) {
+    if (barrier_successor_set_.contains(BB)) {
       region.barrier_blocks.insert(BB);
     } else {
       for (BasicBlock *succ : successors(BB)) {
@@ -716,14 +716,14 @@ void compiler::utils::Barrier::GatherBarrierRegionUses(
       if (PHINode *pn = dyn_cast<PHINode>(&I)) {
         for (unsigned i = 0, e = pn->getNumIncomingValues(); i != e; i++) {
           Value *val = pn->getIncomingValue(i);
-          if (CheckValidUse(val) && !ignore.count(val)) {
+          if (CheckValidUse(val) && !ignore.contains(val)) {
             if (auto *inst = dyn_cast<Instruction>(val)) {
               BasicBlock *incoming = pn->getIncomingBlock(i);
               BasicBlock *parent = inst->getParent();
               // If the incoming edge comes from outside the region, it is
               // going to get removed anyway, so disregard it
-              if (bbmap.count(incoming)) {
-                if (!bbmap.count(parent)) {
+              if (bbmap.contains(incoming)) {
+                if (!bbmap.contains(parent)) {
                   region.uses_ext.insert(val);
                 } else if (!DT.dominates(bbmap[parent], bbmap[incoming])) {
                   region.uses_int.insert(val);
@@ -734,10 +734,10 @@ void compiler::utils::Barrier::GatherBarrierRegionUses(
         }
       } else {
         for (Value *val : I.operands()) {
-          if (CheckValidUse(val) && !ignore.count(val)) {
+          if (CheckValidUse(val) && !ignore.contains(val)) {
             if (auto *inst = dyn_cast<Instruction>(val)) {
               BasicBlock *parent = inst->getParent();
-              if (!bbmap.count(parent)) {
+              if (!bbmap.contains(parent)) {
                 region.uses_ext.insert(val);
               } else if (!DT.dominates(bbmap[parent], BBclone)) {
                 region.uses_int.insert(val);
@@ -847,7 +847,7 @@ void compiler::utils::Barrier::TidyLiveVariables() {
       removals.push_back(v);
     } else if (auto *cast = dyn_cast<CastInst>(v)) {
       Value *op = cast->getOperand(0);
-      if (whole_live_variables_set_.count(op)) {
+      if (whole_live_variables_set_.contains(op)) {
         removals.push_back(v);
       }
     }
@@ -1126,7 +1126,7 @@ Function *compiler::utils::Barrier::GenerateNewKernel(BarrierRegion &region) {
     vmap[block] = cloned_bb;
 
     // Remove last terminator from clone block with barrier.
-    if (region.barrier_blocks.count(block)) {
+    if (region.barrier_blocks.contains(block)) {
       cloned_bb->getTerminator()->eraseFromParent();
 
       // Return the next barrier's id.
@@ -1450,7 +1450,7 @@ BasicBlock *compiler::utils::Barrier::CloneBasicBlock(
     new_inst->insertInto(new_bb, new_bb->end());
 
     // Record live variables' defs which are in current kernel.
-    if (whole_live_variables_set_.count(&i)) {
+    if (whole_live_variables_set_.contains(&i)) {
       live_defs_info.insert(&i);
     }
 

--- a/modules/compiler/compiler_pipeline/source/compute_local_memory_usage_pass.cpp
+++ b/modules/compiler/compiler_pipeline/source/compute_local_memory_usage_pass.cpp
@@ -79,7 +79,7 @@ PreservedAnalyses ComputeLocalMemoryUsagePass::run(Module &M,
       // call graph.
       if (none_of(GV.users(), [&VisitedFns](const User *U) {
             return isa<Instruction>(U) &&
-                   VisitedFns.count(cast<Instruction>(U)->getFunction());
+                   VisitedFns.contains(cast<Instruction>(U)->getFunction());
           })) {
         LLVM_DEBUG(dbgs() << "  GV '" << GV.getName() << "' is unused\n");
         continue;

--- a/modules/compiler/compiler_pipeline/source/gdb_registration_listener.cpp
+++ b/modules/compiler/compiler_pipeline/source/gdb_registration_listener.cpp
@@ -169,7 +169,7 @@ void GDBJITRegistrationListener::notifyObjectLoaded(
   const size_t Size =
       DebugObj.getBinary()->getMemoryBufferRef().getBufferSize();
 
-  assert(ObjectBufferMap.find(K) == ObjectBufferMap.end() &&
+  assert(!ObjectBufferMap.contains(K) &&
          "Second attempt to perform debug registration.");
   jit_code_entry *JITCodeEntry = new jit_code_entry();
 

--- a/modules/compiler/compiler_pipeline/source/pass_machinery.cpp
+++ b/modules/compiler/compiler_pipeline/source/pass_machinery.cpp
@@ -23,7 +23,6 @@ using namespace llvm;
 
 namespace compiler {
 namespace utils {
-
 // Note that Clang has three on/off options for debugging pass managers:
 // `-fdebug-pass-manager`, `-fdebug-pass-structure`, and
 // `-fdebug-pass-arguments``.
@@ -49,9 +48,10 @@ namespace utils {
 // While clang also pushes `mdebug-pass` onto LLVM, it only works for the
 // legacy pass manager, and so we choose to only support and model the
 // `debug-pass-manager` form.
-static cl::opt<DebugLogging> DebugPM(
-    "debug-pass-manager", cl::Hidden, cl::ValueOptional,
-    cl::desc("Print pass management debugging information"),
+DebugLogging DebugPasses;
+static cl::opt<DebugLogging, true> DebugPM(
+    "debug-pass-manager", cl::location(DebugPasses), cl::Hidden,
+    cl::ValueOptional, cl::desc("Print pass management debugging information"),
     cl::init(DebugLogging::None),
     cl::values(
         clEnumValN(DebugLogging::Normal, "", ""),
@@ -61,8 +61,10 @@ static cl::opt<DebugLogging> DebugPM(
             DebugLogging::Verbose, "verbose",
             "Print extra information about adaptors and pass managers")));
 
-static cl::opt<bool> VerifyEach("verify-each",
-                                cl::desc("Verify after each transform"));
+bool VerifyEachIsEnabled;
+static cl::opt<bool, true> VerifyEach("verify-each",
+                                      cl::location(VerifyEachIsEnabled),
+                                      cl::desc("Verify after each transform"));
 
 PassMachinery::PassMachinery(LLVMContext &Ctx, TargetMachine *TM,
                              bool VerifyEach, DebugLogging debugLogLevel)

--- a/modules/compiler/compiler_pipeline/source/prepare_barriers_pass.cpp
+++ b/modules/compiler/compiler_pipeline/source/prepare_barriers_pass.cpp
@@ -54,7 +54,7 @@ PreservedAnalyses compiler::utils::PrepareBarriersPass::run(
 
         // If it's one of our kernels don't inline it, and definitely don't
         // delete it either. No need to inline already dead functions, either!
-        if (!Callee->isDefTriviallyDead() && Kernels.count(Callee) == 0) {
+        if (!Callee->isDefTriviallyDead() && !Kernels.contains(Callee)) {
           FuncsWithBarriers.insert(Callee);
         }
       }
@@ -91,7 +91,7 @@ PreservedAnalyses compiler::utils::PrepareBarriersPass::run(
 
         // The function we inlined into now contains a barrier, so add it
         // to the set.
-        if (!InfoF->isDefTriviallyDead() && Kernels.count(InfoF) == 0) {
+        if (!InfoF->isDefTriviallyDead() && !Kernels.contains(InfoF)) {
           FuncsWithBarriers.insert(InfoF);
         }
       } else {

--- a/modules/compiler/compiler_pipeline/source/reduce_to_function_pass.cpp
+++ b/modules/compiler/compiler_pipeline/source/reduce_to_function_pass.cpp
@@ -143,7 +143,7 @@ PreservedAnalyses compiler::utils::ReduceToFunctionPass::run(
   SmallPtrSet<Function *, 16> toDelete;
 
   for (Function &F : M) {
-    if (0 == FnsToKeep.count(&F)) {
+    if (!FnsToKeep.contains(&F)) {
       F.dropAllReferences();
       toDelete.insert(&F);
     }

--- a/modules/compiler/source/base/source/context.cpp
+++ b/modules/compiler/source/base/source/context.cpp
@@ -17,6 +17,7 @@
 #include <base/context.h>
 #include <llvm/Bitcode/BitcodeReader.h>
 #include <llvm/IR/LLVMContext.h>
+#include <llvm/Pass.h>
 #include <spirv-ll/context.h>
 #include <spirv-ll/module.h>
 
@@ -35,24 +36,11 @@ BaseContext::BaseContext() {
         compiler::utils::getLLVMGlobalMutex());
     llvm::cl::ParseCommandLineOptions(1, argv, "", nullptr, "CA_LLVM_OPTIONS");
 
-    const llvm::StringMap<llvm::cl::Option *> &opt_map =
-        llvm::cl::getRegisteredOptions();
+    llvm_time_passes = llvm::TimePassesIsEnabled;
 
-    if (const auto *opt = opt_map.lookup("time-passes")) {
-      llvm_time_passes =
-          static_cast<const llvm::cl::opt<bool, true> *>(opt)->getValue();
-    }
+    llvm_verify_each = compiler::utils::VerifyEachIsEnabled;
 
-    if (const auto *opt = opt_map.lookup("verify-each")) {
-      llvm_verify_each =
-          static_cast<const llvm::cl::opt<bool> *>(opt)->getValue();
-    }
-
-    if (const auto *opt = opt_map.lookup("debug-pass-manager")) {
-      llvm_debug_passes =
-          static_cast<const llvm::cl::opt<compiler::utils::DebugLogging> *>(opt)
-              ->getValue();
-    }
+    llvm_debug_passes = compiler::utils::DebugPasses;
   });
 #endif
 }

--- a/modules/compiler/source/base/source/printf_replacement_pass.cpp
+++ b/modules/compiler/source/base/source/printf_replacement_pass.cpp
@@ -416,7 +416,7 @@ CallInst *CreateCall(IRBuilder<> &ir, Function *const f,
 void findAndRecurseFunctionUsers(
     Function *F, SmallPtrSetImpl<const Function *> &set_of_callers) {
   // See if the function has already been flagged
-  if (set_of_callers.count(F)) {
+  if (set_of_callers.contains(F)) {
     return;
   }
 
@@ -851,7 +851,7 @@ PreservedAnalyses compiler::PrintfReplacementPass::run(
                                                    bool &ClonedWithBody,
                                                    bool &ClonedNoBody) {
     ClonedWithBody = !func.getName().starts_with("__llvm") &&
-                     funcs_calling_printf.count(&func);
+                     funcs_calling_printf.contains(&func);
     ClonedNoBody = false;
   };
 

--- a/modules/compiler/spirv-ll/source/context.cpp
+++ b/modules/compiler/spirv-ll/source/context.cpp
@@ -79,7 +79,7 @@ spirv_ll::Context::getSpecializableConstants(llvm::ArrayRef<uint32_t> code) {
       // Boolean spec constants are given a size of 1 bit.
       case spv::OpSpecConstantTrue: {
         auto *opSpecConstantTrue = module.create<OpSpecConstantTrue>(op);
-        if (specIds.count(opSpecConstantTrue->IdResult()) != 0) {
+        if (specIds.contains(opSpecConstantTrue->IdResult())) {
           specConstants.insert(std::pair<spv::Id, SpecializationDesc>{
               specIds[opSpecConstantTrue->IdResult()],
               {SpecializationType::BOOL, 1}});
@@ -87,7 +87,7 @@ spirv_ll::Context::getSpecializableConstants(llvm::ArrayRef<uint32_t> code) {
       } break;
       case spv::OpSpecConstantFalse: {
         auto *opSpecConstantFalse = module.create<OpSpecConstantFalse>(op);
-        if (specIds.count(opSpecConstantFalse->IdResult()) != 0) {
+        if (specIds.contains(opSpecConstantFalse->IdResult())) {
           specConstants.insert(std::pair<spv::Id, SpecializationDesc>{
               specIds[opSpecConstantFalse->IdResult()],
               {SpecializationType::BOOL, 1}});
@@ -97,19 +97,19 @@ spirv_ll::Context::getSpecializableConstants(llvm::ArrayRef<uint32_t> code) {
       // Look up the size in bits from the type for number spec cosntants.
       case spv::OpSpecConstant: {
         auto *opSpecConstant = module.create<OpSpecConstant>(op);
-        if (types.count(opSpecConstant->IdResultType()) == 0) {
+        if (!types.contains(opSpecConstant->IdResultType())) {
           return cargo::make_unexpected(
               Error{"unknown SPIR-V specialization constant result type"});
         }
         auto *opType = types[opSpecConstant->IdResultType()];
         if (opType->isIntType()) {
-          if (specIds.count(opSpecConstant->IdResult()) != 0) {
+          if (specIds.contains(opSpecConstant->IdResult())) {
             specConstants.insert(std::pair<spv::Id, SpecializationDesc>{
                 specIds[opSpecConstant->IdResult()],
                 {SpecializationType::INT, opType->getTypeInt()->Width()}});
           }
         } else if (opType->isFloatType()) {
-          if (specIds.count(opSpecConstant->IdResult()) != 0) {
+          if (specIds.contains(opSpecConstant->IdResult())) {
             specConstants.insert(std::pair<spv::Id, SpecializationDesc>{
                 specIds[opSpecConstant->IdResult()],
                 {SpecializationType::FLOAT, opType->getTypeFloat()->Width()}});

--- a/modules/compiler/spirv-ll/source/module.cpp
+++ b/modules/compiler/spirv-ll/source/module.cpp
@@ -126,7 +126,7 @@ uint32_t spirv_ll::Module::getAddressingModel() const {
 }
 
 void spirv_ll::Module::addEntryPoint(const OpEntryPoint *op) {
-  if (!EntryPoints.count(op->EntryPoint())) {
+  if (!EntryPoints.contains(op->EntryPoint())) {
     EntryPoints.insert({op->EntryPoint(), op});
   }
 }
@@ -488,7 +488,7 @@ void spirv_ll::Module::addForwardPointer(spv::Id id) {
 }
 
 bool spirv_ll::Module::isForwardPointer(spv::Id id) const {
-  return ForwardPointers.count(id);
+  return ForwardPointers.contains(id);
 }
 
 void spirv_ll::Module::removeForwardPointer(spv::Id id) {

--- a/modules/compiler/targets/host/source/AddFloatingPointControl.cpp
+++ b/modules/compiler/targets/host/source/AddFloatingPointControl.cpp
@@ -223,7 +223,7 @@ PreservedAnalyses host::AddFloatingPointControlPass::run(
     Module &M, ModuleAnalysisManager &) {
   SmallPtrSet<Function *, 4> newFunctions;
   for (auto &F : M.functions()) {
-    if (compiler::utils::isKernelEntryPt(F) && !newFunctions.count(&F)) {
+    if (compiler::utils::isKernelEntryPt(F) && !newFunctions.contains(&F)) {
       if (auto *newFunction = runOnFunction(F, SetFTZ)) {
         newFunctions.insert(newFunction);
       }

--- a/modules/compiler/targets/host/source/kernel.cpp
+++ b/modules/compiler/targets/host/source/kernel.cpp
@@ -391,7 +391,7 @@ HostKernel::lookupOrCreateOptimizedKernel(std::array<size_t, 3> local_size) {
           [&](llvm::Expected<llvm::orc::SymbolMap> r) {
             if (r) {
               assert(r->size() == 1 && "Unexpected number of results");
-              assert(r->count(name) && "Missing result for symbol");
+              assert(r->contains(name) && "Missing result for symbol");
               auto address = r->begin()->second.getAddress();
               promise.set_value(address.getValue());
             } else {

--- a/modules/compiler/tools/muxc/muxc.h
+++ b/modules/compiler/tools/muxc/muxc.h
@@ -53,7 +53,7 @@ class driver {
   uint32_t ModuleNumErrors = 0;
   std::string ModuleLog;
   /// @brief Selected compiler.
-  const compiler::Info *CompilerInfo;
+  const compiler::Info *CompilerInfo = nullptr;
   /// @brief Compiler context to drive compilation.
   std::unique_ptr<compiler::Context> CompilerContext;
   /// @brief Compiler target to drive compilation.

--- a/modules/compiler/vecz/source/analysis/divergence_analysis.cpp
+++ b/modules/compiler/vecz/source/analysis/divergence_analysis.cpp
@@ -365,7 +365,7 @@ void DivergenceResult::markDivLoopDivBlocks(BasicBlock &BB, Loop &L,
   L.getExitBlocks(exits);
   const auto &divergentExits = escapePoints(BB, L);
   for (BasicBlock *E : exits) {
-    if (divergentExits.count(E)) {
+    if (divergentExits.contains(E)) {
       markDivergent(*E);
     }
     // All loop exits of a divergent loop need their PHIs marked varying.

--- a/modules/compiler/vecz/source/analysis/liveness_analysis.cpp
+++ b/modules/compiler/vecz/source/analysis/liveness_analysis.cpp
@@ -231,8 +231,8 @@ void LivenessResult::Impl::calculateMaxRegistersInBlock(const BasicBlock *BB) {
     // Operands are live so they use a register. Increment registerCount if not
     // in live out or already counted.
     for (const auto *operand : inst.operand_values()) {
-      if (definesVariable(*operand) && !liveOut.count(operand) &&
-          !seenButNotInLiveOut.count(operand)) {
+      if (definesVariable(*operand) && !liveOut.contains(operand) &&
+          !seenButNotInLiveOut.contains(operand)) {
         registersUsed++;
         seenButNotInLiveOut.insert(operand);
       }

--- a/modules/compiler/vecz/source/control_flow_boscc.cpp
+++ b/modules/compiler/vecz/source/control_flow_boscc.cpp
@@ -174,7 +174,7 @@ bool ControlFlowConversionState::BOSCCGadget::duplicateUniformRegions() {
           duplicatedLoops.push_back(loop);
         }
 
-        if (!duplicatedLoopSet.count(loop)) {
+        if (!duplicatedLoopSet.contains(loop)) {
           newBTag.loop = LTag;
           loop->addBasicBlockToLoop(newB, *LI);
         }
@@ -193,7 +193,7 @@ bool ControlFlowConversionState::BOSCCGadget::duplicateUniformRegions() {
   // Since we added all loops by their headers in DCBI order, inner loops will
   // always follow outer loops, so there is no need to sort them.
   for (Loop *L : duplicatedLoops) {
-    if (!LMap.count(L) && !noDuplicateLoops.count(L)) {
+    if (!LMap.contains(L) && !noDuplicateLoops.contains(L)) {
       VECZ_FAIL_IF(!duplicateUniformLoops(L));
     }
   }
@@ -526,7 +526,7 @@ bool ControlFlowConversionState::BOSCCGadget::connectBOSCCRegions() {
   // then the loop now has 2 preheaders. We thus need to blend them into one
   // single preheader.
   for (auto *const LTag : DR->getLoopOrdering()) {
-    if (!LTag->isLoopDivergent() && !LMap.count(LTag->loop)) {
+    if (!LTag->isLoopDivergent() && !LMap.contains(LTag->loop)) {
       BasicBlock *predicatedPreheader = LTag->preheader;
       if (BasicBlock *uniformPreheader = getBlock(predicatedPreheader)) {
         BasicBlock *header = LTag->header;
@@ -577,7 +577,7 @@ bool ControlFlowConversionState::BOSCCGadget::connectBOSCCRegions() {
     const Loop *L = pair.first;
 
     if (Loop *parentL = L->getParentLoop()) {
-      if (LMap.count(parentL)) {
+      if (LMap.contains(parentL)) {
         continue;
       }
     }
@@ -783,7 +783,7 @@ bool ControlFlowConversionState::BOSCCGadget::connectUniformRegion(
   BasicBlock *connectionPoint = target;
 
   const auto *const LTag = DR->getTag(predicatedB).loop;
-  const bool needsStore = LTag && LMap.count(LTag->loop);
+  const bool needsStore = LTag && LMap.contains(LTag->loop);
   if (needsStore) {
     // 'store' is a block that will contain all the uniform versions of the
     // live in instructions of the predicated target.
@@ -818,7 +818,7 @@ bool ControlFlowConversionState::BOSCCGadget::connectUniformRegion(
 
     // 'store' belongs in the first outer loop non duplicated.
     Loop *parentLoop = LTag->loop->getParentLoop();
-    while (parentLoop && LMap.count(parentLoop)) {
+    while (parentLoop && LMap.contains(parentLoop)) {
       parentLoop = parentLoop->getParentLoop();
     }
     if (parentLoop) {
@@ -867,7 +867,7 @@ bool ControlFlowConversionState::BOSCCGadget::blendConnectionPoint(
       // because of 'CP'. These blocks are all the blocks that have more than
       // one predecessor, that belong to the same region as 'CP', and that
       // succeed it.
-      if (!region.blendPoints.count(CP)) {
+      if (!region.blendPoints.contains(CP)) {
         // The first blend point impacted by 'CP' is 'CP' itself.
         region.blendPoints.insert({CP, {CP}});
 
@@ -968,7 +968,7 @@ bool ControlFlowConversionState::BOSCCGadget::blendFinalize() {
 
   for (const auto &tag : DR->getBlockOrdering()) {
     BasicBlock *blendPoint = tag.BB;
-    if (blendBlocks.count(blendPoint) == 0) {
+    if (!blendBlocks.contains(blendPoint)) {
       continue;
     }
 
@@ -986,7 +986,7 @@ bool ControlFlowConversionState::BOSCCGadget::blendFinalize() {
     }
 
     for (auto *liveInVal : liveness->getBlockInfo(blendPoint).LiveIn) {
-      if (blendedValues.count(liveInVal)) {
+      if (blendedValues.contains(liveInVal)) {
         continue;
       }
 

--- a/modules/compiler/vecz/source/ir_cleanup.cpp
+++ b/modules/compiler/vecz/source/ir_cleanup.cpp
@@ -62,7 +62,7 @@ bool AreUsersDead(Instruction *I,
     }
 
     // I is held by a non-dead user.
-    if (!DeadList.count(UserI) && !WorkList.count(UserI)) {
+    if (!DeadList.contains(UserI) && !WorkList.contains(UserI)) {
       return false;
     }
 

--- a/modules/compiler/vecz/source/transform/basic_mem2reg_pass.cpp
+++ b/modules/compiler/vecz/source/transform/basic_mem2reg_pass.cpp
@@ -162,7 +162,7 @@ bool BasicMem2RegPass::canPromoteAlloca(AllocaInst *Alloca) const {
 
   // Stores must precede other users.
   for (Instruction &I : EntryBB) {
-    if (NonStoreUsers.count(&I)) {
+    if (NonStoreUsers.contains(&I)) {
       return false;
     } else if (&I == TheStore) {
       break;

--- a/modules/compiler/vecz/source/transform/interleaved_group_combine_pass.cpp
+++ b/modules/compiler/vecz/source/transform/interleaved_group_combine_pass.cpp
@@ -223,7 +223,7 @@ bool InterleavedGroupCombinePass::InterleavedGroupInfo::canDeinterleaveMask(
   // If it finds any of the mask's own operands as group members or in
   // between group members, the mask cannot be (trivially) moved.
   while (IA) {
-    if (Ops.count(IA)) {
+    if (Ops.contains(IA)) {
       // We found something the mask depends on, so we can't de-interleave...
       return false;
     } else if (IA == Data.front()) {

--- a/modules/compiler/vecz/source/transform/packetization_helpers.cpp
+++ b/modules/compiler/vecz/source/transform/packetization_helpers.cpp
@@ -539,7 +539,7 @@ void Packetizer::Result::getPacketValues(unsigned width,
 
 PacketRange Packetizer::Result::createPacket(unsigned width) const {
   assert(info && "Can't create a packet on a fail state");
-  assert(info->packets.count(width) == 0 &&
+  assert(!info->packets.contains(width) &&
          "Shouldn't create the same packet twice");
 
   const auto start = packetizer.packetData.size();

--- a/modules/compiler/vecz/source/transform/pre_linearize_pass.cpp
+++ b/modules/compiler/vecz/source/transform/pre_linearize_pass.cpp
@@ -228,7 +228,7 @@ PreservedAnalyses PreLinearizePass::run(Function &F,
       VU.choices().isEnabled(VectorizationChoices::eDivisionExceptions);
 
   InstructionCost boscc_cost;
-  UniformValueResult *UVR = nullptr;
+  const UniformValueResult *UVR = nullptr;
   if (VU.choices().linearizeBOSCC()) {
     boscc_cost = calculateBoolReductionCost(F.getContext(), F.getParent(), TTI,
                                             VU.width());
@@ -261,7 +261,7 @@ PreservedAnalyses PreLinearizePass::run(Function &F,
       SmallVector<BasicBlock *, 2> hoistable;
       SmallPtrSet<BasicBlock *, 2> new_succs;
       for (auto *succ : successors(BB)) {
-        if (targets.count(succ) == 0) {
+        if (!targets.contains(succ)) {
           if (single_succs[succ] == nullptr || pred_size(succ) != 1 ||
               LI.getLoopFor(succ) != block_loop || !isTrivialBlock(*succ)) {
             simple = false;

--- a/modules/compiler/vecz/source/transform/scalarization_pass.cpp
+++ b/modules/compiler/vecz/source/transform/scalarization_pass.cpp
@@ -258,7 +258,7 @@ PreservedAnalyses ScalarizationPass::run(llvm::Function &F,
         }
 
         if (I.getType()->isVectorTy() && UVR.isVarying(&I) &&
-            tracer.visited.count(&I) == 0) {
+            !tracer.visited.contains(&I)) {
           SR.setNeedsScalarization(&I);
           NeedsScalarization = true;
         }

--- a/modules/compiler/vecz/source/vecz_pass_builder.cpp
+++ b/modules/compiler/vecz/source/vecz_pass_builder.cpp
@@ -124,10 +124,10 @@ void VeczPassMachinery::addClassToPassNames() {
   // Register a callback which skips all passes once we've failed to vectorize
   // a function.
   PIC.registerShouldRunOptionalPassCallback([&](StringRef, llvm::Any IR) {
-    const Function **FPtr = any_cast<const Function *>(&IR);
+    const Function *const *FPtr = any_cast<const Function *>(&IR);
     const Function *F = FPtr ? *FPtr : nullptr;
     if (!F) {
-      if (const auto **L = any_cast<const Loop *>(&IR)) {
+      if (const auto *const *L = any_cast<const Loop *>(&IR)) {
         F = (*L)->getHeader()->getParent();
       } else {
         // Always run module passes

--- a/modules/mux/source/hal/source/memory.cpp
+++ b/modules/mux/source/hal/source/memory.cpp
@@ -46,7 +46,7 @@ cargo::expected<void *, mux_result_t> memory::map(::hal::hal_device_t *device,
 // muxFlushMappedMemoryToDevice
 mux_result_t memory::flushToDevice(::hal::hal_device_t *device, uint64_t offset,
                                    uint64_t size) {
-  uint8_t *src = nullptr;
+  const uint8_t *src = nullptr;
   if (hostPtr) {
     src = static_cast<uint8_t *>(hostPtr) + offset;
   } else {

--- a/modules/mux/targets/host/source/command_buffer.cpp
+++ b/modules/mux/targets/host/source/command_buffer.cpp
@@ -77,10 +77,10 @@ void populatePackedArgs(
       case mux_descriptor_info_type_buffer: {
         const mux_descriptor_info_buffer_s info = descriptor.buffer_descriptor;
 
-        ::host::buffer_s *const host_buffer =
+        const ::host::buffer_s *const host_buffer =
             static_cast<::host::buffer_s *>(info.buffer);
 
-        uint8_t *const buffer_value =
+        const uint8_t *const buffer_value =
             static_cast<uint8_t *>(host_buffer->data) + info.offset;
 
         std::memcpy(packed_args_alloc + offset,
@@ -157,7 +157,7 @@ void populatePackedArgs(
         offset += sizeof(size_t);
       } break;
       case mux_descriptor_info_type_null_buffer: {
-        void *nullvar = nullptr;
+        const void *nullvar = nullptr;
         std::memcpy(packed_args_alloc + offset, static_cast<void *>(&nullvar),
                     sizeof(void *));
         offset += sizeof(void *);
@@ -1039,7 +1039,7 @@ mux_result_t hostUpdateDescriptors(mux_command_buffer_t command_buffer,
         std::memcpy(arg_address, &(info.size), sizeof(size_t));
       } break;
       case mux_descriptor_info_type_null_buffer: {
-        void *null = nullptr;
+        const void *null = nullptr;
         std::memcpy(arg_address, static_cast<void *>(&null), sizeof(void *));
       } break;
     }

--- a/modules/mux/targets/host/source/kernel.cpp
+++ b/modules/mux/targets/host/source/kernel.cpp
@@ -184,7 +184,7 @@ mux_result_t host::kernel_s::getKernelVariantForWGSize(
     host::kernel_variant_s *out_variant_data) {
   (void)local_size_y;
   (void)local_size_z;
-  host::kernel_variant_s *best_variant = nullptr;
+  const host::kernel_variant_s *best_variant = nullptr;
   for (auto &v : variant_data) {
     // If the local size isn't a multiple of the minimum work width, we must
     // disregard this kernel.

--- a/modules/mux/targets/host/source/queue.cpp
+++ b/modules/mux/targets/host/source/queue.cpp
@@ -74,7 +74,7 @@ void threadPoolCleanup(void *const v_queue, void *const v_command_buffer,
 }
 
 void commandReadBuffer(host::command_info_s *info) {
-  host::command_info_read_buffer_s *const read = &(info->read_command);
+  const host::command_info_read_buffer_s *const read = &(info->read_command);
 
   auto buffer = static_cast<host::buffer_s *>(read->buffer);
 
@@ -83,7 +83,7 @@ void commandReadBuffer(host::command_info_s *info) {
 }
 
 void commandWriteBuffer(host::command_info_s *info) {
-  host::command_info_write_buffer_s *const write = &(info->write_command);
+  const host::command_info_write_buffer_s *const write = &(info->write_command);
 
   auto buffer = static_cast<host::buffer_s *>(write->buffer);
 
@@ -99,7 +99,7 @@ void commandFillBuffer(host::command_info_s *info) {
   size_t size = fill->pattern_size;
   uint8_t *const start = static_cast<uint8_t *>(buffer->data) + fill->offset;
   uint8_t *current = start + size;
-  uint8_t *const end = start + fill->size;
+  const uint8_t *const end = start + fill->size;
 
   std::memcpy(start, fill->pattern, size);
 
@@ -113,7 +113,7 @@ void commandFillBuffer(host::command_info_s *info) {
 }
 
 void commandCopyBuffer(host::command_info_s *info) {
-  host::command_info_copy_buffer_s *const copy = &(info->copy_command);
+  const host::command_info_copy_buffer_s *const copy = &(info->copy_command);
 
   auto dst_buffer = static_cast<host::buffer_s *>(copy->dst_buffer);
   auto src_buffer = static_cast<host::buffer_s *>(copy->src_buffer);
@@ -308,7 +308,7 @@ void commandNDRange(host::queue_s *queue, host::command_info_s *info) {
 
 void commandUserCallback(host::queue_s *queue, host::command_info_s *info,
                          host::command_buffer_s *command_buffer) {
-  host::command_info_user_callback_s *const user_callback =
+  const host::command_info_user_callback_s *const user_callback =
       &(info->user_callback_command);
 
   (user_callback->user_function)(queue, command_buffer,
@@ -317,7 +317,7 @@ void commandUserCallback(host::queue_s *queue, host::command_info_s *info,
 
 [[nodiscard]] mux_query_duration_result_t commandBeginQuery(
     host::command_info_s *info, mux_query_duration_result_t duration_query) {
-  host::command_info_begin_query_s *const begin_query =
+  const host::command_info_begin_query_s *const begin_query =
       &(info->begin_query_command);
   if (begin_query->pool->type == mux_query_type_duration) {
     return static_cast<host::query_pool_s *>(begin_query->pool)
@@ -328,7 +328,8 @@ void commandUserCallback(host::queue_s *queue, host::command_info_s *info,
 
 [[nodiscard]] mux_query_duration_result_t commandEndQuery(
     host::command_info_s *info, mux_query_duration_result_t duration_query) {
-  host::command_info_end_query_s *const end_query = &(info->end_query_command);
+  const host::command_info_end_query_s *const end_query =
+      &(info->end_query_command);
   if (end_query->pool->type == mux_query_type_duration) {
     auto end_duration_query = static_cast<host::query_pool_s *>(end_query->pool)
                                   ->getDurationQueryAt(end_query->index);
@@ -355,7 +356,7 @@ void commandEndQuery(host::command_info_s *info) {
 #endif
 
 void commandResetQueryPool(host::command_info_s *info) {
-  host::command_info_reset_query_pool_s *const reset_query_pool =
+  const host::command_info_reset_query_pool_s *const reset_query_pool =
       &(info->reset_query_pool_command);
   auto query_pool = static_cast<host::query_pool_s *>(reset_query_pool->pool);
   query_pool->reset(reset_query_pool->index, reset_query_pool->count);

--- a/source/cl/source/command_queue.cpp
+++ b/source/cl/source/command_queue.cpp
@@ -377,14 +377,12 @@ cl_int _cl_command_queue::cleanupCompletedCommandBuffers() {
     }
 
     // Move destroyed semaphores to the back, then erase them.
-    auto first_released_semaphore = std::stable_partition(
+    auto first_released_semaphore = std::remove_if(
         completed_signal_semaphores.begin(), completed_signal_semaphores.end(),
         [&released_semaphores](mux_shared_semaphore semaphore) {
-          // When semaphore is not in released_semaphores return true which
-          // moves it to the front, otherwise move it to the back.
           return std::find(released_semaphores.begin(),
                            released_semaphores.end(),
-                           semaphore) == released_semaphores.end();
+                           semaphore) != released_semaphores.end();
         });
     completed_signal_semaphores.erase(first_released_semaphore,
                                       completed_signal_semaphores.end());

--- a/source/cl/source/context.cpp
+++ b/source/cl/source/context.cpp
@@ -61,7 +61,7 @@ cargo::expected<cl_context, cl_int> _cl_context::create(
 
   // Create SPIR-V device infos.
 #if defined(OCL_EXTENSION_cl_khr_il_program) || defined(CL_VERSION_3_0)
-  for (_cl_device_id *device : devices) {
+  for (const _cl_device_id *device : devices) {
     auto device_info = device->mux_device->info;
     context->spv_device_infos[device_info] =
         *cl::binary::getSPIRVDeviceInfo(device_info, device->profile);

--- a/source/cl/source/event.cpp
+++ b/source/cl/source/event.cpp
@@ -208,8 +208,8 @@ CL_API_ENTRY cl_int CL_API_CALL cl::WaitForEvents(cl_uint num_events,
   OCL_CHECK(0 == num_events, return CL_INVALID_VALUE);
   OCL_CHECK(!event_list, return CL_INVALID_VALUE);
 
-  _cl_context *previousContext = nullptr;
-  _cl_command_queue *previousQueue = nullptr;
+  const _cl_context *previousContext = nullptr;
+  const _cl_command_queue *previousQueue = nullptr;
   bool moreThanOneQueue = false;
   bool userEventInList = false;
 

--- a/source/cl/source/mem.cpp
+++ b/source/cl/source/mem.cpp
@@ -461,7 +461,7 @@ cl::EnqueueUnmapMemObject(cl_command_queue command_queue, cl_mem memobj,
   OCL_CHECK(!command_queue, return CL_INVALID_COMMAND_QUEUE);
   OCL_CHECK(!memobj, return CL_INVALID_MEM_OBJECT);
   OCL_CHECK(!mapped_ptr, return CL_INVALID_VALUE);
-  _cl_context *context = command_queue->context;
+  const _cl_context *context = command_queue->context;
   OCL_CHECK(context != memobj->context, return CL_INVALID_CONTEXT);
 
   const cl_int error = cl::validate::EventWaitList(
@@ -470,7 +470,7 @@ cl::EnqueueUnmapMemObject(cl_command_queue command_queue, cl_mem memobj,
   cl_mem parent =
       (nullptr != memobj->optional_parent) ? memobj->optional_parent : memobj;
 
-  char *base_pointer = static_cast<char *>(parent->map_base_pointer);
+  const char *base_pointer = static_cast<char *>(parent->map_base_pointer);
   if (CL_MEM_USE_HOST_PTR & parent->flags) {
     // When CL_MEM_USE_HOST_PTR is set then our map entry point returns a
     // pointer value derived from the user provided host_ptr.

--- a/source/cl/test/UnitCL/source/Common.cpp
+++ b/source/cl/test/UnitCL/source/Common.cpp
@@ -1024,7 +1024,7 @@ size_t UCL::getTypeSize(const char *const type) {
 }
 
 bool UCL::hasPlatformExtensionSupport(const char *extension_name) {
-  cl_platform_id *platforms = getPlatforms();
+  const cl_platform_id *platforms = getPlatforms();
   cl_platform_id platform = platforms[0];
 
   size_t extension_names_size = 0;

--- a/source/cl/test/UnitCL/source/clCompileProgram.cpp
+++ b/source/cl/test/UnitCL/source/clCompileProgram.cpp
@@ -776,7 +776,7 @@ class clCompileLinkEmbeddedHeaderPrototype
 
 TEST_F(clCompileLinkEmbeddedHeaderPrototype, Default) {
   cl_int errorcode = CL_SUCCESS;
-  cl_program link_input[] = {program, program_with_header};
+  const cl_program link_input[] = {program, program_with_header};
   cl_program linked = clLinkProgram(context, 1, &device, nullptr, 2, link_input,
                                     nullptr, nullptr, &errorcode);
   EXPECT_TRUE(linked);
@@ -805,7 +805,7 @@ class clCompileLinkEmbeddedHeaderDeclaration
 // Redmine issue #5295.
 TEST_F(clCompileLinkEmbeddedHeaderDeclaration, DISABLED_Default) {
   cl_int errorcode = CL_SUCCESS;
-  cl_program link_input[] = {program, program_with_header};
+  const cl_program link_input[] = {program, program_with_header};
   cl_program linked = clLinkProgram(context, 1, &device, nullptr, 2, link_input,
                                     nullptr, nullptr, &errorcode);
   EXPECT_TRUE(linked);

--- a/source/cl/test/UnitCL/source/clCreateProgramWithBinary.cpp
+++ b/source/cl/test/UnitCL/source/clCreateProgramWithBinary.cpp
@@ -354,7 +354,7 @@ TEST_F(clCreateProgramWithBinaryTest, CreateProgramThenTryCompile) {
   ASSERT_SUCCESS(errcode);
 
   const size_t num_devices = 1;
-  cl_device_id *devices = &device;
+  const cl_device_id *devices = &device;
 
   for (size_t i = 0; i < num_devices; ++i) {
     ASSERT_SUCCESS(binaryStatii[i]);

--- a/source/cl/test/UnitCL/source/clEnqueueFillImage.cpp
+++ b/source/cl/test/UnitCL/source/clEnqueueFillImage.cpp
@@ -144,7 +144,7 @@ TEST_P(clEnqueueFillImageTest, FillFull) {
   cl_int status = !CL_SUCCESS;
   size_t imageRowPitch = 0;
   size_t imageSlicePitch = 0;
-  cl_uint4 *const mappedImage = static_cast<cl_uint4 *>(clEnqueueMapImage(
+  const cl_uint4 *const mappedImage = static_cast<cl_uint4 *>(clEnqueueMapImage(
       command_queue, image, CL_TRUE, CL_MAP_READ, origin, region,
       &imageRowPitch, &imageSlicePitch, 1, &event, nullptr, &status));
   EXPECT_TRUE(mappedImage);
@@ -205,7 +205,7 @@ TEST_P(clEnqueueFillImageTest, FillStart) {
   cl_int status = !CL_SUCCESS;
   size_t imageRowPitch = 0;
   size_t imageSlicePitch = 0;
-  cl_uint4 *const mappedImage = static_cast<cl_uint4 *>(clEnqueueMapImage(
+  const cl_uint4 *const mappedImage = static_cast<cl_uint4 *>(clEnqueueMapImage(
       command_queue, image, CL_TRUE, CL_MAP_READ, mapOrigin, mapRegion,
       &imageRowPitch, &imageSlicePitch, 1, &event, nullptr, &status));
   EXPECT_TRUE(mappedImage);
@@ -272,7 +272,7 @@ TEST_P(clEnqueueFillImageTest, FillEnd) {
   cl_int status = !CL_SUCCESS;
   size_t imageRowPitch = 0;
   size_t imageSlicePitch = 0;
-  cl_uint4 *const mappedImage = static_cast<cl_uint4 *>(clEnqueueMapImage(
+  const cl_uint4 *const mappedImage = static_cast<cl_uint4 *>(clEnqueueMapImage(
       command_queue, image, CL_TRUE, CL_MAP_READ, mapOrigin, mapRegion,
       &imageRowPitch, &imageSlicePitch, 1, &event, nullptr, &status));
   EXPECT_TRUE(mappedImage);
@@ -343,7 +343,7 @@ TEST_P(clEnqueueFillImageTest, FillMiddle) {
   cl_int status = !CL_SUCCESS;
   size_t imageRowPitch = 0;
   size_t imageSlicePitch = 0;
-  cl_uint4 *const mappedImage = static_cast<cl_uint4 *>(clEnqueueMapImage(
+  const cl_uint4 *const mappedImage = static_cast<cl_uint4 *>(clEnqueueMapImage(
       command_queue, image, CL_TRUE, CL_MAP_READ, mapOrigin, mapRegion,
       &imageRowPitch, &imageSlicePitch, 1, &event, nullptr, &status));
   EXPECT_TRUE(mappedImage);

--- a/source/cl/test/UnitCL/source/clEnqueueMapBuffer.cpp
+++ b/source/cl/test/UnitCL/source/clEnqueueMapBuffer.cpp
@@ -97,7 +97,7 @@ class clEnqueueMapBufferTest : public ucl::CommandQueueTest,
   void EventWaitListAPICall(cl_int err, cl_uint num_events,
                             const cl_event *events, cl_event *event) override {
     cl_int errcode = !CL_SUCCESS;
-    void *const map = clEnqueueMapBuffer(
+    const void *const map = clEnqueueMapBuffer(
         command_queue, inMem, CL_TRUE, CL_MAP_WRITE_INVALIDATE_REGION, 0,
         int_size, num_events, events, event, &errcode);
     EXPECT_EQ_ERRCODE(err, errcode);
@@ -363,7 +363,7 @@ TEST_F(clEnqueueMapBufferTest, WithOffset) {
 
   const size_t offset = 1;
 
-  int *const map = static_cast<int *>(clEnqueueMapBuffer(
+  const int *const map = static_cast<int *>(clEnqueueMapBuffer(
       command_queue, inMem, CL_TRUE, CL_MAP_READ, offset * sizeof(int),
       sizeof(int), 0, nullptr, nullptr, &errcode));
   ASSERT_SUCCESS(errcode);
@@ -516,7 +516,7 @@ TEST_F(clEnqueueMapBufferTest, ValidOverlappingWriteMappings) {
 
 TEST_F(clEnqueueMapBufferTest, InvalidCommandQueue) {
   cl_int errcode = !CL_SUCCESS;
-  void *const map = clEnqueueMapBuffer(
+  const void *const map = clEnqueueMapBuffer(
       nullptr, inMem, CL_FALSE, CL_MAP_WRITE_INVALIDATE_REGION, 0, int_size, 1,
       &writeEvent, &mapEvent, &errcode);
   EXPECT_EQ_ERRCODE(CL_INVALID_COMMAND_QUEUE, errcode);
@@ -525,7 +525,7 @@ TEST_F(clEnqueueMapBufferTest, InvalidCommandQueue) {
 
 TEST_F(clEnqueueMapBufferTest, InvalidBuffer) {
   cl_int errcode = !CL_SUCCESS;
-  void *const map = clEnqueueMapBuffer(
+  const void *const map = clEnqueueMapBuffer(
       command_queue, nullptr, CL_FALSE, CL_MAP_WRITE_INVALIDATE_REGION, 0,
       int_size, 1, &writeEvent, &mapEvent, &errcode);
   EXPECT_EQ_ERRCODE(CL_INVALID_MEM_OBJECT, errcode);
@@ -534,7 +534,7 @@ TEST_F(clEnqueueMapBufferTest, InvalidBuffer) {
 
 TEST_F(clEnqueueMapBufferTest, InvalidValueOutOfBounds) {
   cl_int errcode = !CL_SUCCESS;
-  void *const map = clEnqueueMapBuffer(
+  const void *const map = clEnqueueMapBuffer(
       command_queue, inMem, CL_FALSE, CL_MAP_WRITE_INVALIDATE_REGION, int_size,
       int_size, 1, &writeEvent, &mapEvent, &errcode);
   EXPECT_EQ_ERRCODE(CL_INVALID_VALUE, errcode);
@@ -543,9 +543,9 @@ TEST_F(clEnqueueMapBufferTest, InvalidValueOutOfBounds) {
 
 TEST_F(clEnqueueMapBufferTest, InvalidValueSizeZero) {
   cl_int errcode = !CL_SUCCESS;
-  void *const map = clEnqueueMapBuffer(command_queue, inMem, CL_FALSE,
-                                       CL_MAP_WRITE_INVALIDATE_REGION, 0, 0, 1,
-                                       &writeEvent, &mapEvent, &errcode);
+  const void *const map = clEnqueueMapBuffer(
+      command_queue, inMem, CL_FALSE, CL_MAP_WRITE_INVALIDATE_REGION, 0, 0, 1,
+      &writeEvent, &mapEvent, &errcode);
   EXPECT_EQ_ERRCODE(CL_INVALID_VALUE, errcode);
   EXPECT_FALSE(map);
 }
@@ -554,7 +554,7 @@ TEST_F(clEnqueueMapBufferTest, InvalidValueFlags) {
   cl_int errcode = !CL_SUCCESS;
   const auto all_valid_map_flags = static_cast<cl_map_flags>(
       CL_MAP_READ | CL_MAP_WRITE | CL_MAP_WRITE_INVALIDATE_REGION);
-  void *const map =
+  const void *const map =
       clEnqueueMapBuffer(command_queue, inMem, CL_FALSE, (~all_valid_map_flags),
                          0, int_size, 1, &writeEvent, &mapEvent, &errcode);
   EXPECT_EQ_ERRCODE(CL_INVALID_VALUE, errcode);
@@ -579,7 +579,7 @@ TEST_F(clEnqueueMapBufferTest, InvalidOperationBufferWriteOnlyWithReadMap) {
 
   errcode = !CL_SUCCESS;
 
-  void *const map =
+  const void *const map =
       clEnqueueMapBuffer(command_queue, subMem, CL_FALSE, CL_MAP_READ, 0,
                          int_size, 1, &writeEvent, &mapEvent, &errcode);
   EXPECT_EQ_ERRCODE(CL_INVALID_OPERATION, errcode);
@@ -606,7 +606,7 @@ TEST_F(clEnqueueMapBufferTest, InvalidOperationBufferNoAccessWithReadMap) {
 
   errcode = !CL_SUCCESS;
 
-  void *const map =
+  const void *const map =
       clEnqueueMapBuffer(command_queue, subMem, CL_FALSE, CL_MAP_READ, 0,
                          int_size, 1, &writeEvent, &mapEvent, &errcode);
   EXPECT_EQ_ERRCODE(CL_INVALID_OPERATION, errcode);
@@ -633,13 +633,13 @@ TEST_F(clEnqueueMapBufferTest, InvalidOperationBufferReadOnlyWithWriteMap) {
 
   errcode = !CL_SUCCESS;
 
-  void *const map1 =
+  const void *const map1 =
       clEnqueueMapBuffer(command_queue, subMem, CL_FALSE, CL_MAP_WRITE, 0,
                          int_size, 1, &writeEvent, &mapEvent, &errcode);
   EXPECT_EQ_ERRCODE(CL_INVALID_OPERATION, errcode);
   EXPECT_FALSE(map1);
 
-  void *const map2 = clEnqueueMapBuffer(
+  const void *const map2 = clEnqueueMapBuffer(
       command_queue, subMem, CL_FALSE, CL_MAP_WRITE_INVALIDATE_REGION, 0,
       int_size, 1, &writeEvent, &mapEvent, &errcode);
   EXPECT_EQ_ERRCODE(CL_INVALID_OPERATION, errcode);
@@ -666,13 +666,13 @@ TEST_F(clEnqueueMapBufferTest, InvalidOperationBufferNoAccessWithWriteMap) {
 
   errcode = !CL_SUCCESS;
 
-  void *const map1 =
+  const void *const map1 =
       clEnqueueMapBuffer(command_queue, subMem, CL_FALSE, CL_MAP_WRITE, 0,
                          int_size, 1, &writeEvent, &mapEvent, &errcode);
   EXPECT_EQ_ERRCODE(CL_INVALID_OPERATION, errcode);
   EXPECT_FALSE(map1);
 
-  void *const map2 = clEnqueueMapBuffer(
+  const void *const map2 = clEnqueueMapBuffer(
       command_queue, subMem, CL_FALSE, CL_MAP_WRITE_INVALIDATE_REGION, 0,
       int_size, 1, &writeEvent, &mapEvent, &errcode);
   EXPECT_EQ_ERRCODE(CL_INVALID_OPERATION, errcode);

--- a/source/cl/test/UnitCL/source/clEnqueueMapImage.cpp
+++ b/source/cl/test/UnitCL/source/clEnqueueMapImage.cpp
@@ -358,7 +358,7 @@ TEST_P(clEnqueueMapImageTests, MapImage) {
   size_t image_row_pitch = 0;
   size_t image_slice_pitch = 0;
 
-  void *ptr = clEnqueueMapImage(
+  const void *ptr = clEnqueueMapImage(
       command_queue, src_image, CL_TRUE, CL_MAP_READ, origin, region,
       &image_row_pitch, &image_slice_pitch, 0, nullptr, nullptr, &error);
   EXPECT_NE(nullptr, ptr);

--- a/source/cl/test/UnitCL/source/clEnqueueNDRangeKernel.cpp
+++ b/source/cl/test/UnitCL/source/clEnqueueNDRangeKernel.cpp
@@ -1632,7 +1632,7 @@ struct clEnqueueNDRangeKernelWorkItemTest
 };
 
 TEST_P(clEnqueueNDRangeKernelWorkItemTest, Default) {
-  const NDRangeValue val = GetParam();
+  const NDRangeValue &val = GetParam();
   cl_event fillEvent, ndRangeEvent;
 
   if (nullptr == val.global_work_size) {

--- a/source/cl/test/UnitCL/source/clEnqueueNativeKernel.cpp
+++ b/source/cl/test/UnitCL/source/clEnqueueNativeKernel.cpp
@@ -113,7 +113,7 @@ TEST_F(clEnqueueNativeKernelTest, InvalidMemObject) {
     cl_mem buffer = clCreateBuffer(context, CL_MEM_READ_WRITE, sizeof(cl_int),
                                    nullptr, &status);
     EXPECT_SUCCESS(status);
-    cl_mem mems[] = {buffer, nullptr};
+    const cl_mem mems[] = {buffer, nullptr};
     const void *args_mem_loc[2] = {nullptr, nullptr};
 
     EXPECT_EQ_ERRCODE(

--- a/source/cl/test/UnitCL/source/clEnqueueSVMMemcpy.cpp
+++ b/source/cl/test/UnitCL/source/clEnqueueSVMMemcpy.cpp
@@ -38,7 +38,7 @@ TEST_F(clEnqueueSVMMemcpyTest, NotImplemented) {
   }
   const cl_bool blocking_copy{};
   void *dst_ptr{};
-  void *src_ptr{};
+  const void *src_ptr{};
   const size_t size{};
   const cl_uint num_events_in_wait_list{};
   const cl_event *event_wait_list{};

--- a/source/cl/test/UnitCL/source/clGetEventInfo.cpp
+++ b/source/cl/test/UnitCL/source/clGetEventInfo.cpp
@@ -388,7 +388,7 @@ TEST_F(clGetEventInfoTest, MapBufferEvent) {
   ASSERT_SUCCESS(errcode);
 
   cl_event event;
-  void *mapped_data =
+  const void *mapped_data =
       clEnqueueMapBuffer(command_queue, in_mem, CL_FALSE, CL_MAP_READ, 0, size,
                          0, nullptr, &event, &errcode);
   ASSERT_SUCCESS(errcode);

--- a/source/cl/test/UnitCL/source/clGetMemObjectInfo.cpp
+++ b/source/cl/test/UnitCL/source/clGetMemObjectInfo.cpp
@@ -101,7 +101,7 @@ TEST_F(clGetMemObjectInfoTest, MemHostPtr) {
   ASSERT_SUCCESS(
       clGetMemObjectInfo(hostBuffer, CL_MEM_HOST_PTR, 0, nullptr, &size));
   ASSERT_EQ(sizeof(void *), size);
-  void *ptr = nullptr;
+  const void *ptr = nullptr;
   ASSERT_SUCCESS(clGetMemObjectInfo(hostBuffer, CL_MEM_HOST_PTR, size,
                                     static_cast<void *>(&ptr), nullptr));
   ASSERT_EQ(&data, ptr);

--- a/source/cl/test/UnitCL/source/clLinkProgram.cpp
+++ b/source/cl/test/UnitCL/source/clLinkProgram.cpp
@@ -124,7 +124,7 @@ TEST_F(clLinkProgramGoodTest, ProgramListWithNoPrograms) {
 }
 
 TEST_F(clLinkProgramGoodTest, InvalidProgram) {
-  cl_program programs[] = {program, nullptr};
+  const cl_program programs[] = {program, nullptr};
   cl_int errorcode;
   EXPECT_FALSE(clLinkProgram(context, 0, nullptr, nullptr, 2, programs, nullptr,
                              nullptr, &errorcode));
@@ -140,7 +140,7 @@ TEST_F(clLinkProgramGoodTest, NullCallbackWithData) {
 }
 
 TEST_F(clLinkProgramGoodTest, InvalidDevice) {
-  cl_device_id devices[] = {device, nullptr};
+  const cl_device_id devices[] = {device, nullptr};
   cl_int errorcode;
   EXPECT_FALSE(clLinkProgram(context, 2, devices, nullptr, 1, &program, nullptr,
                              nullptr, &errorcode));
@@ -155,7 +155,7 @@ TEST_F(clLinkProgramGoodTest, UncompiledProgramInList) {
   EXPECT_TRUE(otherProgram);
   ASSERT_SUCCESS(errorcode);
 
-  cl_program programs[] = {program, otherProgram};
+  const cl_program programs[] = {program, otherProgram};
   EXPECT_FALSE(clLinkProgram(context, 0, nullptr, nullptr, 2, programs, nullptr,
                              nullptr, &errorcode));
   ASSERT_EQ_ERRCODE(CL_INVALID_OPERATION, errorcode);
@@ -173,7 +173,7 @@ TEST_F(clLinkProgramGoodTest, LinkFailureDuplicateKernels) {
   ASSERT_SUCCESS(clCompileProgram(otherProgram, 0, nullptr, nullptr, 0, nullptr,
                                   nullptr, nullptr, nullptr));
 
-  cl_program programs[] = {program, otherProgram};
+  const cl_program programs[] = {program, otherProgram};
   EXPECT_FALSE(clLinkProgram(context, 0, nullptr, nullptr, 2, programs, nullptr,
                              nullptr, &errorcode));
   ASSERT_EQ_ERRCODE(CL_LINK_PROGRAM_FAILURE, errorcode);
@@ -260,7 +260,7 @@ TEST_F(clLinkProgramGoodTest, CreateLibraryAndLinkAgainstIt) {
   ASSERT_SUCCESS(clCompileProgram(otherProgram, 0, nullptr, nullptr, 0, nullptr,
                                   nullptr, nullptr, nullptr));
 
-  cl_program programs[] = {otherProgram, linkedProgram};
+  const cl_program programs[] = {otherProgram, linkedProgram};
   cl_program finalProgram = clLinkProgram(context, 0, nullptr, nullptr, 2,
                                           programs, nullptr, nullptr, &status);
   EXPECT_TRUE(finalProgram);
@@ -509,8 +509,8 @@ constant int extern_constant_int = 42;
   error = clCompileProgram(program_extern_constant_def, 1, &device, "", 0,
                            nullptr, nullptr, nullptr, nullptr);
   ASSERT_SUCCESS(error);
-  cl_program programs[2] = {program_extern_constant_def,
-                            program_extern_constant_use};
+  const cl_program programs[2] = {program_extern_constant_def,
+                                  program_extern_constant_use};
   cl_program linked_program = clLinkProgram(context, 1, &device, "", 2,
                                             programs, nullptr, nullptr, &error);
   EXPECT_NE(nullptr, linked_program);
@@ -550,8 +550,8 @@ int extern_function_int() { return 42;})";
   error = clCompileProgram(program_extern_function_def, 1, &device, "", 0,
                            nullptr, nullptr, nullptr, nullptr);
   ASSERT_SUCCESS(error);
-  cl_program programs[2] = {program_extern_function_def,
-                            program_extern_function_use};
+  const cl_program programs[2] = {program_extern_function_def,
+                                  program_extern_function_use};
   cl_program linked_program = clLinkProgram(context, 1, &device, "", 2,
                                             programs, nullptr, nullptr, &error);
   EXPECT_NE(nullptr, linked_program);

--- a/source/cl/test/UnitCL/source/clSetKernelExecInfo.cpp
+++ b/source/cl/test/UnitCL/source/clSetKernelExecInfo.cpp
@@ -100,7 +100,7 @@ TEST_F(clSetKernelExecInfoTest, InvalidValue) {
   // around returning CL_INVALID_OPERATION when fine-grained SVM isn't
   // supported. This complicates which error code gets priority, and there
   // aren't any CTS tests yet to use as a reference.
-  void *svm_ptr[1] = {nullptr};
+  const void *svm_ptr[1] = {nullptr};
 
   // Invalid param_name
   EXPECT_EQ_ERRCODE(

--- a/source/cl/test/UnitCL/source/cl_codeplay_kernel_exec_info/usm.cpp
+++ b/source/cl/test/UnitCL/source/cl_codeplay_kernel_exec_info/usm.cpp
@@ -234,7 +234,7 @@ TEST_F(KernelExecInfoCodeplayUSMPtrs, IndirectDevicePointer) {
                                 static_cast<void *>(&output_buffer)));
 
   // Pass indirect USM pointers to runtime
-  void *indirect_usm_pointers[1] = {device_ptr};
+  const void *indirect_usm_pointers[1] = {device_ptr};
   const cl_int err = clSetKernelExecInfoCODEPLAY(
       exec_info_kernel, CL_KERNEL_EXEC_INFO_USM_PTRS_INTEL, sizeof(void *),
       static_cast<void *>(indirect_usm_pointers));
@@ -265,7 +265,7 @@ TEST_F(KernelExecInfoCodeplayUSMPtrs, OffsetDevicePointer) {
                                 static_cast<void *>(&output_buffer)));
 
   // Pass base device USM pointer to runtime as used indirectly
-  void *indirect_usm_pointers[1] = {device_ptr};
+  const void *indirect_usm_pointers[1] = {device_ptr};
   const cl_int err = clSetKernelExecInfoCODEPLAY(
       exec_info_kernel, CL_KERNEL_EXEC_INFO_USM_PTRS_INTEL, sizeof(void *),
       static_cast<void *>(indirect_usm_pointers));

--- a/source/cl/test/UnitCL/source/cl_intel_unified_shared_memory/usm_allocate.cpp
+++ b/source/cl/test/UnitCL/source/cl_intel_unified_shared_memory/usm_allocate.cpp
@@ -32,7 +32,8 @@ TEST_F(USMTests, HostMemAlloc_InvalidUsage) {
   cl_int err;
 
   // Invalid context
-  void *host_ptr = clHostMemAllocINTEL(nullptr, nullptr, bytes, align, &err);
+  const void *host_ptr =
+      clHostMemAllocINTEL(nullptr, nullptr, bytes, align, &err);
   EXPECT_EQ_ERRCODE(err, CL_INVALID_CONTEXT);
   EXPECT_EQ(host_ptr, nullptr);
 
@@ -207,7 +208,7 @@ TEST_F(USMTests, DeviceMemAlloc_InvalidUsage) {
   cl_int err;
 
   // Invalid context
-  void *device_ptr =
+  const void *device_ptr =
       clDeviceMemAllocINTEL(nullptr, device, nullptr, bytes, align, &err);
   EXPECT_EQ_ERRCODE(err, CL_INVALID_CONTEXT);
   EXPECT_EQ(device_ptr, nullptr);
@@ -345,7 +346,7 @@ TEST_F(USMTests, SingleSharedMemAlloc_InvalidUsage) {
   }
 
   // Invalid context
-  void *shared_ptr =
+  const void *shared_ptr =
       clSharedMemAllocINTEL(nullptr, device, nullptr, bytes, align, &err);
   EXPECT_EQ_ERRCODE(err, CL_INVALID_CONTEXT);
   EXPECT_EQ(shared_ptr, nullptr);
@@ -512,7 +513,7 @@ TEST_F(USMTests, CrossSharedMemAlloc_InvalidUsage) {
   }
 
   // Invalid context
-  void *shared_ptr =
+  const void *shared_ptr =
       clSharedMemAllocINTEL(nullptr, nullptr, nullptr, bytes, align, &err);
   EXPECT_EQ_ERRCODE(err, CL_INVALID_CONTEXT);
   EXPECT_EQ(shared_ptr, nullptr);

--- a/source/cl/test/UnitCL/source/cl_intel_unified_shared_memory/usm_enqueue.cpp
+++ b/source/cl/test/UnitCL/source/cl_intel_unified_shared_memory/usm_enqueue.cpp
@@ -243,7 +243,7 @@ TEST_F(USMCommandQueueTest, MemFill_ValidUsage) {
 // Test for invalid API usage of clEnqueueMemcpyINTEL()
 TEST_F(USMCommandQueueTest, Memcpy_InvalidUsage) {
   for (auto ptr : allPointers()) {
-    void *offset_ptr = getPointerOffset(ptr, sizeof(cl_int) * 4);
+    const void *offset_ptr = getPointerOffset(ptr, sizeof(cl_int) * 4);
 
     // No command queue
     cl_int err = clEnqueueMemcpyINTEL(nullptr, CL_TRUE, ptr, offset_ptr,
@@ -274,7 +274,7 @@ TEST_F(USMCommandQueueTest, Memcpy_InvalidUsage) {
     EXPECT_EQ_ERRCODE(err, CL_INVALID_VALUE);
 
     // Overlapping copy
-    void *overlap_ptr = getPointerOffset(ptr, 1);
+    const void *overlap_ptr = getPointerOffset(ptr, 1);
     err = clEnqueueMemcpyINTEL(queue, CL_TRUE, ptr, overlap_ptr, sizeof(cl_int),
                                0, nullptr, nullptr);
     EXPECT_EQ_ERRCODE(err, CL_MEM_COPY_OVERLAP);

--- a/source/cl/test/UnitCL/source/cl_intel_unified_shared_memory/usm_free.cpp
+++ b/source/cl/test/UnitCL/source/cl_intel_unified_shared_memory/usm_free.cpp
@@ -223,7 +223,7 @@ TEST_F(USMBlockingFreeTest, MultipleQueueSingleAlloc) {
       reference.fill(pattern);
 
       const size_t offset = i * sizeof(pattern) * elements_to_fill;
-      void *offset_host_ptr = getPointerOffset(host_ptr, offset);
+      const void *offset_host_ptr = getPointerOffset(host_ptr, offset);
       EXPECT_TRUE(0 == std::memcmp(reference.data(), offset_host_ptr,
                                    sizeof(pattern) * elements_to_fill));
     }
@@ -370,7 +370,7 @@ TEST_F(USMBlockingFreeTest, MultipleQueueMultipleAlloc) {
     std::array<cl_uint, elements / 2> reference1, reference2;
     reference1.fill(pattern_A);
     reference2.fill(pattern_B);
-    void *offset_ptr = getPointerOffset(host_ptr, halfway_offset);
+    const void *offset_ptr = getPointerOffset(host_ptr, halfway_offset);
     EXPECT_TRUE(0 == std::memcmp(host_ptr, reference1.data(), halfway_offset));
     EXPECT_TRUE(0 ==
                 std::memcmp(offset_ptr, reference2.data(), halfway_offset));
@@ -502,7 +502,7 @@ TEST_F(USMBlockingFreeKernelTest, Task) {
       reference.fill(pattern);
 
       const size_t offset = i * sizeof(pattern) * elements_to_fill;
-      void *offset_host_ptr = getPointerOffset(host_ptr, offset);
+      const void *offset_host_ptr = getPointerOffset(host_ptr, offset);
       ASSERT_TRUE(0 == std::memcmp(reference.data(), offset_host_ptr,
                                    sizeof(pattern) * elements_to_fill));
     }
@@ -541,7 +541,7 @@ TEST_F(USMBlockingFreeKernelTest, NDRange) {
     void *input_offset_ptr = getPointerOffset(input_usm_ptr, offset);
     ASSERT_SUCCESS(clSetKernelArgMemPointerINTEL(kernel, 0, input_offset_ptr));
 
-    void *output_offset_ptr = getPointerOffset(output_usm_ptr, offset);
+    const void *output_offset_ptr = getPointerOffset(output_usm_ptr, offset);
     ASSERT_SUCCESS(clSetKernelArgMemPointerINTEL(kernel, 1, output_offset_ptr));
 
     ASSERT_SUCCESS(clEnqueueMemFillINTEL(queues[tid], input_offset_ptr,
@@ -581,7 +581,7 @@ TEST_F(USMBlockingFreeKernelTest, NDRange) {
 
       const size_t copy_size = sizeof(pattern) * elements_to_fill;
       const size_t offset = i * copy_size;
-      void *offset_host_ptr = getPointerOffset(host_ptr, offset);
+      const void *offset_host_ptr = getPointerOffset(host_ptr, offset);
 
       ASSERT_TRUE(0 ==
                   std::memcmp(reference.data(), offset_host_ptr, copy_size));

--- a/source/cl/test/UnitCL/source/cl_intel_unified_shared_memory/usm_kernel.cpp
+++ b/source/cl/test/UnitCL/source/cl_intel_unified_shared_memory/usm_kernel.cpp
@@ -150,7 +150,7 @@ TEST_P(USMSetKernelArgMemPointerTest, ValidUsage) {
   const cl_uint arg_index = GetParam();
 
   for (auto ptr : allPointers()) {
-    void *offset_ptr = getPointerOffset(ptr, sizeof(cl_int));
+    const void *offset_ptr = getPointerOffset(ptr, sizeof(cl_int));
     EXPECT_SUCCESS(clSetKernelArgMemPointerINTEL(kernel, arg_index, ptr));
 
     EXPECT_SUCCESS(
@@ -581,7 +581,7 @@ TEST_F(USMVectorAddKernelTest, OverwriteUSMArg) {
 
   // Find pointer addressing halfway into the memory allocation
   const size_t half_bytes = bytes / 2;
-  void *offset_device_ptr = getPointerOffset(device_ptr, half_bytes);
+  const void *offset_device_ptr = getPointerOffset(device_ptr, half_bytes);
 
   ASSERT_SUCCESS(clSetKernelArgMemPointerINTEL(kernel, 1, offset_device_ptr));
   ASSERT_SUCCESS(clSetKernelArg(kernel, 2, sizeof(cl_mem),
@@ -655,8 +655,8 @@ TEST_F(USMVectorAddKernelTest, MultipleKernels) {
 
   // Set original kernel arguments
   const size_t half_bytes = bytes / 2;
-  void *offset_device_ptr = getPointerOffset(device_ptr, half_bytes);
-  void *offset_deviceB_ptr = getPointerOffset(device_ptrB, half_bytes);
+  const void *offset_device_ptr = getPointerOffset(device_ptr, half_bytes);
+  const void *offset_deviceB_ptr = getPointerOffset(device_ptrB, half_bytes);
 
   ASSERT_SUCCESS(clSetKernelArgMemPointerINTEL(kernel, 0, device_ptr));
   ASSERT_SUCCESS(clSetKernelArgMemPointerINTEL(kernel, 1, offset_device_ptr));
@@ -694,8 +694,8 @@ TEST_F(USMVectorAddKernelTest, MultipleKernels) {
 TEST_F(USMVectorAddKernelTest, RepeatedEnqueue) {
   // Set kernel arguments
   const size_t half_bytes = bytes / 2;
-  void *offset_device_ptr = getPointerOffset(device_ptr, half_bytes);
-  void *offset_deviceB_ptr = getPointerOffset(device_ptrB, half_bytes);
+  const void *offset_device_ptr = getPointerOffset(device_ptr, half_bytes);
+  const void *offset_deviceB_ptr = getPointerOffset(device_ptrB, half_bytes);
 
   ASSERT_SUCCESS(clSetKernelArgMemPointerINTEL(kernel, 0, device_ptr));
   ASSERT_SUCCESS(clSetKernelArgMemPointerINTEL(kernel, 1, offset_device_ptr));

--- a/source/cl/test/UnitCL/source/cl_intel_unified_shared_memory/usm_kernel_exec_info.cpp
+++ b/source/cl/test/UnitCL/source/cl_intel_unified_shared_memory/usm_kernel_exec_info.cpp
@@ -398,7 +398,7 @@ TEST_F(USMIndirectAccessTest, IndirectDevicePointer) {
                                 static_cast<void *>(&output_buffer)));
 
   // Pass indirect USM pointers to runtime
-  void *indirect_usm_pointers[1] = {device_ptr};
+  const void *indirect_usm_pointers[1] = {device_ptr};
   const cl_int err = clSetKernelExecInfo(
       kernel, CL_KERNEL_EXEC_INFO_USM_PTRS_INTEL, sizeof(void *),
       static_cast<void *>(indirect_usm_pointers));
@@ -432,7 +432,7 @@ TEST_F(USMIndirectAccessTest, IndirectHostPointer) {
   ASSERT_SUCCESS(clSetKernelArgMemPointerINTEL(kernel, 1, device_ptr));
 
   // Pass indirect USM pointers to runtime
-  void *indirect_usm_pointers[1] = {host_ptr};
+  const void *indirect_usm_pointers[1] = {host_ptr};
   const cl_int err = clSetKernelExecInfo(
       kernel, CL_KERNEL_EXEC_INFO_USM_PTRS_INTEL, sizeof(void *),
       static_cast<void *>(indirect_usm_pointers));
@@ -466,7 +466,7 @@ TEST_F(USMIndirectAccessTest, IndirectSharedPointer) {
   ASSERT_SUCCESS(clSetKernelArgMemPointerINTEL(kernel, 1, device_ptr));
 
   // Pass indirect USM pointers to runtime
-  void *indirect_usm_pointers[1] = {shared_ptr};
+  const void *indirect_usm_pointers[1] = {shared_ptr};
   const cl_int err = clSetKernelExecInfo(
       kernel, CL_KERNEL_EXEC_INFO_USM_PTRS_INTEL, sizeof(void *),
       static_cast<void *>(indirect_usm_pointers));
@@ -510,7 +510,7 @@ TEST_F(USMIndirectAccessTest, IndirectDevicePtrInsideHostPtr) {
                                 static_cast<void *>(&output_buffer)));
 
   // Pass indirect USM pointers to runtime
-  void *indirect_usm_pointers[1] = {device_ptr};
+  const void *indirect_usm_pointers[1] = {device_ptr};
   const cl_int err = clSetKernelExecInfo(
       kernel, CL_KERNEL_EXEC_INFO_USM_PTRS_INTEL, sizeof(void *),
       static_cast<void *>(indirect_usm_pointers));
@@ -545,7 +545,7 @@ TEST_F(USMIndirectAccessTest, IndirectDevicePtrThenHostPtr) {
                                 static_cast<void *>(&output_buffer)));
 
   // Pass indirect device USM pointer to runtime
-  void *indirect_usm_pointers[1] = {device_ptr};
+  const void *indirect_usm_pointers[1] = {device_ptr};
   cl_int err = clSetKernelExecInfo(kernel, CL_KERNEL_EXEC_INFO_USM_PTRS_INTEL,
                                    sizeof(void *),
                                    static_cast<void *>(indirect_usm_pointers));
@@ -606,7 +606,7 @@ TEST_F(USMIndirectAccessTest, IndirectDevicePtrAndHostPtr) {
 
   // Pass both USM pointers to runtime as used indirectly, but only use one in
   // each execution
-  void *indirect_usm_pointers[2] = {device_ptr, host_ptr};
+  const void *indirect_usm_pointers[2] = {device_ptr, host_ptr};
   const cl_int err = clSetKernelExecInfo(
       kernel, CL_KERNEL_EXEC_INFO_USM_PTRS_INTEL, sizeof(void *),
       static_cast<void *>(indirect_usm_pointers));
@@ -657,7 +657,7 @@ TEST_F(USMIndirectAccessTest, OffsetDevicePointer) {
                                 static_cast<void *>(&output_buffer)));
 
   // Pass base device USM pointer to runtime as used indirectly
-  void *indirect_usm_pointers[1] = {device_ptr};
+  const void *indirect_usm_pointers[1] = {device_ptr};
   const cl_int err = clSetKernelExecInfo(
       kernel, CL_KERNEL_EXEC_INFO_USM_PTRS_INTEL, sizeof(void *),
       static_cast<void *>(indirect_usm_pointers));
@@ -865,7 +865,7 @@ TEST_F(USMIndirectAccessTest, DeviceFlagAndExplicitPtr) {
   ASSERT_TRUE(deferred_device_alloc != nullptr);
 
   // Specify deferred device allocation pointer will be used explicitly
-  void *indirect_usm_pointers[1] = {deferred_device_alloc};
+  const void *indirect_usm_pointers[1] = {deferred_device_alloc};
   err = clSetKernelExecInfo(kernel, CL_KERNEL_EXEC_INFO_USM_PTRS_INTEL,
                             sizeof(void *),
                             static_cast<void *>(indirect_usm_pointers));
@@ -943,7 +943,7 @@ TEST_F(USMIndirectAccessTest, DisableAllFlags) {
   EXPECT_SUCCESS(err);
 
   // Explicitly set that device_ptr is used indirectly by the kernel.
-  void *indirect_usm_pointers[1] = {device_ptr};
+  const void *indirect_usm_pointers[1] = {device_ptr};
   err = clSetKernelExecInfo(kernel, CL_KERNEL_EXEC_INFO_USM_PTRS_INTEL,
                             sizeof(void *),
                             static_cast<void *>(indirect_usm_pointers));

--- a/source/cl/test/UnitCL/source/cl_intel_unified_shared_memory/usm_mem_cpy.cpp
+++ b/source/cl/test/UnitCL/source/cl_intel_unified_shared_memory/usm_mem_cpy.cpp
@@ -281,7 +281,7 @@ TYPED_TEST(USMMemCpyTest, DeviceToDevice) {
     reference1.fill(pattern1);
     reference2.fill(pattern2);
 
-    void *offset_host_ptr = getPointerOffset(host_ptr_A, offset);
+    const void *offset_host_ptr = getPointerOffset(host_ptr_A, offset);
     const char *tested_type_string = test_patterns<TypeParam>::as_string;
     EXPECT_TRUE(0 == std::memcmp(reference2.data(), host_ptr_A, offset))
         << "For type " << tested_type_string;
@@ -637,7 +637,7 @@ TYPED_TEST(USMMemCpyTest, DeviceToUser) {
   reference1.fill(pattern1);
   reference2.fill(pattern2);
 
-  void *offset_user_ptr = getPointerOffset(user_data, offset);
+  const void *offset_user_ptr = getPointerOffset(user_data, offset);
   const char *tested_type_string = test_patterns<TypeParam>::as_string;
 
   EXPECT_TRUE(0 == std::memcmp(reference1.data(), user_data, offset))

--- a/source/cl/test/UnitCL/source/cl_intel_unified_shared_memory/usm_mem_info.cpp
+++ b/source/cl/test/UnitCL/source/cl_intel_unified_shared_memory/usm_mem_info.cpp
@@ -115,7 +115,7 @@ TEST_F(USMMemInfoTest, AllocType) {
     EXPECT_SUCCESS(err);
     EXPECT_EQ(sizeof(cl_unified_shared_memory_type_intel), param_size);
 
-    void *offset_host_ptr = getPointerOffset(host_ptr, sizeof(cl_int));
+    const void *offset_host_ptr = getPointerOffset(host_ptr, sizeof(cl_int));
     cl_unified_shared_memory_type_intel host_alloc_type = 0;
     err = clGetMemAllocInfoINTEL(
         context, offset_host_ptr, CL_MEM_ALLOC_TYPE_INTEL,
@@ -130,7 +130,8 @@ TEST_F(USMMemInfoTest, AllocType) {
     EXPECT_SUCCESS(err);
     EXPECT_EQ(sizeof(cl_unified_shared_memory_type_intel), param_size);
 
-    void *offset_shared_ptr = getPointerOffset(shared_ptr, sizeof(cl_int));
+    const void *offset_shared_ptr =
+        getPointerOffset(shared_ptr, sizeof(cl_int));
     cl_unified_shared_memory_type_intel shared_alloc_type = 0;
     err = clGetMemAllocInfoINTEL(
         context, offset_shared_ptr, CL_MEM_ALLOC_TYPE_INTEL,
@@ -139,7 +140,7 @@ TEST_F(USMMemInfoTest, AllocType) {
     EXPECT_EQ(CL_MEM_TYPE_SHARED_INTEL, shared_alloc_type);
   }
 
-  void *offset_device_ptr = getPointerOffset(device_ptr, sizeof(cl_int));
+  const void *offset_device_ptr = getPointerOffset(device_ptr, sizeof(cl_int));
 
   cl_unified_shared_memory_type_intel alloc_type = 0;
   err = clGetMemAllocInfoINTEL(context, offset_device_ptr,
@@ -173,8 +174,8 @@ TEST_F(USMMemInfoTest, AllocBasePtr) {
     EXPECT_SUCCESS(err);
     EXPECT_EQ(sizeof(void *), param_size);
 
-    void *offset_host_ptr = getPointerOffset(host_ptr, sizeof(cl_int));
-    void *host_alloc_base_addr = nullptr;
+    const void *offset_host_ptr = getPointerOffset(host_ptr, sizeof(cl_int));
+    const void *host_alloc_base_addr = nullptr;
 
     err = clGetMemAllocInfoINTEL(
         context, offset_host_ptr, CL_MEM_ALLOC_BASE_PTR_INTEL,
@@ -192,8 +193,9 @@ TEST_F(USMMemInfoTest, AllocBasePtr) {
     EXPECT_SUCCESS(err);
     EXPECT_EQ(sizeof(void *), param_size);
 
-    void *offset_shared_ptr = getPointerOffset(shared_ptr, sizeof(cl_int));
-    void *shared_alloc_base_addr = nullptr;
+    const void *offset_shared_ptr =
+        getPointerOffset(shared_ptr, sizeof(cl_int));
+    const void *shared_alloc_base_addr = nullptr;
 
     err = clGetMemAllocInfoINTEL(
         context, offset_shared_ptr, CL_MEM_ALLOC_BASE_PTR_INTEL,
@@ -204,7 +206,7 @@ TEST_F(USMMemInfoTest, AllocBasePtr) {
     EXPECT_EQ(shared_ptr, shared_alloc_base_addr);
   }
 
-  void *offset_device_ptr = getPointerOffset(device_ptr, sizeof(cl_int));
+  const void *offset_device_ptr = getPointerOffset(device_ptr, sizeof(cl_int));
   void *alloc_base_addr = nullptr;
 
   err = clGetMemAllocInfoINTEL(
@@ -240,7 +242,7 @@ TEST_F(USMMemInfoTest, AllocSize) {
     EXPECT_SUCCESS(err);
     EXPECT_EQ(sizeof(size_t), param_size);
 
-    void *offset_host_ptr = getPointerOffset(host_ptr, sizeof(cl_int));
+    const void *offset_host_ptr = getPointerOffset(host_ptr, sizeof(cl_int));
     size_t host_alloc_size = 0;
 
     err = clGetMemAllocInfoINTEL(
@@ -256,7 +258,8 @@ TEST_F(USMMemInfoTest, AllocSize) {
     EXPECT_SUCCESS(err);
     EXPECT_EQ(sizeof(size_t), param_size);
 
-    void *offset_shared_ptr = getPointerOffset(shared_ptr, sizeof(cl_int));
+    const void *offset_shared_ptr =
+        getPointerOffset(shared_ptr, sizeof(cl_int));
     size_t shared_alloc_size = 0;
 
     err = clGetMemAllocInfoINTEL(
@@ -266,7 +269,7 @@ TEST_F(USMMemInfoTest, AllocSize) {
     EXPECT_EQ(bytes, shared_alloc_size);
   }
 
-  void *offset_device_ptr = getPointerOffset(device_ptr, sizeof(cl_int));
+  const void *offset_device_ptr = getPointerOffset(device_ptr, sizeof(cl_int));
 
   size_t alloc_size = 0;
   err = clGetMemAllocInfoINTEL(context, offset_device_ptr,
@@ -299,7 +302,7 @@ TEST_F(USMMemInfoTest, AllocDevice) {
                                  0, nullptr, &param_size);
     EXPECT_SUCCESS(err);
     EXPECT_EQ(sizeof(cl_device_id), param_size);
-    void *offset_host_ptr = getPointerOffset(host_ptr, sizeof(cl_int));
+    const void *offset_host_ptr = getPointerOffset(host_ptr, sizeof(cl_int));
 
     cl_device_id host_alloc_device = device;
     err = clGetMemAllocInfoINTEL(
@@ -315,7 +318,8 @@ TEST_F(USMMemInfoTest, AllocDevice) {
                                  0, nullptr, &param_size);
     EXPECT_SUCCESS(err);
     EXPECT_EQ(sizeof(cl_device_id), param_size);
-    void *offset_shared_ptr = getPointerOffset(shared_ptr, sizeof(cl_int));
+    const void *offset_shared_ptr =
+        getPointerOffset(shared_ptr, sizeof(cl_int));
 
     cl_device_id shared_alloc_device = device;
     err = clGetMemAllocInfoINTEL(
@@ -326,7 +330,7 @@ TEST_F(USMMemInfoTest, AllocDevice) {
     EXPECT_EQ(device, shared_alloc_device);
   }
 
-  void *offset_device_ptr = getPointerOffset(device_ptr, sizeof(cl_int));
+  const void *offset_device_ptr = getPointerOffset(device_ptr, sizeof(cl_int));
   cl_device_id alloc_device = NULL;
   err = clGetMemAllocInfoINTEL(context, offset_device_ptr,
                                CL_MEM_ALLOC_DEVICE_INTEL, sizeof(alloc_device),
@@ -361,7 +365,7 @@ TEST_F(USMMemInfoTest, AllocFlags) {
     EXPECT_SUCCESS(err);
     EXPECT_EQ(sizeof(cl_mem_alloc_flags_intel), param_size);
 
-    void *offset_host_ptr = getPointerOffset(host_ptr, sizeof(cl_int));
+    const void *offset_host_ptr = getPointerOffset(host_ptr, sizeof(cl_int));
 
     cl_mem_alloc_flags_intel host_alloc_flags = 0;
     err = clGetMemAllocInfoINTEL(
@@ -377,7 +381,8 @@ TEST_F(USMMemInfoTest, AllocFlags) {
     EXPECT_SUCCESS(err);
     EXPECT_EQ(sizeof(cl_mem_alloc_flags_intel), param_size);
 
-    void *offset_shared_ptr = getPointerOffset(shared_ptr, sizeof(cl_int));
+    const void *offset_shared_ptr =
+        getPointerOffset(shared_ptr, sizeof(cl_int));
 
     cl_mem_alloc_flags_intel shared_alloc_flags = 0;
     err = clGetMemAllocInfoINTEL(
@@ -387,7 +392,7 @@ TEST_F(USMMemInfoTest, AllocFlags) {
     EXPECT_EQ(0, shared_alloc_flags);
   }
 
-  void *offset_device_ptr = getPointerOffset(device_ptr, sizeof(cl_int));
+  const void *offset_device_ptr = getPointerOffset(device_ptr, sizeof(cl_int));
 
   cl_mem_alloc_flags_intel alloc_flags = 0;
   err = clGetMemAllocInfoINTEL(context, offset_device_ptr,

--- a/source/cl/test/UnitCL/source/cl_intel_unified_shared_memory/usm_mem_set.cpp
+++ b/source/cl/test/UnitCL/source/cl_intel_unified_shared_memory/usm_mem_set.cpp
@@ -98,7 +98,7 @@ TEST_F(USMMemSetTest, DeviceAllocation) {
   EXPECT_SUCCESS(clFinish(queue));
 
   if (host_ptr) {
-    cl_int *host_validation_ptr = reinterpret_cast<cl_int *>(host_ptr);
+    const cl_int *host_validation_ptr = reinterpret_cast<cl_int *>(host_ptr);
     const cl_int correct_result[8] = {CL_INT_MAX, 0xA,        0xA,
                                       0xA,        CL_INT_MIN, CL_INT_MIN,
                                       CL_INT_MIN, CL_INT_MIN};
@@ -138,7 +138,7 @@ TEST_F(USMMemSetTest, SharedAllocation) {
   EXPECT_SUCCESS(clFinish(queue));
 
   if (host_ptr) {
-    cl_int *host_validation_ptr = reinterpret_cast<cl_int *>(host_ptr);
+    const cl_int *host_validation_ptr = reinterpret_cast<cl_int *>(host_ptr);
     const cl_int correct_result[8] = {CL_INT_MAX, 0xA,        0xA,
                                       0xA,        CL_INT_MIN, CL_INT_MIN,
                                       CL_INT_MIN, CL_INT_MIN};

--- a/source/cl/test/UnitCL/source/kts/relationals.cpp
+++ b/source/cl/test/UnitCL/source/kts/relationals.cpp
@@ -324,7 +324,7 @@ void OneArgRelational::TestAgainstReference(const char *builtin,
     // Map buffers to verify results
     cargo::small_vector<void *, 2> mapped_ptrs;
     ReadMapBuffers<2>(mapped_ptrs);
-    T *input = (T *)mapped_ptrs[0];
+    const T *input = (T *)mapped_ptrs[0];
     void *output = mapped_ptrs[1];
 
     // Verify correct result
@@ -476,8 +476,8 @@ void TwoArgRelational::TestAgainstReference(
     // Map buffers to verify data
     cargo::small_vector<void *, 3> mapped_ptrs;
     ReadMapBuffers<3>(mapped_ptrs);
-    T *input1 = (T *)mapped_ptrs[0];
-    T *input2 = (T *)mapped_ptrs[1];
+    const T *input1 = (T *)mapped_ptrs[0];
+    const T *input2 = (T *)mapped_ptrs[1];
     void *output = mapped_ptrs[2];
 
     for (size_t i = 0; i < scalar_elems; ++i) {
@@ -607,10 +607,10 @@ void BitSelectTest::TestAgainstReference(const std::function<U(U, U, U)> &ref) {
     // Map buffers so we can verify results
     cargo::small_vector<void *, 4> mapped_ptrs;
     ReadMapBuffers<4>(mapped_ptrs);
-    U *input1 = (U *)mapped_ptrs[0];
-    U *input2 = (U *)mapped_ptrs[1];
-    U *input3 = (U *)mapped_ptrs[2];
-    U *output = (U *)mapped_ptrs[3];
+    const U *input1 = (U *)mapped_ptrs[0];
+    const U *input2 = (U *)mapped_ptrs[1];
+    const U *input3 = (U *)mapped_ptrs[2];
+    const U *output = (U *)mapped_ptrs[3];
 
     for (size_t i = 0; i < scalar_elems; ++i) {
       // Ignore sneaky 4th element of vec3
@@ -748,10 +748,10 @@ void SelectTest::TestAgainstReference(const std::function<T(T, T, U)> &ref,
     // Map Buffers for reading
     cargo::small_vector<void *, 4> mapped_ptrs;
     ReadMapBuffers<4>(mapped_ptrs);
-    T *input1 = (T *)mapped_ptrs[0];
-    T *input2 = (T *)mapped_ptrs[1];
-    U *input3 = (U *)mapped_ptrs[2];
-    T *output = (T *)mapped_ptrs[3];
+    const T *input1 = (T *)mapped_ptrs[0];
+    const T *input2 = (T *)mapped_ptrs[1];
+    const U *input3 = (U *)mapped_ptrs[2];
+    const T *output = (T *)mapped_ptrs[3];
 
     for (size_t i = 0; i < scalar_elems; ++i) {
       // Ignore sneaky 4th element of vec3

--- a/source/cl/test/UnitCL/source/ktst_spirv.cpp
+++ b/source/cl/test/UnitCL/source/ktst_spirv.cpp
@@ -96,7 +96,7 @@ struct Simple {
 
 // SPIR-V CTS tests copied into UnitCL to test regression on CA-1526
 static std::ostream &operator<<(std::ostream &stream, const Simple &data) {
-  stream << "{" << data.a << ", " << data.b << "}";
+  stream << "{" << data.a << ", " << static_cast<int>(data.b) << "}";
   return stream;
 }
 

--- a/source/cl/test/UnitCL/source/main.cpp
+++ b/source/cl/test/UnitCL/source/main.cpp
@@ -288,7 +288,7 @@ int main(int argc, char **argv) {
   // Let Google Test parse the arguments first
   testing::InitGoogleTest(&argc, argv);
 
-  testing::Environment *const environment =
+  const testing::Environment *const environment =
       testing::AddGlobalTestEnvironment(ucl::Environment::instance);
 
   if (environment != ucl::Environment::instance) {

--- a/source/cl/tools/oclc/oclc.cpp
+++ b/source/cl/tools/oclc/oclc.cpp
@@ -342,7 +342,7 @@ bool oclc::Driver::VerifySignedInt(const std::vector<std::string> &vec) {
 
 bool oclc::Driver::VerifyDoubleVec(const std::vector<std::string> &vec) {
   for (const std::string &s : vec) {
-    char *doubleEnd = VerifyDouble(s);
+    const char *doubleEnd = VerifyDouble(s);
     if (doubleEnd != nullptr && *doubleEnd == '\0') {
       return false;
     }
@@ -1667,7 +1667,7 @@ bool oclc::Driver::EnqueueKernel() {
 
     std::string raw_type_name(param_type_name);
     // if the current argument has a typedefed type, swap it out
-    char *is_buf = strchr(param_type_name, '*');
+    const char *is_buf = strchr(param_type_name, '*');
     if (is_buf) {
       raw_type_name = raw_type_name.substr(0, (is_buf - param_type_name));
     }
@@ -1683,10 +1683,10 @@ bool oclc::Driver::EnqueueKernel() {
     }
 
     // If we have a star in it treat it as a buffer
-    char *is_image1d = strstr(param_type_name, "image1d_t");
-    char *is_image2d = strstr(param_type_name, "image2d_t");
-    char *is_image3d = strstr(param_type_name, "image3d_t");
-    char *is_sampler = strstr(param_type_name, "sampler_t");
+    const char *is_image1d = strstr(param_type_name, "image1d_t");
+    const char *is_image2d = strstr(param_type_name, "image2d_t");
+    const char *is_image3d = strstr(param_type_name, "image3d_t");
+    const char *is_sampler = strstr(param_type_name, "sampler_t");
     const bool is_scalar = type_name_to_size_map.count(raw_type_name) != 0;
 
     const size_t vecSizeIndex = raw_type_name.find_first_of("1248");
@@ -1963,9 +1963,9 @@ bool oclc::Driver::EnqueueKernel() {
     OCLC_CHECK_CL(err, "Setting kernel argument failed");
   }
 
-  size_t *local_data = local_work_size_.empty()
-                           ? nullptr
-                           : local_work_size_[local_work_size_index].data();
+  const size_t *local_data =
+      local_work_size_.empty() ? nullptr
+                               : local_work_size_[local_work_size_index].data();
   // Enqueue kernel
   if (execute_) {
     err =

--- a/source/vk/test/UnitVK/source/CmdPushConstants.cpp
+++ b/source/vk/test/UnitVK/source/CmdPushConstants.cpp
@@ -89,8 +89,8 @@ class CmdPushConstants : public uvk::PipelineTest,
     pushConstantRange.size = sizeof(pushConstant);
     pushConstantRange.stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;
 
-    VkDescriptorSetLayout layouts[2] = {descriptorSetLayout,
-                                        descriptorSetLayout};
+    const VkDescriptorSetLayout layouts[2] = {descriptorSetLayout,
+                                              descriptorSetLayout};
 
     pipelineLayoutCreateInfo.pushConstantRangeCount = 1;
     pipelineLayoutCreateInfo.pPushConstantRanges = &pushConstantRange;
@@ -295,7 +295,7 @@ TEST_F(CmdPushConstants, DefaultBindUnusedDescriptorSet) {
 
   vkUpdateDescriptorSets(device, 1, &write, 0, nullptr);
 
-  VkDescriptorSet sets[2] = {descriptorSet, descriptorSetB};
+  const VkDescriptorSet sets[2] = {descriptorSet, descriptorSetB};
 
   vkCmdBindPipeline(commandBuffer, VK_PIPELINE_BIND_POINT_COMPUTE, pipeline);
   vkCmdBindDescriptorSets(commandBuffer, VK_PIPELINE_BIND_POINT_COMPUTE,

--- a/source/vk/test/UnitVK/source/CmdWaitEvents.cpp
+++ b/source/vk/test/UnitVK/source/CmdWaitEvents.cpp
@@ -195,7 +195,7 @@ TEST_F(CmdWaitEventsCommandBuffers, MultipleCommandBuffers) {
 
   ASSERT_EQ_RESULT(VK_SUCCESS, vkEndCommandBuffer(commandBuffer));
 
-  VkCommandBuffer commandBuffers[] = {commandBuffer2, commandBuffer};
+  const VkCommandBuffer commandBuffers[] = {commandBuffer2, commandBuffer};
   submitInfo.commandBufferCount = 2;
   submitInfo.pCommandBuffers = commandBuffers;
 

--- a/source/vk/test/UnitVK/source/FlushMappedMemoryRanges.cpp
+++ b/source/vk/test/UnitVK/source/FlushMappedMemoryRanges.cpp
@@ -284,8 +284,8 @@ TEST_F(FlushMappedMemoryRanges, Default) {
   ASSERT_EQ_RESULT(VK_SUCCESS, vkInvalidateMappedMemoryRanges(
                                    device, 1, &flushMappedMemoryRange));
 
-  uint32_t *resultMemory = static_cast<uint32_t *>(mappedMemory) +
-                           (alignedBufferSize / sizeof(uint32_t));
+  const uint32_t *resultMemory = static_cast<uint32_t *>(mappedMemory) +
+                                 (alignedBufferSize / sizeof(uint32_t));
 
   // validate results
   for (uint32_t k = 0; k < bufferElements; k++) {

--- a/source/vk/test/UnitVK/source/Semaphores.cpp
+++ b/source/vk/test/UnitVK/source/Semaphores.cpp
@@ -227,7 +227,7 @@ TEST_F(Semaphores, TwoSemaphores) {
 
   ASSERT_EQ_RESULT(VK_SUCCESS, vkEndCommandBuffer(commandBuffer2));
 
-  VkSemaphore semaphores[] = {semaphore, semaphore2};
+  const VkSemaphore semaphores[] = {semaphore, semaphore2};
   submitInfo.commandBufferCount = 1;
   submitInfo.pCommandBuffers = &commandBuffer2;
   submitInfo.signalSemaphoreCount = 2;
@@ -301,7 +301,7 @@ TEST_F(Semaphores, TwoCommandBuffers) {
 
   ASSERT_EQ_RESULT(VK_SUCCESS, vkEndCommandBuffer(commandBuffer));
 
-  VkCommandBuffer commandBuffers[] = {commandBuffer2, commandBuffer};
+  const VkCommandBuffer commandBuffers[] = {commandBuffer2, commandBuffer};
 
   submitInfo.commandBufferCount = 2;
   submitInfo.pCommandBuffers = commandBuffers;


### PR DESCRIPTION
# Overview

Address more clang & clang-tidy warnings.

# Reason for change

*Describe how the current behaviour of the project is causing problems for you
or is otherwise unsatisfactory for your use case.*

# Description of change

* Add more const where we can.
* Use contains() rather than count() to check for existence.
* Stop looking up options through llvm::cl::getRegisteredOptions() when we can use their corresponding variables instead.
* Stop creating unused .blend PHI nodes.
* Enforce W^X in our loader.
* Use remove_if() rather than stable_partition() to remove released semaphores.
* Ensure driver::CompilerInfo is always initialized.

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-19](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
