### PR TITLE
Add initial apt-get updates for aarch64/riscv64 llvm (20) builds

### DIFF
--- a/.github/actions/do_build_llvm/action.yml
+++ b/.github/actions/do_build_llvm/action.yml
@@ -58,6 +58,7 @@ runs:
         shell: bash
         if: inputs.arch == 'aarch64' && (inputs.use_github_cache == 'false' || steps.cache.outputs.cache-hit != 'true')
         run: |
+          sudo apt-get update
           sudo apt-get install --yes g++-aarch64-linux-gnu
           echo "ARCH_FLAGS=-DCMAKE_TOOLCHAIN_FILE=$GITHUB_WORKSPACE/platform/arm-linux/aarch64-toolchain.cmake -DLLVM_HOST_TRIPLE=aarch64-unknown-linux-gnu" > $GITHUB_ENV
 
@@ -65,6 +66,7 @@ runs:
         shell: bash
         if: inputs.arch == 'riscv64' && (inputs.use_github_cache == 'false' || steps.cache.outputs.cache-hit != 'true')
         run: |
+          sudo apt-get update
           sudo apt-get install --yes g++-riscv64-linux-gnu
           echo "ARCH_FLAGS=-DCMAKE_TOOLCHAIN_FILE=$GITHUB_WORKSPACE/platform/riscv64-linux/riscv64-gcc-toolchain.cmake -DLLVM_HOST_TRIPLE=riscv64-unknown-linux-gnu" > $GITHUB_ENV
 

--- a/.github/workflows/planned_testing_caller_20.yml
+++ b/.github/workflows/planned_testing_caller_20.yml
@@ -29,5 +29,6 @@ jobs:
       # We can set ock, test_sycl_cts etc here optionally if this is used as a
       # pull request. Any parameters below this is intended for local testing
       # and should not be merged nor reviewed (other than checking it should not be merged).
+      # extras here
 
 

--- a/.github/workflows/planned_testing_caller_20.yml
+++ b/.github/workflows/planned_testing_caller_20.yml
@@ -29,6 +29,5 @@ jobs:
       # We can set ock, test_sycl_cts etc here optionally if this is used as a
       # pull request. Any parameters below this is intended for local testing
       # and should not be merged nor reviewed (other than checking it should not be merged).
-      # extras here
 
 


### PR DESCRIPTION
# Overview

Add initial `apt-get update` commands for llvm builds. Previously in place for x86_64 only.

# Reason for change

Omission of commands fails llvm 20 builds.

# Description of change

Add missing updates.

# Anything else we should know?

Test builds get passed previous point of failure.
Any dev/test scaffolding will be removed prior to final merge.
