### PR TITLE
Fix for disabled path for city runner

### DIFF
--- a/.github/workflows/planned_testing_caller.yml
+++ b/.github/workflows/planned_testing_caller.yml
@@ -21,6 +21,10 @@ on:
         type: boolean
         description: 'Enable testing sycl-cts'
         default: true
+      test_sycl_e2e:
+        type: boolean
+        description: 'Enable testing sycl-e2e'
+        default: true
       test_opencl_cts:
         type: boolean
         description: 'Enable testing opencl-cts'
@@ -85,6 +89,7 @@ jobs:
       ock: ${{ inputs.ock }}
       test_tornado: ${{ inputs.test_tornado }}
       test_sycl_cts: ${{ inputs.test_sycl_cts }}
+      test_sycl_e2e: ${{ inputs.test_sycl_e2e }}
       test_opencl_cts: ${{ inputs.test_opencl_cts }}
       native_cpu: ${{ inputs.native_cpu }}
 

--- a/.github/workflows/planned_testing_caller_19.yml
+++ b/.github/workflows/planned_testing_caller_19.yml
@@ -22,20 +22,20 @@ jobs:
       use_llvm_github_cache: true
       # We can set ock, test_sycl_cts etc here optionally if this is used as a pull request.
       # Any with parameters below this is intended for local testing and should not be merged.
-      target_list: '[ "host_x86_64_linux" ]'
-      ock: true
-      native_cpu: true
-      test_tornado: false
-      test_sycl_cts: true
-      test_opencl_cts: true
-      test_sycl_e2e: true
-      run_internal: false
-      run_external: true
+      # target_list: '[ "host_x86_64_linux" ]'
+      # ock: true
+      # native_cpu: true
+      # test_tornado: true
+      # test_sycl_cts: true
+      # test_sycl_e2e: true      
+      # test_opencl_cts: true
+      # run_internal: true
+      # run_external: true
       # build_llvm: true
 
       # # These can be set to a workflow run-id to download from a previous workflow. This can be seen from
       # # the action run of a job or workflow
       # # e.g. https://github.com/uxlfoundation/oneapi-construction-kit/actions/runs/<run-id>/.....
-      download_ock_artefact: host_x86_64_linux=14500551627;host_aarch64_linux=14500551627;host_riscv64_linux=14500551627
-      download_dpcpp_artefact: host_x86_64_linux=14500551627;host_aarch64_linux=14500551627;host_riscv64_linux=14500551627
-      download_sycl_cts_artefact: host_x86_64_linux=14500551627;host_aarch64_linux=14500551627;host_riscv64_linux=14500551627
+      # download_ock_artefact: host_x86_64_linux=14225268091;host_aarch64_linux=14225268091;host_riscv64_linux=14225268091
+      # download_dpcpp_artefact: host_x86_64_linux=14225268091;host_aarch64_linux=14225268091;host_riscv64_linux=14225268091
+      # download_sycl_cts_artefact: host_x86_64_linux=14225268091;host_aarch64_linux=14225268091;host_riscv64_linux=14225268091

--- a/.github/workflows/planned_testing_caller_19.yml
+++ b/.github/workflows/planned_testing_caller_19.yml
@@ -22,19 +22,20 @@ jobs:
       use_llvm_github_cache: true
       # We can set ock, test_sycl_cts etc here optionally if this is used as a pull request.
       # Any with parameters below this is intended for local testing and should not be merged.
-      # target_list: '[ "host_x86_64_linux" ]'
-      # ock: true
-      # native_cpu: true
-      # test_tornado: true
-      # test_sycl_cts: true
-      # test_opencl_cts: true
-      # run_internal: true
-      # run_external: true
+      target_list: '[ "host_x86_64_linux" ]'
+      ock: true
+      native_cpu: true
+      test_tornado: false
+      test_sycl_cts: true
+      test_opencl_cts: true
+      test_sycl_e2e: true
+      run_internal: false
+      run_external: true
       # build_llvm: true
 
       # # These can be set to a workflow run-id to download from a previous workflow. This can be seen from
       # # the action run of a job or workflow
       # # e.g. https://github.com/uxlfoundation/oneapi-construction-kit/actions/runs/<run-id>/.....
-      # download_ock_artefact: host_x86_64_linux=14225268091;host_aarch64_linux=14225268091;host_riscv64_linux=14225268091
-      # download_dpcpp_artefact: host_x86_64_linux=14225268091;host_aarch64_linux=14225268091;host_riscv64_linux=14225268091
-      # download_sycl_cts_artefact: host_x86_64_linux=14225268091;host_aarch64_linux=14225268091;host_riscv64_linux=14225268091
+      download_ock_artefact: host_x86_64_linux=14500551627;host_aarch64_linux=14500551627;host_riscv64_linux=14500551627
+      download_dpcpp_artefact: host_x86_64_linux=14500551627;host_aarch64_linux=14500551627;host_riscv64_linux=14500551627
+      download_sycl_cts_artefact: host_x86_64_linux=14500551627;host_aarch64_linux=14500551627;host_riscv64_linux=14500551627

--- a/scripts/testing/city_runner/test_info.py
+++ b/scripts/testing/city_runner/test_info.py
@@ -228,6 +228,12 @@ class TestList(object):
                         test_name = executable.name
                     test = TestInfo(test_name, executable, arguments,
                                     device_filter)
+                    test.ignore = ignored
+                    test.disabled = disabled
+                    test.unimplemented = unimplemented
+                    test.xfail = xfail
+                    test.mayfail = mayfail
+
                     if len(chunks) >= 3:
                         test.update_test_info_from_attribute(chunks[2])
 

--- a/scripts/testing/sycl_e2e/override_opencl.csv
+++ b/scripts/testing/sycl_e2e/override_opencl.csv
@@ -119,7 +119,7 @@ SYCL,Graph/RecordReplay/buffer_copy_2d.cpp,XFail
 SYCL,Graph/RecordReplay/buffer_copy_offsets.cpp,XFail
 SYCL,Graph/RecordReplay/host_task2.cpp,XFail
 SYCL,Graph/Threading/submit.cpp,XFail
-SYCL,HierPar/hier_par_basic.cpp,XFail
+SYCL,HierPar/hier_par_basic.cpp,MayFail
 SYCL,HierPar/hier_par_wgscope_O0.cpp,MayFail
 SYCL,KernelCompiler/sycl.cpp,XFail
 SYCL,KernelCompiler/sycl_device_globals.cpp,XFail


### PR DESCRIPTION
# Overview
   
The fix is to restore the updating of test_info's variables from the disabled list amongst others, whilst keeping the refactored update using a function.

# Reason for change

This was broken in a recent refactoring causing some test to be run that were disabled.
