### PR TITLE
SYCL_CTS CI for RISC-V on Opencl & Native_cpu

### DIFF
--- a/.github/actions/do_build_dpcpp/action.yml
+++ b/.github/actions/do_build_dpcpp/action.yml
@@ -64,11 +64,14 @@ runs:
       run: |
         CROSS_OPTS=""
         if [[ "${{inputs.target}}" =~ .*riscv64.* ]] ; then
-          CROSS_OPTS="--cmake-opt=-DCMAKE_TOOLCHAIN_FILE=${{steps.calc_vars.outputs.toolchain}} --cmake-opt=-DLLVM_HOST_TRIPLE=${{steps.calc_vars.outputs.arch}}-unknown-linux-gnu --cmake-opt=-DLLVM_NATIVE_TOOL_DIR=$GITHUB_WORKSPACE/llvm/build/x86_64-linux/install/bin"
+          CROSS_OPTS="--cmake-opt=-DCMAKE_TOOLCHAIN_FILE=${{steps.calc_vars.outputs.toolchain}} \
+                      --cmake-opt=-DLLVM_HOST_TRIPLE=${{steps.calc_vars.outputs.arch}}-unknown-linux-gnu \
+                      --cmake-opt=-DLLVM_NATIVE_TOOL_DIR=$GITHUB_WORKSPACE/llvm/build/x86_64-linux/install/bin"
         fi
         cd llvm
         set -x
-        python3 buildbot/configure.py -o build/${{steps.calc_vars.outputs.arch}}-linux --host-target="X86;AArch64;RISCV" --native_cpu \
+        python3 buildbot/configure.py -o build/${{steps.calc_vars.outputs.arch}}-linux \
+                --host-target="X86;AArch64;RISCV" --native_cpu \
                 --llvm-external-projects=lld --cmake-opt=-DNATIVECPU_USE_OCK=ON \
                 $CROSS_OPTS \
                 --cmake-opt=-DLLVM_ENABLE_ZLIB=OFF --cmake-opt=-DLLVM_ENABLE_ZSTD=OFF

--- a/.github/actions/do_build_dpcpp/action.yml
+++ b/.github/actions/do_build_dpcpp/action.yml
@@ -28,6 +28,22 @@ runs:
         repository: intel/llvm
         path: llvm
 
+    # Note: checkout action (above) cleans "path:". Do native artifact download/unpackage after that.
+    - name: download pre-built native dpc++ artifact for cross builds
+      if: contains(inputs.download_dpcpp_artefact, inputs.target) != true && contains(inputs.target, 'host_riscv')
+      uses: actions/download-artifact@v4
+      with:
+        name: 'dpcpp_host_x86_64_linux'
+        path: llvm/build/x86_64-linux/install
+
+    - name: unpackage native dpc++ artifacts for cross builds # package/unpackage avoids known 'permissions loss' issue
+      if: contains(inputs.download_dpcpp_artefact, inputs.target) != true && contains(inputs.target, 'host_riscv')
+      shell: bash
+      run: |
+        cd llvm/build/x86_64-linux/install
+        tar xf dpcpp.tar
+        rm dpcpp.tar
+
     - name: apply patches
       if: contains(inputs.download_dpcpp_artefact, inputs.target) != true    
       shell: bash
@@ -45,27 +61,29 @@ runs:
     - name: dpcpp configure
       if: contains(inputs.download_dpcpp_artefact, inputs.target) != true
       shell: bash
