### PR TITLE
Fix hal_remote build

### DIFF
--- a/hal/hal_remote/include/hal_remote/hal_server.h
+++ b/hal/hal_remote/include/hal_remote/hal_server.h
@@ -59,24 +59,24 @@ class hal_server {
     status_decode_failed
   };
   hal_server(hal::hal_transmitter *transmitter, hal::hal_t *hal);
+  ~hal_server();
 
-  virtual error_code process_commands();
+  error_code process_commands();
 
  protected:
-  ~hal_server();
-  virtual error_code process_command();
-  virtual hal_server::error_code process_mem_alloc(uint32_t device);
-  virtual hal_server::error_code process_mem_free(uint32_t device);
-  virtual hal_server::error_code process_mem_write(uint32_t device);
-  virtual hal_server::error_code process_mem_read(uint32_t device);
-  virtual hal_server::error_code process_mem_fill(uint32_t device);
-  virtual hal_server::error_code process_mem_copy(uint32_t device);
-  virtual hal_server::error_code process_program_free(uint32_t device);
-  virtual hal_server::error_code process_find_kernel(uint32_t device);
-  virtual hal_server::error_code process_program_load(uint32_t device);
-  virtual hal_server::error_code process_kernel_exec(uint32_t device);
-  virtual hal_server::error_code process_device_create(uint32_t device);
-  virtual hal_server::error_code process_device_delete(uint32_t device);
+  error_code process_command();
+  hal_server::error_code process_mem_alloc(uint32_t device);
+  hal_server::error_code process_mem_free(uint32_t device);
+  hal_server::error_code process_mem_write(uint32_t device);
+  hal_server::error_code process_mem_read(uint32_t device);
+  hal_server::error_code process_mem_fill(uint32_t device);
+  hal_server::error_code process_mem_copy(uint32_t device);
+  hal_server::error_code process_program_free(uint32_t device);
+  hal_server::error_code process_find_kernel(uint32_t device);
+  hal_server::error_code process_program_load(uint32_t device);
+  hal_server::error_code process_kernel_exec(uint32_t device);
+  hal_server::error_code process_device_create(uint32_t device);
+  hal_server::error_code process_device_delete(uint32_t device);
 
   error_code receive_payload(hal_binary_encoder::COMMAND command,
                              std::vector<uint8_t> &payload);


### PR DESCRIPTION
# Overview

Fix hal_remote build

# Reason for change

The previous attempt to address the issue raised by clang-tidy (virtual class with public non-virtual destructor) was not right: hal_server is constructed directly, not through any derived class.

# Description of change

hal_server is never derived from, so we can make it a non-virtual class instead.

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-19](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
