### PR TITLE
Fix up Instrinsic::getAttributes to work across LLVM versions

### DIFF
--- a/modules/compiler/compiler_pipeline/source/builtin_info.cpp
+++ b/modules/compiler/compiler_pipeline/source/builtin_info.cpp
@@ -336,7 +336,8 @@ Builtin BuiltinInfo::analyzeBuiltin(const Function &F) const {
     int32_t Properties = eBuiltinPropertyNone;
 
     const Intrinsic::ID IntrID = (Intrinsic::ID)F.getIntrinsicID();
-    const AttributeList AS = Intrinsic::getAttributes(F.getContext(), IntrID);
+    const AttributeList AS = multi_llvm::Intrinsic::getAttributes(
+        F.getContext(), IntrID, F.getFunctionType());
     const bool NoSideEffect = F.onlyReadsMemory();
     bool SafeIntrinsic = false;
     switch (IntrID) {


### PR DESCRIPTION
# Overview

Support multiple Intrinsic::getAttributes() versions by using templates to allow support for both. This can be simplified in the future once dpc++ catches up with LLVM in this aspect.

# Reason for change

LLVM has changed the function signature of Instrinsic::getAttributes
