### PR TITLE
[LLVM 19] Work around loop vectorizer issue.

### DIFF
--- a/modules/compiler/compiler_pipeline/CMakeLists.txt
+++ b/modules/compiler/compiler_pipeline/CMakeLists.txt
@@ -48,6 +48,7 @@ add_ca_library(compiler-pipeline STATIC
   ${CMAKE_CURRENT_SOURCE_DIR}/include/compiler/utils/pipeline_parse_helpers.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/compiler/utils/prepare_barriers_pass.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/compiler/utils/reduce_to_function_pass.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/include/compiler/utils/remove_address_spaces_pass.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/compiler/utils/remove_exceptions_pass.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/compiler/utils/remove_lifetime_intrinsics_pass.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/compiler/utils/rename_builtins_pass.h
@@ -97,6 +98,7 @@ add_ca_library(compiler-pipeline STATIC
   ${CMAKE_CURRENT_SOURCE_DIR}/source/pass_machinery.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/source/prepare_barriers_pass.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/source/reduce_to_function_pass.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/source/remove_address_spaces_pass.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/source/remove_exceptions_pass.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/source/remove_lifetime_intrinsics_pass.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/source/rename_builtins_pass.cpp

--- a/modules/compiler/compiler_pipeline/include/compiler/utils/remove_address_spaces_pass.h
+++ b/modules/compiler/compiler_pipeline/include/compiler/utils/remove_address_spaces_pass.h
@@ -1,0 +1,43 @@
+// Copyright (C) Codeplay Software Limited
+//
+// Licensed under the Apache License, Version 2.0 (the "License") with LLVM
+// Exceptions; you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/LICENSE.txt
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+/// @file
+///
+/// Remove address spaces pass.
+
+#ifndef COMPILER_UTILS_REMOVE_ADDRESS_SPACES_PASS_H_INCLUDED
+#define COMPILER_UTILS_REMOVE_ADDRESS_SPACES_PASS_H_INCLUDED
+
+#include <llvm/IR/PassManager.h>
+#include <multi_llvm/multi_llvm.h>
+
+#if LLVM_VERSION_LESS(20, 0)
+namespace compiler {
+namespace utils {
+
+/// @brief A pass that removes address spaces from functions to work around LLVM
+/// issue #124759.
+class RemoveAddressSpacesPass final
+    : public llvm::PassInfoMixin<RemoveAddressSpacesPass> {
+ public:
+  llvm::PreservedAnalyses run(llvm::Function &,
+                              llvm::FunctionAnalysisManager &);
+};
+}  // namespace utils
+}  // namespace compiler
+#endif
+
+#endif  // COMPILER_UTILS_REMOVE_ADDRESS_SPACES_PASS_H_INCLUDED

--- a/modules/compiler/compiler_pipeline/source/remove_address_spaces_pass.cpp
+++ b/modules/compiler/compiler_pipeline/source/remove_address_spaces_pass.cpp
@@ -1,0 +1,146 @@
+// Copyright (C) Codeplay Software Limited
+//
+// Licensed under the Apache License, Version 2.0 (the "License") with LLVM
+// Exceptions; you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/LICENSE.txt
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <compiler/utils/remove_address_spaces_pass.h>
+#include <llvm/IR/Function.h>
+#include <llvm/IR/IRBuilder.h>
+#include <llvm/IR/Instructions.h>
+
+using namespace llvm;
+
+#if LLVM_VERSION_LESS(20, 0)
+static Type *removeAddressSpaces(Type *T) {
+  constexpr unsigned DefaultAddressSpace = 0;
+
+  if (auto *PtrTy = dyn_cast<PointerType>(T)) {
+    if (PtrTy->getAddressSpace() != DefaultAddressSpace) {
+      return PointerType::get(T->getContext(), DefaultAddressSpace);
+    }
+  } else if (auto *VecTy = dyn_cast<VectorType>(T)) {
+    if (auto *EltTy = removeAddressSpaces(VecTy->getElementType())) {
+      return VectorType::get(EltTy, VecTy);
+    }
+  }
+
+  return nullptr;
+}
+
+PreservedAnalyses compiler::utils::RemoveAddressSpacesPass::run(
+    Function &F, FunctionAnalysisManager &) {
+  bool Changed = false;
+
+  auto MaybeCastOperand = [&](Instruction &I, Use &Op, Type *T) {
+    if (Op->getType() == T) return false;
+    IRBuilder<> B(&I);
+    Op.set(B.CreateAddrSpaceCast(Op, T));
+    return true;
+  };
+
+  auto MaybeCastResult = [&](Value &V, Type *OldTy, Type *NewTy,
+                             BasicBlock::iterator InsertPt) {
+    if (V.use_empty()) return false;
+    auto *CastV =
+        new AddrSpaceCastInst(PoisonValue::get(OldTy), NewTy, "", InsertPt);
+    V.mutateType(NewTy);
+    V.replaceAllUsesWith(CastV);
+    V.mutateType(OldTy);
+    CastV->setOperand(0, &V);
+    return true;
+  };
+
+  // If any args have a non-default address space, replace their uses with a
+  // cast to the default address space inserted in the entry block.
+  auto InsertPt = F.getEntryBlock().getFirstNonPHIOrDbgOrAlloca();
+  for (auto &Arg : F.args()) {
+    if (auto *T = Arg.getType(); auto *NewTy = removeAddressSpaces(T)) {
+      Changed |= MaybeCastResult(Arg, T, NewTy, InsertPt);
+    }
+  }
+
+  // Mutate all instructions to remove non-default address spaces. In most cases
+  // this is done by mutating the instruction directly, but in calls and
+  // extractvalues we cannot do that so insert a new addrspacecast instruction
+  // instead.
+  for (auto &BB : F) {
+    for (auto &I : BB) {
+      if (auto *T = I.getType(); auto *NewTy = removeAddressSpaces(T)) {
+        // call and extractvalue instructions need special handling. Cast their
+        // result instead.
+        if (isa<CallBase>(I) || isa<ExtractValueInst>(I)) {
+          InsertPt = std::next(I.getIterator());
+          InsertPt.setHeadBit(true);
+          Changed |= MaybeCastResult(I, T, NewTy, InsertPt);
+        } else {
+          I.mutateType(NewTy);
+          Changed = true;
+        }
+      }
+    }
+  }
+
+  // Now go over instructions again to remove address space casts made
+  // redundant, and insert new address space casts as required.
+  for (auto &BB : F) {
+    for (auto &I : make_early_inc_range(BB)) {
+      if (isa<AddrSpaceCastInst>(I)) {
+        if (I.getType() == I.getOperand(0)->getType()) {
+          I.replaceAllUsesWith(I.getOperand(0));
+          I.eraseFromParent();
+          Changed = true;
+        }
+        continue;
+      }
+
+      // For call instructions, operand types need to match parameter types.
+      if (auto *CB = dyn_cast<CallBase>(&I)) {
+        auto *FTy = CB->getFunctionType();
+        for (unsigned Idx = 0, E = FTy->getNumParams(); Idx != E; ++Idx) {
+          Changed |=
+              MaybeCastOperand(I, I.getOperandUse(Idx), FTy->getParamType(Idx));
+        }
+        continue;
+      }
+
+      // For insertvalue instructions, operand types need to match structure or
+      // array element type.
+      if (auto *IVI = dyn_cast<InsertValueInst>(&I)) {
+        Changed |= MaybeCastOperand(
+            I, I.getOperandUse(InsertValueInst::getInsertedValueOperandIndex()),
+            ExtractValueInst::getIndexedType(
+                IVI->getAggregateOperand()->getType(), IVI->getIndices()));
+        continue;
+      }
+
+      // For other instructions, operands should be non-address-space-qualified.
+      // Operands that are arguments or other instructions will have been
+      // updated already, but we may still have constants to deal with.
+      for (auto &Op : I.operands()) {
+        if (auto *T = Op->getType(); auto *NewTy = removeAddressSpaces(T)) {
+          Changed |= MaybeCastOperand(I, Op, NewTy);
+        }
+      }
+    }
+  }
+
+  if (Changed) {
+    PreservedAnalyses PA;
+    PA.preserveSet<CFGAnalyses>();
+    return PA;
+  } else {
+    return PreservedAnalyses::all();
+  }
+}
+#endif

--- a/modules/compiler/source/base/source/base_module_pass_machinery.cpp
+++ b/modules/compiler/source/base/source/base_module_pass_machinery.cpp
@@ -47,6 +47,7 @@
 #include <compiler/utils/pipeline_parse_helpers.h>
 #include <compiler/utils/prepare_barriers_pass.h>
 #include <compiler/utils/reduce_to_function_pass.h>
+#include <compiler/utils/remove_address_spaces_pass.h>
 #include <compiler/utils/remove_exceptions_pass.h>
 #include <compiler/utils/remove_lifetime_intrinsics_pass.h>
 #include <compiler/utils/rename_builtins_pass.h>

--- a/modules/compiler/source/base/source/base_module_pass_registry.def
+++ b/modules/compiler/source/base/source/base_module_pass_registry.def
@@ -175,6 +175,9 @@ FUNCTION_PASS("manual-type-legalization", compiler::utils::ManualTypeLegalizatio
 FUNCTION_PASS("software-div", compiler::SoftwareDivisionPass())
 FUNCTION_PASS("replace-addrspace-fns", compiler::utils::ReplaceAddressSpaceQualifierFunctionsPass())
 FUNCTION_PASS("remove-lifetime", compiler::utils::RemoveLifetimeIntrinsicsPass())
+#if LLVM_VERSION_LESS(20, 0)
+FUNCTION_PASS("remove-address-spaces", compiler::utils::RemoveAddressSpacesPass())
+#endif
 FUNCTION_PASS("remove-exceptions", compiler::utils::RemoveExceptionsPass())
 FUNCTION_PASS("replace-mem-intrins", compiler::utils::ReplaceMemIntrinsicsPass())
 FUNCTION_PASS("print<generic-metadata>", compiler::utils::GenericMetadataPrinterPass(llvm::dbgs()))

--- a/modules/compiler/targets/host/source/HostPassMachinery.cpp
+++ b/modules/compiler/targets/host/source/HostPassMachinery.cpp
@@ -31,6 +31,7 @@
 #include <compiler/utils/metadata.h>
 #include <compiler/utils/metadata_analysis.h>
 #include <compiler/utils/pipeline_parse_helpers.h>
+#include <compiler/utils/remove_address_spaces_pass.h>
 #include <compiler/utils/remove_exceptions_pass.h>
 #include <compiler/utils/remove_lifetime_intrinsics_pass.h>
 #include <compiler/utils/replace_address_space_qualifier_functions_pass.h>
@@ -285,6 +286,11 @@ llvm::ModulePassManager HostPassMachinery::getKernelFinalizationPasses(
   // Functions with __attribute__ ((always_inline)) should
   // be inlined even at -O0.
   PM.addPass(llvm::AlwaysInlinerPass());
+
+#if LLVM_VERSION_LESS(20, 0)
+  PM.addPass(llvm::createModuleToFunctionPassAdaptor(
+      compiler::utils::RemoveAddressSpacesPass()));
+#endif
 
   // Running this pass here is the "nuclear option", it would be better to
   // ensure exception handling is never introduced in the first place, but

--- a/scripts/testing/sycl_cts/override_opencl_llvm_19.csv
+++ b/scripts/testing/sycl_cts/override_opencl_llvm_19.csv
@@ -1,2 +1,0 @@
-SYCL_CTS,test_math_builtin_api "math_builtin_float_base_*",XFail
-SYCL_CTS,test_math_builtin_api "math_builtin_float_double_*",XFail


### PR DESCRIPTION
# Overview

[LLVM 19] Work around loop vectorizer issue.

# Reason for change

The loop vectorizer gets confused by having pointers to distinct address spaces that are derived from the same object. This has been fixed for LLVM 20, but as long as we support LLVM 19, work around it there.

# Description of change

*Describe the intended behaviour your changes are meant to introduce to the
project and explain how they resolve the problem stated above. Detail any
relevant changes that may affect other users of the project, such as
compilation options, runtime flags, expected inputs and outputs, API entry
points, etc.*

*If you have added new testing, provide details on what tests you have added
and what the purpose of them is.*

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-19](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