-      run:
-        cd llvm; python3 buildbot/configure.py
-        -o build
-        --host-target="X86;AArch64;RISCV"
-        --native_cpu
-        --llvm-external-projects=lld
-        --cmake-opt=-DNATIVECPU_USE_OCK=ON
-        --cmake-opt=-DLLVM_ENABLE_ZLIB=OFF
-        --cmake-opt=-DLLVM_ENABLE_ZSTD=OFF
+      run: |
+        CROSS_OPTS=""
+        if [[ "${{inputs.target}}" =~ .*riscv64.* ]] ; then
+          CROSS_OPTS="--cmake-opt=-DCMAKE_TOOLCHAIN_FILE=${{steps.calc_vars.outputs.toolchain}} --cmake-opt=-DLLVM_HOST_TRIPLE=${{steps.calc_vars.outputs.arch}}-unknown-linux-gnu --cmake-opt=-DLLVM_NATIVE_TOOL_DIR=$GITHUB_WORKSPACE/llvm/build/x86_64-linux/install/bin"
+        fi
+        cd llvm
+        set -x
+        python3 buildbot/configure.py -o build/${{steps.calc_vars.outputs.arch}}-linux --host-target="X86;AArch64;RISCV" --native_cpu \
+                --llvm-external-projects=lld --cmake-opt=-DNATIVECPU_USE_OCK=ON \
+                $CROSS_OPTS \
+                --cmake-opt=-DLLVM_ENABLE_ZLIB=OFF --cmake-opt=-DLLVM_ENABLE_ZSTD=OFF
 
     - name: build sycl-headers
       if: contains(inputs.download_dpcpp_artefact, inputs.target) != true
       shell: bash
       run:
-        cmake --build llvm/build -- sycl-headers
+        cmake --build llvm/build/${{steps.calc_vars.outputs.arch}}-linux -- sycl-headers
   
     - name: build dpc plus plus
       if: contains(inputs.download_dpcpp_artefact, inputs.target) != true
       shell: bash
       run:
-       python3 llvm/buildbot/compile.py -o llvm/build -v -j 8
+       python3 llvm/buildbot/compile.py -o llvm/build/${{steps.calc_vars.outputs.arch}}-linux -v -j 8
 
     - name: build extra utilties
       if: contains(inputs.download_dpcpp_artefact, inputs.target) != true
@@ -74,7 +92,7 @@ runs:
       # cross builds. They are enabled on all targets for consistency.
       shell: bash
       run:
-       cmake --build llvm/build -- FileCheck clang-tblgen
+       cmake --build llvm/build/${{steps.calc_vars.outputs.arch}}-linux -- FileCheck clang-tblgen
         libclc-remangler llvm-as llvm-min-tblgen llvm-tblgen not
         opt prepare_builtins -j8
 
@@ -82,34 +100,30 @@ runs:
       if: contains(inputs.download_dpcpp_artefact, inputs.target) != true
       shell: bash
       run:
-        cd llvm/build/bin;
+        cd llvm/build//${{steps.calc_vars.outputs.arch}}-linux/bin;
         cp FileCheck clang-tblgen libclc-remangler llvm-as llvm-min-tblgen
         llvm-tblgen not opt prepare_builtins ../install/bin
 
-    # TODO: For now just linux x86_64
-    #       Review for location of components (paths) and any archive package/unpackage reqs.
-    #- name: install config files to pick up libraries for cross compilation.
-    #  if: contains(inputs.download_dpcpp_artefact, inputs.target) != true
-    #  shell: bash
-    #  run: |
-    #    echo Installing configuration files
-    #    cd llvm/build/bin
-    #    # Install configuration files to pick up libraries for cross compilation.
-    #    for arch in x86_64 aarch64 riscv64; do
-    #      echo "
-    #      -L<CFGDIR>/../../../$arch-linux/install/lib
-    #      -fsycl-libdevice-path=<CFGDIR>/../../../$arch-linux/install/lib
-    #      -fsycl-libspirv-path=<CFGDIR>/../../../$arch-linux/install/lib/clc/remangled-l64-signed_char.libspirv-$arch-unknown-linux-gnu.bc
-    #      " >../install/bin/$arch-unknown-linux-gnu.cfg;
-    #    done
+    - name: install config files to pick up libraries for cross compilation.
+      if: contains(inputs.download_dpcpp_artefact, inputs.target) != true
+      shell: bash
+      run: |
+        echo Installing configuration files
+        cd llvm/build/${{steps.calc_vars.outputs.arch}}-linux/bin
+        # Install configuration files to pick up libraries for cross compilation.
+        for arch in x86_64 aarch64 riscv64; do
+          echo "
+          -L<CFGDIR>/../../../${arch}-linux/install/lib
+          " >../install/bin/${arch}-unknown-linux-gnu.cfg;
+        done
 
     - name: download dpc plus plus from official releases
       # TODO: This is a bit imperfect as it should parse it properly
       if: contains(inputs.download_dpcpp_artefact, inputs.target) && contains(inputs.download_dpcpp_artefact, 'download_release')
       shell: bash
       run: |
