### PR TITLE
Set minimum cmake version via cmake options to 3.5

### DIFF
--- a/.github/actions/setup_build/action.yml
+++ b/.github/actions/setup_build/action.yml
@@ -43,6 +43,7 @@ runs:
       if: ${{ inputs.os == 'windows' }}
       shell: pwsh
       run: |
+        choco install --yes cmake --allow-downgrade --version=3.30.1
         Invoke-WebRequest  https://sdk.lunarg.com/sdk/download/1.3.283.0/windows/VulkanSDK-1.3.283.0-Installer.exe -OutFile Installer.exe
         .\Installer.exe --accept-licenses --default-answer --confirm-command install
         rm Installer.exe


### PR DESCRIPTION
# Overview

Windows build was complaining because the ICD loader minumum version was < 3.5. This fixes this until they have updated that.
