### PR TITLE
[LLVM 21] Take address space into account for legality.

### DIFF
--- a/modules/compiler/multi_llvm/include/multi_llvm/target_transform_info.h
+++ b/modules/compiler/multi_llvm/include/multi_llvm/target_transform_info.h
@@ -1,0 +1,74 @@
+// Copyright (C) Codeplay Software Limited
+//
+// Licensed under the Apache License, Version 2.0 (the "License") with LLVM
+// Exceptions; you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/LICENSE.txt
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef MULTI_LLVM_TARGET_TRANSFORM_INFO_H_INCLUDED
+#define MULTI_LLVM_TARGET_TRANSFORM_INFO_H_INCLUDED
+
+#include <llvm/Analysis/TargetTransformInfo.h>
+#include <multi_llvm/llvm_version.h>
+
+namespace multi_llvm {
+
+namespace detail {
+
+template <typename TargetTransformInfo>
+auto isLegalMaskedLoadImpl(const TargetTransformInfo &TTI, llvm::Type *Ty,
+                           llvm::Align Alignment, unsigned)
+    -> decltype(TTI.isLegalMaskedLoad(Ty, Alignment)) {
+  return TTI.isLegalMaskedLoad(Ty, Alignment);
+}
+
+template <typename TargetTransformInfo>
+auto isLegalMaskedStoreImpl(const TargetTransformInfo &TTI, llvm::Type *Ty,
+                            llvm::Align Alignment, unsigned)
+    -> decltype(TTI.isLegalMaskedStore(Ty, Alignment)) {
+  return TTI.isLegalMaskedStore(Ty, Alignment);
+}
+
+#if LLVM_VERSION_GREATER_EQUAL(21, 0)
+// TODO: Make this depend only on LLVM version once we do not have to remain
+// compatible with slightly older LLVM 21 snapshots.
+
+template <typename TargetTransformInfo>
+auto isLegalMaskedLoadImpl(const TargetTransformInfo &TTI, llvm::Type *Ty,
+                           llvm::Align Alignment, unsigned AddrSpace)
+    -> decltype(TTI.isLegalMaskedLoad(Ty, Alignment, AddrSpace)) {
+  return TTI.isLegalMaskedLoad(Ty, Alignment, AddrSpace);
+}
+
+template <typename TargetTransformInfo>
+auto isLegalMaskedStoreImpl(const TargetTransformInfo &TTI, llvm::Type *Ty,
+                            llvm::Align Alignment, unsigned AddrSpace)
+    -> decltype(TTI.isLegalMaskedStore(Ty, Alignment, AddrSpace)) {
+  return TTI.isLegalMaskedStore(Ty, Alignment, AddrSpace);
+}
+#endif
+
+}  // namespace detail
+
+bool isLegalMaskedLoad(const llvm::TargetTransformInfo &TTI, llvm::Type *Ty,
+                       llvm::Align Alignment, unsigned AddrSpace) {
+  return detail::isLegalMaskedLoadImpl(TTI, Ty, Alignment, AddrSpace);
+}
+
+bool isLegalMaskedStore(const llvm::TargetTransformInfo &TTI, llvm::Type *Ty,
+                        llvm::Align Alignment, unsigned AddrSpace) {
+  return detail::isLegalMaskedStoreImpl(TTI, Ty, Alignment, AddrSpace);
+}
+
+}  // namespace multi_llvm
+
+#endif  // MULTI_LLVM_TARGET_TRANSFORM_INFO_H_INCLUDED

--- a/modules/compiler/vecz/include/vecz/vecz_target_info.h
+++ b/modules/compiler/vecz/include/vecz/vecz_target_info.h
@@ -570,8 +570,10 @@ class TargetInfo {
   /// @param[in] F The function in which the instruction will be created.
   /// @param[in] Ty Type of the vector to load.
   /// @param[in] Alignment Alignment of the operation.
+  /// @param[in] AddrSpace Address space of the operation.
   virtual VPMemOpLegality isVPLoadLegal(const llvm::Function *F, llvm::Type *Ty,
-                                        unsigned Alignment) const;
+                                        unsigned Alignment,
+                                        unsigned AddrSpace) const;
 
   /// @return A VPMemOpLegality enum stating whether we can create a vp.store or
   /// a masked.store intrinsic.
@@ -579,9 +581,10 @@ class TargetInfo {
   /// @param[in] F The function in which the instruction will be created.
   /// @param[in] Ty Type of the vector to store.
   /// @param[in] Alignment Alignment of the operation.
+  /// @param[in] AddrSpace Address space of the operation.
   virtual VPMemOpLegality isVPStoreLegal(const llvm::Function *F,
-                                         llvm::Type *Ty,
-                                         unsigned Alignment) const;
+                                         llvm::Type *Ty, unsigned Alignment,
+                                         unsigned AddrSpace) const;
 
   /// @return A VPMemOpLegality enum stating whether we can create a vp.gather
   /// or a masked.gather intrinsic.
@@ -589,9 +592,10 @@ class TargetInfo {
   /// @param[in] F The function in which the instruction will be created.
   /// @param[in] Ty Type of the vector to gather.
   /// @param[in] Alignment Alignment of the operation.
+  /// @param[in] AddrSpace Address space of the operation.
   virtual VPMemOpLegality isVPGatherLegal(const llvm::Function *F,
-                                          llvm::Type *Ty,
-                                          unsigned Alignment) const;
+                                          llvm::Type *Ty, unsigned Alignment,
+                                          unsigned AddrSpace) const;
 
   /// @return A VPMemOpLegality enum stating whether we can create a vp.scatter
   /// or a masked.scatter intrinsic.
@@ -599,9 +603,10 @@ class TargetInfo {
   /// @param[in] F The function in which the instruction will be created.
   /// @param[in] Ty Type of the vector to scatter.
   /// @param[in] Alignment Alignment of the operation.
+  /// @param[in] AddrSpace Address space of the operation.
   virtual VPMemOpLegality isVPScatterLegal(const llvm::Function *F,
-                                           llvm::Type *Ty,
-                                           unsigned Alignment) const;
+                                           llvm::Type *Ty, unsigned Alignment,
+                                           unsigned AddrSpace) const;
 
   /// @brief Function to check whether a given type is valid as the element type
   /// of a scalable vector used in a VP intrinsic.
@@ -619,9 +624,9 @@ class TargetInfo {
   VPMemOpLegality checkMemOpLegality(
       const llvm::Function *F,
       llvm::function_ref<bool(const llvm::TargetTransformInfo &, llvm::Type *,
-                              unsigned)>
+                              unsigned, unsigned)>
           Checker,
-      llvm::Type *Ty, unsigned Alignment) const;
+      llvm::Type *Ty, unsigned Alignment, unsigned AddrSpace) const;
 
   /// @brief Create a broadcast of a vector.
   ///


### PR DESCRIPTION
# Overview

[LLVM 21] Take address space into account for legality.

# Reason for change

LLVM 21 allows for the possibility that some operations are legal only in some address spaces.

# Description of change

*Describe the intended behaviour your changes are meant to introduce to the
project and explain how they resolve the problem stated above. Detail any
relevant changes that may affect other users of the project, such as
compilation options, runtime flags, expected inputs and outputs, API entry
points, etc.*

*If you have added new testing, provide details on what tests you have added
and what the purpose of them is.*

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-19](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