-        mkdir -p llvm/build/install
-        cd llvm/build/install
+        mkdir -p llvm/build/${{steps.calc_vars.outputs.arch}}-linux/install
+        cd llvm/build/${{steps.calc_vars.outputs.arch}}-linux/install
         # Get latest build - go back 2 weeks max else fail
         for COUNTER in {0..13}; do
             DATESTAMP=$(date -d "-$COUNTER day" '+%Y-%m-%d')
@@ -127,22 +141,22 @@ runs:
         download_id=`echo $download_id | sed 's/.*${{inputs.target}}=//' | sed 's/;.*//'`
         echo download id is "'$download_id'"
         # TODO : make this work on windows
-        mkdir -p llvm/build/install
+        mkdir -p llvm/build/${{steps.calc_vars.outputs.arch}}-linux/install
         git config --global --add safe.directory $PWD        
-        gh run download $download_id -n dpcpp_${{ inputs.target }} -D llvm/build/install
-        ls llvm/build/install
+        gh run download $download_id -n dpcpp_${{ inputs.target }} -D llvm/build/${{steps.calc_vars.outputs.arch}}-linux/install
+        ls llvm/build/${{steps.calc_vars.outputs.arch}}-linux/install
 
 
     - name: package artefacts  # package/unpackage avoids known 'permissions loss' issue
       shell: bash
       if: contains(inputs.download_dpcpp_artefact, inputs.target) != true
       run: |
-        cd llvm/build/install
+        cd llvm/build/${{steps.calc_vars.outputs.arch}}-linux/install
         tar cf dpcpp.tar *
 
     - name: upload dpcpp artifact
       uses: actions/upload-artifact@v4
       with:
         name: dpcpp_${{inputs.target}}
-        path: llvm/build/install/dpcpp.tar
+        path: llvm/build/${{steps.calc_vars.outputs.arch}}-linux/install/dpcpp.tar
         retention-days: 7

--- a/.github/actions/do_build_sycl_cts/action.yml
+++ b/.github/actions/do_build_sycl_cts/action.yml
@@ -38,18 +38,50 @@ runs:
         name: header_${{inputs.target}}
         path: install_headers
 
-    - name: download dpc++ artifact
-      if: contains(inputs.download_sycl_cts_artefact, inputs.target) != true
+    - name: download native x86_64 dpc++ artifact (for x86_64 & riscv64 qemu)
+      if: contains(inputs.download_sycl_cts_artefact, inputs.target) != true &&
+          ( contains(inputs.target, 'host_x86_64') || contains(inputs.target, 'host_riscv') )
       uses: actions/download-artifact@v4
       with:
-        name: dpcpp_${{inputs.target}}
-        path: install_dpcpp
+        name: dpcpp_host_x86_64_linux
+        path: dpcpp/x86_64-linux/install
 
-    - name: unpackage dpc++ artifacts # package/unpackage avoids known 'permissions loss' issue
-      if: contains(inputs.download_sycl_cts_artefact, inputs.target) != true
+    - name: unpackage native dpc++ artifact (for x86_64 & riscv64) # package/unpackage avoids known 'permissions loss' issue
+      if: contains(inputs.download_sycl_cts_artefact, inputs.target) != true &&
+          ( contains(inputs.target, 'host_x86_64') || contains(inputs.target, 'host_riscv') )
       shell: bash
       run: |
