### PR TITLE
[LLVM 19] Fix workaround for loop vectorizer issue.

### DIFF
--- a/modules/compiler/compiler_pipeline/source/remove_address_spaces_pass.cpp
+++ b/modules/compiler/compiler_pipeline/source/remove_address_spaces_pass.cpp
@@ -114,6 +114,12 @@ PreservedAnalyses compiler::utils::RemoveAddressSpacesPass::run(
         continue;
       }
 
+      // For ret instructions, operand types need to match return type.
+      if (auto *RI = dyn_cast<ReturnInst>(&I); RI && RI->getReturnValue()) {
+        Changed |= MaybeCastOperand(I, I.getOperandUse(0), F.getReturnType());
+        continue;
+      }
+
       // For insertvalue instructions, operand types need to match structure or
       // array element type.
       if (auto *IVI = dyn_cast<InsertValueInst>(&I)) {


### PR DESCRIPTION
# Overview

[LLVM 19] Fix workaround for loop vectorizer issue.

# Reason for change

The RemoveAddressSpacesPass was failing to handle functions which return address-space-qualified pointers.

# Description of change

*Describe the intended behaviour your changes are meant to introduce to the
project and explain how they resolve the problem stated above. Detail any
relevant changes that may affect other users of the project, such as
compilation options, runtime flags, expected inputs and outputs, API entry
points, etc.*

*If you have added new testing, provide details on what tests you have added
and what the purpose of them is.*

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-19](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
