### PR TITLE
Fix UnitCL test IncrementKernelTwiceDifferentQueues

### DIFF
--- a/source/cl/test/UnitCL/source/cl_khr_command_buffer/clEnqueueCommandBufferKHR.cpp
+++ b/source/cl/test/UnitCL/source/cl_khr_command_buffer/clEnqueueCommandBufferKHR.cpp
@@ -150,6 +150,9 @@ TEST_F(CommandBufferEnqueueTest, IncrementKernelTwiceDifferentQueues) {
   EXPECT_SUCCESS(clEnqueueFillBuffer(command_queue, counter_buffer, &zero,
                                      sizeof(cl_int), 0, sizeof(cl_int), 0,
                                      nullptr, nullptr));
+  // We need the fill to be complete before testing the multiple enqueues on the
+  // different queues.
+  clFinish(command_queue);
 
   EXPECT_SUCCESS(clSetKernelArg(kernel, 0, sizeof(cl_mem),
                                 static_cast<void *>(&counter_buffer)));


### PR DESCRIPTION
# Overview

This fixes the IncrementKernelTwiceDifferentQueues UnitCL test by doing a clFinish on the command queue immediately after the fill.

# Reason for change

This test was occasionally failing due to a race condition on the fill, which must take place before enqueuing the command buffers.