-        cd install_dpcpp
+        cd dpcpp/x86_64-linux/install
+        tar xf dpcpp.tar
+        rm dpcpp.tar
+
+    - name: download native aarch64 dpc++ artifact
+      if: contains(inputs.download_sycl_cts_artefact, inputs.target) != true && contains(inputs.target, 'host_aarch64')
+      uses: actions/download-artifact@v4
+      with:
+        name: dpcpp_host_aarch64_linux
+        path: dpcpp/aarch64-linux/install
+
+    - name: unpackage native aarch64 dpc++ artifact # package/unpackage avoids known 'permissions loss' issue
+      if: contains(inputs.download_sycl_cts_artefact, inputs.target) != true && contains(inputs.target, 'host_aarch64')
+      shell: bash
+      run: |
+        cd dpcpp/aarch64-linux/install
+        tar xf dpcpp.tar
+        rm dpcpp.tar
+
+    - name: download cross riscv64 dpc++ artifact
+      if: contains(inputs.download_sycl_cts_artefact, inputs.target) != true && contains(inputs.target, 'host_riscv')
+      uses: actions/download-artifact@v4
+      with:
+        name: dpcpp_host_riscv64_linux
+        path: dpcpp/riscv64-linux/install
+
+    - name: unpackage cross riscv64 dpc++ artifact # package/unpackage avoids known 'permissions loss' issue
+      if: contains(inputs.download_sycl_cts_artefact, inputs.target) != true && contains(inputs.target, 'host_riscv')
+      shell: bash
+      run: |
+        cd dpcpp/riscv64-linux/install
         tar xf dpcpp.tar
         rm dpcpp.tar
 
@@ -83,16 +115,18 @@ runs:
           DEV_OPTS="-DSYCL_CTS_ENABLE_OPENCL_INTEROP_TESTS=OFF -DDPCPP_FLAGS='-fsycl-targets=native_cpu'"
         fi
         export JOPT="4"
-        if [[ "${{inputs.target}}" =~ .*aarch64.* ]] ; then # needed for cp-graviton runner
-          JOPT="2"
+        export ARCHOPT="x86_64"
+        if [[ "${{inputs.target}}" =~ .*aarch64.* ]] ; then
+          JOPT="2" # needed for cp-graviton runner
+          ARCHOPT="aarch64"
         fi
         set -x
         cmake -S SYCL-CTS.src \
             -GNinja \
             -B SYCL-CTS \
             -DSYCL_IMPLEMENTATION=DPCPP \
-            -DDPCPP_INSTALL_DIR=$GITHUB_WORKSPACE/install_dpcpp \
-            -DCMAKE_CXX_COMPILER="$GITHUB_WORKSPACE/install_dpcpp/bin/clang++" \
+            -DDPCPP_INSTALL_DIR=$GITHUB_WORKSPACE/dpcpp/${ARCHOPT}-linux/install \
+            -DCMAKE_CXX_COMPILER="$GITHUB_WORKSPACE/dpcpp/${ARCHOPT}-linux/install/bin/clang++" \
             -DCMAKE_CXX_FLAGS="--target=${{steps.calc_vars.outputs.arch}}-linux-gnu" \
             -DCMAKE_CXX_LINK_FLAGS="-fuse-ld=lld" \
             ${DEV_OPTS}

--- a/.github/actions/run_sycl_cts/action.yml
+++ b/.github/actions/run_sycl_cts/action.yml
@@ -59,8 +59,7 @@ runs:
     - name: run sycl cts
       shell: bash
       env:
-        PREPEND_PATH: ''  # TODO: have qemu as input and set up this
-        SYCL_CTS_TIMEOUT: '02:00:00'
+        SYCL_CTS_TIMEOUT: '03:30:00'
         SYCL_CTS_FILTER: ''
       run: |
         echo running sycl cts
@@ -73,6 +72,11 @@ runs:
           export ONEAPI_DEVICE_SELECTOR=native_cpu:cpu
         fi
         export CTS_CSV_FILE=$GITHUB_WORKSPACE/scripts/testing/sycl-cts.csv
+        export PREPEND_PATH=""
+        if [[ "${{inputs.target}}" =~ .*riscv64.* ]] ; then
+          PREPEND_PATH="--prepend-path '/usr/bin/qemu-riscv64 -L /usr/riscv64-linux-gnu'"
+        fi
+        echo PREPEND_PATH SETTING: $PREPEND_PATH
 
         # Build override file, all is done first, then the target specific. The last file can overwrite previous overrides.
         python3 scripts/testing/create_override_csv.py -d .github/sycl_cts/ \
@@ -81,7 +85,7 @@ runs:
 
         exitcode=0
         set -x
-        python3 $GITHUB_WORKSPACE/scripts/testing/run_cities.py \
+        RUN_CITIES="python3 $GITHUB_WORKSPACE/scripts/testing/run_cities.py \
           --color=always \
           --timeout $SYCL_CTS_TIMEOUT \
           $PREPEND_PATH \
@@ -93,9 +97,12 @@ runs:
           -r SYCL-CTS/cts.xml \
           -v \
           -o override_combined.csv \
