### PR TITLE
Remove RISC-V math_builtin_float_half_* XFail.

### DIFF
--- a/scripts/testing/sycl_cts/override_opencl_host_riscv64_linux.csv
+++ b/scripts/testing/sycl_cts/override_opencl_host_riscv64_linux.csv
@@ -1,1 +1,0 @@
-SYCL_CTS,test_math_builtin_api "math_builtin_float_half_*" --allow-running-no-tests,XFail


### PR DESCRIPTION
# Overview

Remove RISC-V math_builtin_float_half_* XFail.

# Reason for change

This too was fixed by #762.

# Description of change

*Describe the intended behaviour your changes are meant to introduce to the
project and explain how they resolve the problem stated above. Detail any
relevant changes that may affect other users of the project, such as
compilation options, runtime flags, expected inputs and outputs, API entry
points, etc.*

*If you have added new testing, provide details on what tests you have added
and what the purpose of them is.*

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-19](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
