### PR TITLE
CI ock_external workflow update for stand-alone riscv64 

### DIFF
--- a/.github/workflows/planned_testing_caller_19.yml
+++ b/.github/workflows/planned_testing_caller_19.yml
@@ -23,6 +23,7 @@ jobs:
       # We can set ock, test_sycl_cts etc here optionally if this is used as a pull request.
       # Any with parameters below this is intended for local testing and should not be merged.
       target_list: '[ "host_x86_64_linux",
+                      "host_aarch64_linux",
                       "host_riscv64_linux" ]'
       # ock: true
       # native_cpu: true

--- a/.github/workflows/planned_testing_caller_19.yml
+++ b/.github/workflows/planned_testing_caller_19.yml
@@ -22,13 +22,13 @@ jobs:
       use_llvm_github_cache: true
       # We can set ock, test_sycl_cts etc here optionally if this is used as a pull request.
       # Any with parameters below this is intended for local testing and should not be merged.
-      # target_list: '[ "host_x86_64_linux" ]'
+      target_list: '[ "host_riscv64_linux" ]'
       # ock: true
       # native_cpu: true
-      # test_tornado: true
+      test_tornado: false
       # test_sycl_cts: true
-      # test_opencl_cts: true
-      # run_internal: true
+      test_opencl_cts: false
+      run_internal: false
       # run_external: true
       # build_llvm: true
 

--- a/.github/workflows/planned_testing_caller_19.yml
+++ b/.github/workflows/planned_testing_caller_19.yml
@@ -22,15 +22,13 @@ jobs:
       use_llvm_github_cache: true
       # We can set ock, test_sycl_cts etc here optionally if this is used as a pull request.
       # Any with parameters below this is intended for local testing and should not be merged.
-      target_list: '[ "host_x86_64_linux",
-                      "host_aarch64_linux",
-                      "host_riscv64_linux" ]'
+      # target_list: '[ "host_x86_64_linux" ]'
       # ock: true
       # native_cpu: true
-      test_tornado: false
+      # test_tornado: true
       # test_sycl_cts: true
-      test_opencl_cts: false
-      run_internal: false
+      # test_opencl_cts: true
+      # run_internal: true
       # run_external: true
       # build_llvm: true
 

--- a/.github/workflows/planned_testing_caller_19.yml
+++ b/.github/workflows/planned_testing_caller_19.yml
@@ -22,7 +22,8 @@ jobs:
       use_llvm_github_cache: true
       # We can set ock, test_sycl_cts etc here optionally if this is used as a pull request.
       # Any with parameters below this is intended for local testing and should not be merged.
-      target_list: '[ "host_riscv64_linux" ]'
+      target_list: '[ "host_x86_64_linux",
+                      "host_riscv64_linux" ]'
       # ock: true
       # native_cpu: true
       test_tornado: false

--- a/.github/workflows/run_ock_external_tests.yml
+++ b/.github/workflows/run_ock_external_tests.yml
@@ -311,7 +311,7 @@ jobs:
           target: host_aarch64_linux
           download_dpcpp_artefact: ${{ inputs.download_dpcpp_artefact }}
 
-  build_dpcpp_cross:
+  build_dpcpp_riscv64:
     needs: [workflow_vars, build_dpcpp_native_x86_64]  # cross builds need pre-built native artefact
     strategy:
       fail-fast: false  # let all matrix jobs complete
@@ -437,7 +437,7 @@ jobs:
           sycl_device: native_cpu
 
   build_sycl_cts_riscv64_opencl:
-    needs: [workflow_vars, build_icd, build_dpcpp_native_x86_64, build_dpcpp_cross]
+    needs: [workflow_vars, build_icd, build_dpcpp_native_x86_64, build_dpcpp_riscv64]
     runs-on: 'cp-ubuntu-24.04'
     container:
       image: 'ghcr.io/uxlfoundation/ock_ubuntu_24.04-x86-64:latest'
@@ -461,7 +461,7 @@ jobs:
           sycl_device: opencl
 
   build_sycl_cts_riscv64_native_cpu:
-    needs: [workflow_vars, build_dpcpp_native_x86_64, build_dpcpp_cross]
+    needs: [workflow_vars, build_dpcpp_native_x86_64, build_dpcpp_riscv64]
     runs-on: 'cp-ubuntu-24.04'
     container:
       image: 'ghcr.io/uxlfoundation/ock_ubuntu_24.04-x86-64:latest'
