### PR TITLE
Update city runner to always output xfails

### DIFF
--- a/scripts/testing/city_runner/test_info.py
+++ b/scripts/testing/city_runner/test_info.py
@@ -357,6 +357,7 @@ class TestResults(object):
         self.timeout_list = []
         self.xpass_list = []
         self.mayfail_list = []
+        self.xfail_list = []
 
         for test in self.tests:
             try:
@@ -372,6 +373,8 @@ class TestResults(object):
                     self.xpass_list.append(run)
                 elif run.status == "MAYFAIL":
                     self.mayfail_list.append(run)
+                elif run.status == "XFAIL":
+                    self.xfail_list.append(run)
         for test in not_runs:
             run = profile.create_run(test)
             run.status = "FAIL"

--- a/scripts/testing/city_runner/ui.py
+++ b/scripts/testing/city_runner/ui.py
@@ -109,6 +109,18 @@ class TestUI(object):
         cts_fail_rate = self.calc_progress(results.num_total_cts-results.num_passes_cts,
                                            results.num_total_cts, 1)
         self.start_message(self.MESSAGE_TYPE_RESULTS)
+        if results.xfail_list:
+            self.out.write(self.fmt.red("XFailed tests (as expected):\n"))
+            for run in results.xfail_list:
+                self.out.write("  %s\n" % run.test.name)
+            self.out.write("\n")
+
+        if results.mayfail_list:
+            self.out.write(self.fmt.red("May Fail failing tests:\n"))
+            for run in results.mayfail_list:
+                self.out.write("  %s\n" % run.test.name)
+            self.out.write("\n")
+
         if results.fail_list:
             self.out.write(self.fmt.red("Failed tests:\n"))
             for run in results.fail_list:
@@ -118,12 +130,6 @@ class TestUI(object):
         if results.xpass_list:
             self.out.write(self.fmt.red("Unexpected passing XFail tests:\n"))
             for run in results.xpass_list:
-                self.out.write("  %s\n" % run.test.name)
-            self.out.write("\n")
-
-        if results.mayfail_list:
-            self.out.write(self.fmt.red("May Fail failing tests:\n"))
-            for run in results.mayfail_list:
                 self.out.write("  %s\n" % run.test.name)
             self.out.write("\n")
 


### PR DESCRIPTION
# Overview

Added an xfail_list to city runner which is output at the end.

# Reason for change

For clarity, we wish to see any expected fails in the summary at the end.
