### PR TITLE
Fix pr tests cache for cases where it required a cache

### DIFF
--- a/.github/workflows/pr_tests_cache.yml
+++ b/.github/workflows/pr_tests_cache.yml
@@ -100,40 +100,10 @@ jobs:
         with:
           cache_seed: true
 
-  # 32 bit x86
-  ubuntu_22_llvm_current_x86_jobs:
-    if: github.repository == 'uxlfoundation/oneapi-construction-kit' || github.event_name != 'schedule'
-    needs: [ubuntu_22_llvm_current_jobs]  
-    runs-on: ubuntu-22.04
-    container:
-      image: ghcr.io/uxlfoundation/ock_ubuntu_22.04-x86-64:latest
-      volumes:
-        - ${{github.workspace}}:${{github.workspace}}    
-    steps:
-      - name: Checkout repo
-        uses: actions/checkout@v4
-
-      # installs tools, ninja, installs llvm and sets up sccache
-      - name: setup-ubuntu
-        uses:  ./.github/actions/setup_build
-        with:
-          llvm_version: ${{ env.llvm_current }}
-          llvm_build_type: RelAssert
-          save: true
-          cross_arch: x86
-          # Whilst we still have caches use this for 32 bit x86
-          # We may have to drop this or run just this part as part of the nightly.
-          llvm_source: cache
-
-      - name: build ubuntu_clang_x86_llvm_latest_cl3_0_offline
-        uses: ./.github/actions/do_build_pr/run_ubuntu_clang_x86_llvm_latest_cl3_0_offline
-        with:
-          cache_seed: true
-
   # aarch 64
   ubuntu_22_llvm_current_aarch64_jobs:
     if: github.repository == 'uxlfoundation/oneapi-construction-kit' || github.event_name != 'schedule'
-    needs: [ubuntu_22_llvm_current_x86_jobs]  
+    needs: [ubuntu_22_llvm_current_jobs]  
     runs-on: ubuntu-22.04-arm
     container:
       image: ghcr.io/uxlfoundation/ock_ubuntu_22.04-aarch64:latest
@@ -157,32 +127,32 @@ jobs:
         with:
           cache_seed: true
 
-  windows_llvm_current_jobs:
-    if: github.repository == 'uxlfoundation/oneapi-construction-kit' || github.event_name != 'schedule'
-    needs: [ubuntu_22_llvm_current_aarch64_jobs]    
-    runs-on: windows-2019
-    steps:    
-      - name: Setup Windows llvm base
-        uses: llvm/actions/setup-windows@main
-        with:
-          arch: amd64
+  # Restore when PR #707 is merged means windows jobs is restored to PR testing
+  # windows_llvm_current_jobs:
+  #   if: github.repository == 'uxlfoundation/oneapi-construction-kit' || github.event_name != 'schedule'
+  #   runs-on: windows-2019
+  #   steps:    
+  #     - name: Setup Windows llvm base
+  #       uses: llvm/actions/setup-windows@main
+  #       with:
+  #         arch: amd64
 
-      - name: Checkout repo
-        uses: actions/checkout@v4
+  #     - name: Checkout repo
+  #       uses: actions/checkout@v4
 
-      # installs tools, ninja, installs llvm and sets up ccache
-      - name: setup-windows
-        uses:  ./.github/actions/setup_build
-        with:
-          llvm_version: ${{ env.llvm_current }}
-          llvm_build_type: RelAssert
-          save: true
-          os: windows
-          llvm_source: cache
-      - name: build windows_msvc_x86_64_llvm_latest_cl3_0_offline
-        uses: ./.github/actions/do_build_pr/run_windows_msvc_x86_64_llvm_latest_cl3_0_offline
-        with:
-          cache_seed: true
+  #     # installs tools, ninja, installs llvm and sets up ccache
+  #     - name: setup-windows
+  #       uses:  ./.github/actions/setup_build
+  #       with:
+  #         llvm_version: ${{ env.llvm_current }}
+  #         llvm_build_type: RelAssert
+  #         save: true
+  #         os: windows
+  #         llvm_source: install
+  #     - name: build windows_msvc_x86_64_llvm_latest_cl3_0_offline
+  #       uses: ./.github/actions/do_build_pr/run_windows_msvc_x86_64_llvm_latest_cl3_0_offline
+  #       with:
+  #         cache_seed: true
 
 
   # The following tries to delete old caches but fails on the branch due to permissions errors
@@ -190,7 +160,8 @@ jobs:
 
   clean_cache:
     if: github.repository == 'uxlfoundation/oneapi-construction-kit' || github.event_name != 'schedule'
-    needs: [windows_llvm_current_jobs]
+    # Note when windows job is restored, the dependency should be added here.
+    needs: [ubuntu_22_llvm_current_aarch64_jobs]
     runs-on: ubuntu-latest
     permissions:
       actions: write


### PR DESCRIPTION


# Overview

This resolves previous failures, by dropping 32 bit x86 caching and commenting out the windows seeding.

Note the windows seeding should be restored as soon as PR #707 is merged.

# Reason for change

Failing to run to completion due to cache dependencies which are no longer valid.