@@ -561,7 +561,7 @@ jobs:
           llvm_version: ${{ inputs.llvm_version }}
 
   run_sycl_cts_riscv64_opencl:
-    needs: [workflow_vars, create_ock_artefacts_ubuntu, build_dpcpp_native_x86_64, build_dpcpp_cross, build_sycl_cts_riscv64_opencl]
+    needs: [workflow_vars, create_ock_artefacts_ubuntu, build_dpcpp_native_x86_64, build_dpcpp_riscv64, build_sycl_cts_riscv64_opencl]
     runs-on: 'cp-ubuntu-24.04' # note: the job will time-out (>6 hrs) if default github runners are used
     container:
       image: 'ghcr.io/uxlfoundation/ock_ubuntu_24.04-x86-64:latest'
@@ -580,7 +580,7 @@ jobs:
           llvm_version: ${{ inputs.llvm_version }}
 
   run_sycl_cts_riscv64_native_cpu:
-    needs: [workflow_vars, build_dpcpp_native_x86_64, build_dpcpp_cross, build_sycl_cts_riscv64_native_cpu]
+    needs: [workflow_vars, build_dpcpp_native_x86_64, build_dpcpp_riscv64, build_sycl_cts_riscv64_native_cpu]
     runs-on: 'ubuntu-24.04'
     container:
       image: 'ghcr.io/uxlfoundation/ock_ubuntu_24.04-x86-64:latest'

--- a/.github/workflows/run_ock_external_tests.yml
+++ b/.github/workflows/run_ock_external_tests.yml
@@ -265,34 +265,51 @@ jobs:
           target: ${{ matrix.target }}
           llvm_version: ${{ inputs.llvm_version }}
 
-  build_dpcpp_native:
+  build_dpcpp_native_x86_64:
     needs: [workflow_vars]
-    strategy:
-      fail-fast: false  # let all matrix jobs complete
-      matrix:
-        target: ${{ fromJson(inputs.target_list) }}
-        exclude: ${{ fromJson(needs.workflow_vars.outputs.matrix_only_linux_x86_64_aarch64) }}
-
-    runs-on: ${{ contains(matrix.target, 'host_aarch64') && 'ubuntu-22.04-arm' || (contains(matrix.target, 'host_riscv64') && 'ubuntu-24.04' || 'ubuntu-22.04') }}
+    runs-on: 'ubuntu-22.04'
     container:
-      image: ${{ contains(matrix.target, 'host_aarch64') && 'ghcr.io/uxlfoundation/ock_ubuntu_22.04-aarch64:latest'
-             ||                                             'ghcr.io/uxlfoundation/ock_ubuntu_22.04-x86-64:latest' }}
+      image: 'ghcr.io/uxlfoundation/ock_ubuntu_22.04-x86-64:latest'
       volumes:
         - ${{github.workspace}}:${{github.workspace}}
 
-    if: inputs.test_sycl_cts
+    if: inputs.test_sycl_cts && ( contains(inputs.target_list, 'host_x86_64_linux') || contains(inputs.target_list, 'host_riscv64_linux') )
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
       - name: set up gh
         uses: ./.github/actions/setup_gh
         with:
-          os: ${{ contains( matrix.target, 'windows') && 'windows' || 'ubuntu' }}
+          os: 'ubuntu'
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: build dpc++ artefact
         uses: ./.github/actions/do_build_dpcpp
         with:
-          target: ${{ matrix.target }}
+          target: host_x86_64_linux
+          download_dpcpp_artefact: ${{ inputs.download_dpcpp_artefact }}
+
+  build_dpcpp_native_aarch64:
+    needs: [workflow_vars]
+    runs-on: 'ubuntu-22.04-arm'
+    container:
+      image: 'ghcr.io/uxlfoundation/ock_ubuntu_22.04-aarch64:latest'
+      volumes:
+        - ${{github.workspace}}:${{github.workspace}}
+
+    if: inputs.test_sycl_cts
+    if: inputs.test_sycl_cts && contains(inputs.target_list, 'host_aarch64_linux')
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+      - name: set up gh
+        uses: ./.github/actions/setup_gh
+        with:
+          os: 'ubuntu'
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: build dpc++ artefact
+        uses: ./.github/actions/do_build_dpcpp
+        with:
+          target: host_aarch64_linux
           download_dpcpp_artefact: ${{ inputs.download_dpcpp_artefact }}
 
   build_dpcpp_cross:

