### PR TITLE
Fix concurrency issue on scheduling.

### DIFF
--- a/.github/workflows/planned_testing_caller.yml
+++ b/.github/workflows/planned_testing_caller.yml
@@ -59,10 +59,6 @@ on:
         type: boolean
         default: true
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
-
 jobs:
   build_llvm_artefacts:
     name: Call PR testing on schedule


### PR DESCRIPTION
# Overview

Removed concurrency group from planned_testing_caller.yml

# Reason for change

Having the same concurrency group at the top level (planned_testing_caller_19.yml) and the next level down (planned_testing_caller.yml) was causing a deadlock on the scheduled run.