-          $SYCL_CTS_FILTER || exitcode=$?
+          $SYCL_CTS_FILTER"
+        eval $RUN_CITIES || exitcode=$?
 
-        $GITHUB_WORKSPACE/scripts/testing/create_sycl_cts_test_lists.sh $PREPEND_PATH SYCL-CTS $CTS_CSV_FILE csv.txt cts_all.txt
+        RUN_LISTS="$GITHUB_WORKSPACE/scripts/testing/create_sycl_cts_test_lists.sh $PREPEND_PATH SYCL-CTS $CTS_CSV_FILE csv.txt cts_all.txt"
+        eval $RUN_LISTS
+        set +x
         # output a diff of the generated list csv.txt and cts_all.txt
         diff csv.txt cts_all.txt || echo "WARNING - Missing some tests from sycl cts file based on test_all --list-tests - see > above"
         exit $exitcode

--- a/.github/sycl_cts/override_opencl_host_riscv64_linux.csv
+++ b/.github/sycl_cts/override_opencl_host_riscv64_linux.csv
@@ -1,0 +1,1 @@
+SYCL_CTS,test_math_builtin_api "math_builtin_float_half_*" --allow-running-no-tests,Xfail

--- a/.github/workflows/planned_testing_caller_19.yml
+++ b/.github/workflows/planned_testing_caller_19.yml
@@ -38,4 +38,3 @@ jobs:
       # download_ock_artefact: host_x86_64_linux=14225268091;host_aarch64_linux=14225268091;host_riscv64_linux=14225268091
       # download_dpcpp_artefact: host_x86_64_linux=14225268091;host_aarch64_linux=14225268091;host_riscv64_linux=14225268091
       # download_sycl_cts_artefact: host_x86_64_linux=14225268091;host_aarch64_linux=14225268091;host_riscv64_linux=14225268091
-

--- a/.github/workflows/planned_testing_caller_19.yml
+++ b/.github/workflows/planned_testing_caller_19.yml
@@ -31,7 +31,7 @@ jobs:
       # run_internal: true
       # run_external: true
       # build_llvm: true
-      
+
       # # These can be set to a workflow run-id to download from a previous workflow. This can be seen from
       # # the action run of a job or workflow
       # # e.g. https://github.com/uxlfoundation/oneapi-construction-kit/actions/runs/<run-id>/.....

--- a/.github/workflows/planned_testing_caller_19.yml
+++ b/.github/workflows/planned_testing_caller_19.yml
@@ -31,7 +31,7 @@ jobs:
       # run_internal: true
       # run_external: true
       # build_llvm: true
-
+      
       # # These can be set to a workflow run-id to download from a previous workflow. This can be seen from
       # # the action run of a job or workflow
       # # e.g. https://github.com/uxlfoundation/oneapi-construction-kit/actions/runs/<run-id>/.....

--- a/.github/workflows/run_ock_external_tests.yml
+++ b/.github/workflows/run_ock_external_tests.yml
@@ -265,6 +265,8 @@ jobs:
           target: ${{ matrix.target }}
           llvm_version: ${{ inputs.llvm_version }}
 
+  # ALAN TODO: review dpcpp native build for when only target is riscv
+
   build_dpcpp_native:
     needs: [workflow_vars]
     strategy:

--- a/.github/workflows/run_ock_external_tests.yml
+++ b/.github/workflows/run_ock_external_tests.yml
@@ -446,6 +446,30 @@ jobs:
           download_sycl_cts_artefact: ${{ inputs.download_sycl_cts_artefact }}
           sycl_device: opencl
 