--- a/.github/workflows/run_ock_external_tests.yml
+++ b/.github/workflows/run_ock_external_tests.yml
@@ -523,7 +523,7 @@ jobs:
           llvm_version: ${{ inputs.llvm_version }}          
 
   run_sycl_cts_aarch64_opencl:
-    needs: [workflow_vars, create_ock_artefacts_ubuntu, build_dpcpp_native, build_sycl_cts_aarch64_opencl]
+    needs: [workflow_vars, create_ock_artefacts_ubuntu, build_dpcpp_native_aarch64, build_sycl_cts_aarch64_opencl]
     runs-on: 'cp-graviton'
     container:
       image: 'ghcr.io/uxlfoundation/ock_ubuntu_22.04-aarch64:latest'
@@ -542,7 +542,7 @@ jobs:
           llvm_version: ${{ inputs.llvm_version }}
 
   run_sycl_cts_aarch64_native_cpu:
-    needs: [workflow_vars, build_dpcpp_native, build_sycl_cts_aarch64_native_cpu]
+    needs: [workflow_vars, build_dpcpp_native_aarch64, build_sycl_cts_aarch64_native_cpu]
     runs-on: 'cp-graviton'
     container:
       image: 'ghcr.io/uxlfoundation/ock_ubuntu_22.04-aarch64:latest'

--- a/.github/workflows/run_ock_external_tests.yml
+++ b/.github/workflows/run_ock_external_tests.yml
@@ -312,7 +312,7 @@ jobs:
           download_dpcpp_artefact: ${{ inputs.download_dpcpp_artefact }}
 
   build_dpcpp_cross:
-    needs: [workflow_vars, build_dpcpp_native]  # cross builds need pre-built native artefact
+    needs: [workflow_vars, build_dpcpp_native_x86_64]  # cross builds need pre-built native artefact
     strategy:
       fail-fast: false  # let all matrix jobs complete
       matrix:
@@ -341,7 +341,7 @@ jobs:
           download_dpcpp_artefact: ${{ inputs.download_dpcpp_artefact }}
 
   build_sycl_cts_x86_64_opencl:
-    needs: [workflow_vars, build_icd, build_dpcpp_native]
+    needs: [workflow_vars, build_icd, build_dpcpp_native_x86_64]
     runs-on: 'cp-ubuntu-24.04'
     container:
       image: 'ghcr.io/uxlfoundation/ock_ubuntu_22.04-x86-64:latest'
@@ -365,7 +365,7 @@ jobs:
           sycl_device: opencl
 
   build_sycl_cts_x86_64_native_cpu:
-    needs: [workflow_vars, build_dpcpp_native]
+    needs: [workflow_vars, build_dpcpp_native_x86_64]
     runs-on: 'cp-ubuntu-24.04'
     container:
       image: 'ghcr.io/uxlfoundation/ock_ubuntu_22.04-x86-64:latest'
@@ -389,7 +389,7 @@ jobs:
           sycl_device: native_cpu
 
   build_sycl_cts_aarch64_opencl:
-    needs: [workflow_vars, build_icd, build_dpcpp_native]
+    needs: [workflow_vars, build_icd, build_dpcpp_native_aarch64]
     runs-on: 'cp-graviton'
     container:
       image: 'ghcr.io/uxlfoundation/ock_ubuntu_22.04-aarch64:latest'
@@ -413,7 +413,7 @@ jobs:
           sycl_device: opencl
 
   build_sycl_cts_aarch64_native_cpu:
-    needs: [workflow_vars, build_dpcpp_native]
+    needs: [workflow_vars, build_dpcpp_native_aarch64]
     runs-on: 'cp-graviton'
     container:
       image: 'ghcr.io/uxlfoundation/ock_ubuntu_22.04-aarch64:latest'
@@ -437,7 +437,7 @@ jobs:
           sycl_device: native_cpu
 
   build_sycl_cts_riscv64_opencl:
-    needs: [workflow_vars, build_icd, build_dpcpp_native, build_dpcpp_cross]
+    needs: [workflow_vars, build_icd, build_dpcpp_native_x86_64, build_dpcpp_cross]
     runs-on: 'cp-ubuntu-24.04'
     container:
       image: 'ghcr.io/uxlfoundation/ock_ubuntu_24.04-x86-64:latest'
