### PR TITLE
Fix windows move to scheduled testing

### DIFF
--- a/.github/workflows/run_ock_internal_tests.yml
+++ b/.github/workflows/run_ock_internal_tests.yml
@@ -203,7 +203,7 @@ jobs:
   run_windows_msvc_x86_64_llvm_latest_cl3_0_offline:
     runs-on: windows-2019
     # do not run as PR job due to not yet supporting windows install
-    if: contains(inputs.target_list, 'host_x86_64_windows') && inputs.is_pull_request != 'true'
+    if: contains(inputs.target_list, 'host_x86_64_windows') && !inputs.is_pull_request
     steps:
       - name: Setup Windows llvm base
         uses: llvm/actions/setup-windows@main


### PR DESCRIPTION
# Overview

Fix windows move to scheduled testing

# Reason for change

There was a logic error in run_ock_internal_tests which meant that the windows job did not move to scheduled running as intended.