+  build_sycl_cts_riscv64_native_cpu:
+    needs: [workflow_vars, build_dpcpp_native, build_dpcpp_cross]
+    runs-on: 'cp-ubuntu-24.04'
+    container:
+      image: 'ghcr.io/uxlfoundation/ock_ubuntu_24.04-x86-64:latest'
+      volumes:
+        - ${{github.workspace}}:${{github.workspace}}
+
+    if: inputs.test_sycl_cts && inputs.native_cpu && contains(inputs.target_list, 'host_riscv64_linux')
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+      - name: set up gh
+        uses: ./.github/actions/setup_gh
+        with:
+          os: 'ubuntu'
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: build sycl cts artefact
+        uses: ./.github/actions/do_build_sycl_cts
+        with:
+          target: host_riscv64_linux
+          download_sycl_cts_artefact: ${{ inputs.download_sycl_cts_artefact }}
+          sycl_device: native_cpu
+
   run_sycl_cts_x86_64_opencl:
     needs: [workflow_vars, create_ock_artefacts_ubuntu, build_dpcpp_native, build_sycl_cts_x86_64_opencl]
     runs-on: 'ubuntu-22.04'
@@ -539,4 +563,23 @@ jobs:
         with:
           target: host_riscv64_linux
           sycl_device: opencl
+          llvm_version: ${{ inputs.llvm_version }}
+
+  run_sycl_cts_riscv64_native_cpu:
+    needs: [workflow_vars, build_dpcpp_native, build_dpcpp_cross, build_sycl_cts_riscv64_native_cpu]
+    runs-on: 'ubuntu-24.04'
+    container:
+      image: 'ghcr.io/uxlfoundation/ock_ubuntu_24.04-x86-64:latest'
+      volumes:
+        - ${{github.workspace}}:${{github.workspace}}
+
+    if: inputs.test_sycl_cts && inputs.native_cpu && contains(inputs.target_list, 'host_riscv64_linux')
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+      - name: run sycl cts
+        uses: ./.github/actions/run_sycl_cts
+        with:
+          target: host_riscv64_linux
+          sycl_device: native_cpu
           llvm_version: ${{ inputs.llvm_version }}

--- a/.github/workflows/run_ock_external_tests.yml
+++ b/.github/workflows/run_ock_external_tests.yml
@@ -202,6 +202,7 @@ jobs:
     if: inputs.test_tornado
     needs: [ workflow_vars, build_icd, create_ock_artefacts_ubuntu ]
     strategy:
+      fail-fast: false  # let all matrix jobs complete
       matrix:
         target: ${{ fromJson(inputs.target_list) }}
         exclude: ${{ fromJson(needs.workflow_vars.outputs.matrix_only_linux_x86_64) }}
@@ -419,6 +420,30 @@ jobs:
           download_sycl_cts_artefact: ${{ inputs.download_sycl_cts_artefact }}
           sycl_device: native_cpu
 
+  build_sycl_cts_riscv64_opencl:
+    needs: [workflow_vars, build_icd, build_dpcpp_native, build_dpcpp_cross]
+    runs-on: 'cp-ubuntu-24.04'
+    container:
+      image: 'ghcr.io/uxlfoundation/ock_ubuntu_24.04-x86-64:latest'
+      volumes:
+        - ${{github.workspace}}:${{github.workspace}}
+
+    if: inputs.test_sycl_cts && inputs.ock && contains(inputs.target_list, 'host_riscv64_linux')
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+      - name: set up gh
+        uses: ./.github/actions/setup_gh
+        with:
+          os: 'ubuntu'
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: build sycl cts artefact
+        uses: ./.github/actions/do_build_sycl_cts
+        with:
+          target: host_riscv64_linux
+          download_sycl_cts_artefact: ${{ inputs.download_sycl_cts_artefact }}
+          sycl_device: opencl
+
   run_sycl_cts_x86_64_opencl:
     needs: [workflow_vars, create_ock_artefacts_ubuntu, build_dpcpp_native, build_sycl_cts_x86_64_opencl]
     runs-on: 'ubuntu-22.04'
@@ -493,4 +518,23 @@ jobs:
         with:
           target: host_aarch64_linux
           sycl_device: native_cpu
+          llvm_version: ${{ inputs.llvm_version }}
+
+  run_sycl_cts_riscv64_opencl:
+    needs: [workflow_vars, create_ock_artefacts_ubuntu, build_dpcpp_native, build_native_cross, build_sycl_cts_riscv64_opencl]
+    runs-on: 'ubuntu-24.04'
+    container:
+      image: 'ghcr.io/uxlfoundation/ock_ubuntu_24.04-x86-64:latest'
+      volumes:
+        - ${{github.workspace}}:${{github.workspace}}
+
+    if: inputs.test_sycl_cts && inputs.ock && contains(inputs.target_list, 'host_riscv64_linux')
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+      - name: run sycl cts
+        uses: ./.github/actions/run_sycl_cts
+        with:
+          target: host_riscv64_linux
+          sycl_device: opencl
           llvm_version: ${{ inputs.llvm_version }}

