### PR TITLE
Update llvm versions to 19/20 for pr_test_cache, codeql etc.

### DIFF
--- a/.github/actions/build_portBLAS_action/action.yml
+++ b/.github/actions/build_portBLAS_action/action.yml
@@ -17,6 +17,9 @@ runs:
        # installs tools, ninja, installs llvm and sets up sccahe
     - name: setup ubuntu
       uses:  ./.github/actions/setup_build
+      with:
+        llvm_version: 19
+        llvm_build_type: RelAssert
 
     - name: Get Intel OneAPI BaseToolkit
       shell: bash

--- a/.github/actions/setup_build/action.yml
+++ b/.github/actions/setup_build/action.yml
@@ -9,8 +9,7 @@ inputs:
     description: 'llvm Build type (Release, RelAssert) - note we need to use RelAssert for the cache pattern matching'
     default: RelAssert
   llvm_version:
-    description: 'Major llvm version to use for fetching llvm cache e.g. 18'
-    default: 18
+    description: 'Major llvm version to use for fetching llvm cache e.g. 19'
   ubuntu_version:
     description: 'Version of ubuntu used for cache retrieval and prerequisites'
     default: 22.04

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,11 +24,11 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
 
-      # installs tools, ninja and installs llvm (default 18, RelAssert) and sets up cache
+      # installs tools, ninja and installs llvm (default 19, RelAssert) and sets up cache
       - name: setup-ubuntu
         uses:  ./.github/actions/setup_build
         with:
-          llvm_version: 18
+          llvm_version: 19
           llvm_build_type: RelAssert
 
       # Initializes the CodeQL tools for scanning.
@@ -79,7 +79,7 @@ jobs:
       - name: setup-ubuntu
         uses:  ./.github/actions/setup_build
         with:
-          llvm_version: 18
+          llvm_version: 19
           llvm_build_type: RelAssert
 
       # Initializes the CodeQL tools for scanning.

--- a/.github/workflows/create_publish_artifacts.yml
+++ b/.github/workflows/create_publish_artifacts.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Setup ubuntu
         uses:  ./.github/actions/setup_build
         with:
-          llvm_version: 18
+          llvm_version: 19
           llvm_build_type: Release
 
       - name: Setup python

--- a/.github/workflows/pr_tests_cache.yml
+++ b/.github/workflows/pr_tests_cache.yml
@@ -21,8 +21,8 @@ on:
   workflow_dispatch:
 
 env:
-  llvm_previous: '18'
-  llvm_current: '19'
+  llvm_previous: '19'
+  llvm_current: '20'
 
 concurrency:
   group: pr-test-cache-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/run_ock_demo.yml
+++ b/.github/workflows/run_ock_demo.yml
@@ -31,7 +31,7 @@ jobs:
       - name: setup ubuntu
         uses:  ./.github/actions/setup_build
         with:
-          llvm_version: 18
+          llvm_version: 19
           llvm_build_type: RelAssert
 
       - name: setup python

--- a/.github/workflows/run_ock_internal_tests.yml
+++ b/.github/workflows/run_ock_internal_tests.yml
@@ -50,12 +50,10 @@ on:
         required: false
         type: string
         description: 'previous llvm version to for those jobs tied to previous.'
-        default: '18'
       llvm_current:
         required: false
         type: string
         description: 'previous llvm version to for those jobs tied to current.'        
-        default: '19'
 
 permissions:
   packages: read


### PR DESCRIPTION
# Overview

Update llvm versions to 19/20 for pr_test_cache, codeql etc.

# Reason for change

18 has been dropped, these workflow should have been updated too.

# Description of change

Dropped default from setup_build and updated to 19/20 on pr_test_cache, codeql and the ock demo