@@ -461,7 +461,7 @@ jobs:
           sycl_device: opencl
 
   build_sycl_cts_riscv64_native_cpu:
-    needs: [workflow_vars, build_dpcpp_native, build_dpcpp_cross]
+    needs: [workflow_vars, build_dpcpp_native_x86_64, build_dpcpp_cross]
     runs-on: 'cp-ubuntu-24.04'
     container:
       image: 'ghcr.io/uxlfoundation/ock_ubuntu_24.04-x86-64:latest'
@@ -485,7 +485,7 @@ jobs:
           sycl_device: native_cpu
 
   run_sycl_cts_x86_64_opencl:
-    needs: [workflow_vars, create_ock_artefacts_ubuntu, build_dpcpp_native, build_sycl_cts_x86_64_opencl]
+    needs: [workflow_vars, create_ock_artefacts_ubuntu, build_dpcpp_native_x86_64, build_sycl_cts_x86_64_opencl]
     runs-on: 'ubuntu-22.04'
     container:
       image: 'ghcr.io/uxlfoundation/ock_ubuntu_22.04-x86-64:latest'
@@ -504,7 +504,7 @@ jobs:
           llvm_version: ${{ inputs.llvm_version }}
 
   run_sycl_cts_x86_64_native_cpu:
-    needs: [workflow_vars, build_dpcpp_native, build_sycl_cts_x86_64_native_cpu]
+    needs: [workflow_vars, build_dpcpp_native_x86_64, build_sycl_cts_x86_64_native_cpu]
     runs-on: 'ubuntu-22.04'
     container:
       image: 'ghcr.io/uxlfoundation/ock_ubuntu_22.04-x86-64:latest'
@@ -561,7 +561,7 @@ jobs:
           llvm_version: ${{ inputs.llvm_version }}
 
   run_sycl_cts_riscv64_opencl:
-    needs: [workflow_vars, create_ock_artefacts_ubuntu, build_dpcpp_native, build_dpcpp_cross, build_sycl_cts_riscv64_opencl]
+    needs: [workflow_vars, create_ock_artefacts_ubuntu, build_dpcpp_native_x86_64, build_dpcpp_cross, build_sycl_cts_riscv64_opencl]
     runs-on: 'cp-ubuntu-24.04' # note: the job will time-out (>6 hrs) if default github runners are used
     container:
       image: 'ghcr.io/uxlfoundation/ock_ubuntu_24.04-x86-64:latest'
@@ -580,7 +580,7 @@ jobs:
           llvm_version: ${{ inputs.llvm_version }}
 
   run_sycl_cts_riscv64_native_cpu:
-    needs: [workflow_vars, build_dpcpp_native, build_dpcpp_cross, build_sycl_cts_riscv64_native_cpu]
+    needs: [workflow_vars, build_dpcpp_native_x86_64, build_dpcpp_cross, build_sycl_cts_riscv64_native_cpu]
     runs-on: 'ubuntu-24.04'
     container:
       image: 'ghcr.io/uxlfoundation/ock_ubuntu_24.04-x86-64:latest'

--- a/.github/workflows/run_ock_external_tests.yml
+++ b/.github/workflows/run_ock_external_tests.yml
@@ -296,7 +296,6 @@ jobs:
       volumes:
         - ${{github.workspace}}:${{github.workspace}}
 
-    if: inputs.test_sycl_cts
     if: inputs.test_sycl_cts && contains(inputs.target_list, 'host_aarch64_linux')
     steps:
       - name: Checkout repo


### PR DESCRIPTION
# Overview

Allow riscv64 variant of the ock_external workflow to be run independently from other architectures.

# Reason for change

Cross-compile job dependencies were wrong for riscv64 when run alone, leaving a loophole which failed the ock_external workflow. This fix restores "run alone" support for riscv, bringing it into line with other architectures.

# Description of change

- Refactor the `build_dpcpp_native_*` ock_external  jobs to allow riscv64 to be run independently of x86_64. 
- Update downstream jobs `needs:` to indicate the new dependencies involved.

# Anything else we should know?

- Various combinations of architectures - run-alone and otherwise - have been tested to verify the fix.
- Test results match those currently produced on `main`.
- Some planned_testing_caller development/testing scaffolding remains in place to reduce test time and will be removed prior to final merge.