--- a/.github/workflows/run_ock_external_tests.yml
+++ b/.github/workflows/run_ock_external_tests.yml
@@ -521,7 +521,7 @@ jobs:
           llvm_version: ${{ inputs.llvm_version }}
 
   run_sycl_cts_riscv64_opencl:
-    needs: [workflow_vars, create_ock_artefacts_ubuntu, build_dpcpp_native, build_native_cross, build_sycl_cts_riscv64_opencl]
+    needs: [workflow_vars, create_ock_artefacts_ubuntu, build_dpcpp_native, build_dpcpp_cross, build_sycl_cts_riscv64_opencl]
     runs-on: 'ubuntu-24.04'
     container:
       image: 'ghcr.io/uxlfoundation/ock_ubuntu_24.04-x86-64:latest'

--- a/.github/workflows/run_ock_external_tests.yml
+++ b/.github/workflows/run_ock_external_tests.yml
@@ -265,8 +265,6 @@ jobs:
           target: ${{ matrix.target }}
           llvm_version: ${{ inputs.llvm_version }}
 
-  # ALAN TODO: review dpcpp native build for when only target is riscv
-
   build_dpcpp_native:
     needs: [workflow_vars]
     strategy:
@@ -548,7 +546,7 @@ jobs:
 
   run_sycl_cts_riscv64_opencl:
     needs: [workflow_vars, create_ock_artefacts_ubuntu, build_dpcpp_native, build_dpcpp_cross, build_sycl_cts_riscv64_opencl]
-    runs-on: 'cp-ubuntu-24.04' # job times-out (>6 hrs) with default github runners
+    runs-on: 'cp-ubuntu-24.04' # note: the job will time-out (>6 hrs) if default github runners are used
     container:
       image: 'ghcr.io/uxlfoundation/ock_ubuntu_24.04-x86-64:latest'
       volumes:

--- a/.github/workflows/run_ock_external_tests.yml
+++ b/.github/workflows/run_ock_external_tests.yml
@@ -548,7 +548,7 @@ jobs:
 
   run_sycl_cts_riscv64_opencl:
     needs: [workflow_vars, create_ock_artefacts_ubuntu, build_dpcpp_native, build_dpcpp_cross, build_sycl_cts_riscv64_opencl]
-    runs-on: 'ubuntu-24.04'
+    runs-on: 'cp-ubuntu-24.04' # job times-out (>6 hrs) with default github runners
     container:
       image: 'ghcr.io/uxlfoundation/ock_ubuntu_24.04-x86-64:latest'
       volumes:


### PR DESCRIPTION
# Overview

Add SYCL_CTS CI for riscv64 opencl & native_cpu

# Reason for change

Completes SYCL_CTS for all supported architectures.

# Description of change

- added riscv64 SYCL_CTS build & run workflow jobs.
- dpc++ build action updated to handle download/unpackage pre-reqs for riscv64 cross compilation artifacts, with architecture strings added to the install directories for clarity.
- cross-compilation options added to the dpc++ configuration job
- dpc++ configuration files now installed to pick up libraries for cross compilation.
- sycl_cts build action updated to handle download/unpackage pre-reqs for riscv64 cross compilation artifacts, again with architecture strings added to the install directories for clarity.
- PREPEND_PATH options (qemu) added to sycl_cts run job for riscv64.
- single opencl XFAIL test added to the new `override_opencl_host_riscv64_linux.csv file`. (test_math_builtin_api "math_builtin_float_half_*")

# Anything else we should know?

- At time of writing, both opencl & native_cpu test variants are currently under test and are expected to match results on main (TBC)
- Note that the flow of control for the workflow jobs is wrong if riscv64 alone is specified in the target list (currently x86_64 is also needed to build dpc++ correctly). An additional ticket to resolve this is due shortly. 

