### PR TITLE
Do not vectorize NoInline kernels.

### DIFF
--- a/modules/compiler/vecz/source/include/analysis/vectorizable_function_analysis.h
+++ b/modules/compiler/vecz/source/include/analysis/vectorizable_function_analysis.h
@@ -44,10 +44,6 @@ class VectorizableFunctionAnalysis
     /// @brief Whether the function can be vectorized.
     bool canVectorize = false;
 
-    /// @brief If the function can not be vectorized, the value (if any) that
-    /// is the cause of the problem.
-    const llvm::Value *failedAt = nullptr;
-
     /// @brief Handle invalidation events from the new pass manager.
     ///
     /// @return false, as this analysis can never be invalidated.

--- a/source/cl/test/UnitCL/source/ktst_vecz_tasks_task_11.cpp
+++ b/source/cl/test/UnitCL/source/ktst_vecz_tasks_task_11.cpp
@@ -25,6 +25,7 @@
 using namespace kts::ucl;
 
 TEST_P(Execution, Task_11_01_Kernel_Signature) {
+  fail_if_not_vectorized_ = false;
   AddInputBuffer(kts::N, kts::Ref_A);
   AddOutputBuffer(kts::N, kts::Ref_A);
   RunGeneric1D(kts::N);
@@ -38,6 +39,7 @@ TEST_P(Execution, Task_11_02_Kernel_Signature_NoInline_Before) {
 }
 
 TEST_P(Execution, Task_11_03_Kernel_Signature_NoInline_After) {
+  fail_if_not_vectorized_ = false;
   AddInputBuffer(kts::N, kts::Ref_A);
   AddOutputBuffer(kts::N, kts::Ref_A);
   RunGeneric1D(kts::N);


### PR DESCRIPTION
# Overview

Do not vectorize NoInline kernels.

# Reason for change

A recent LLVM 21 change prevents us from being able to vectorize NoInline kernels.

# Description of change

It was probably never a good idea to vectorize them anyway: it is not clear whether the vectorization we perform is something that a user who writes `__attribute__((noinline))` would want. Therefore, explicitly reject vectorization of NoInline functions and restore affected tests to their original version that permitted them to not be vectorized.

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-19](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
