### PR TITLE
[vecz] Track barriers by ID.

### DIFF
--- a/modules/compiler/compiler_pipeline/source/barrier_regions.cpp
+++ b/modules/compiler/compiler_pipeline/source/barrier_regions.cpp
@@ -448,11 +448,12 @@ void compiler::utils::Barrier::Run(llvm::ModuleAnalysisManager &mam) {
   bi_ = &mam.getResult<BuiltinInfoAnalysis>(module_);
   FindBarriers();
 
+  kernel_id_map_[kBarrier_EndID] = nullptr;
+
   if (barriers_.empty()) {
     // If there are no barriers, we can use the original function as the
     // single barrier region.
-    barrier_graph.emplace_back();
-    auto &node = barrier_graph.back();
+    auto &node = barrier_region_id_map_[kBarrier_FirstID];
     node.entry = &func_.getEntryBlock();
     node.id = kBarrier_FirstID;
     node.successor_ids.push_back(kBarrier_EndID);
@@ -524,11 +525,9 @@ void compiler::utils::Barrier::FindBarriers() {
         if (callee != nullptr) {
           const auto B = bi_->analyzeBuiltin(*callee);
           if (BuiltinInfo::isMuxBuiltinWithWGBarrierID(B.ID)) {
-            unsigned id = ~0u;
             auto *const id_param = call_inst->getOperand(0);
-            if (auto *const id_param_c = dyn_cast<ConstantInt>(id_param)) {
-              id = id_param_c->getZExtValue();
-            }
+            auto *const id_param_c = cast<ConstantInt>(id_param);
+            const auto id = id_param_c->getZExtValue();
             orderedBarriers.emplace_back(id, call_inst);
           }
         }
@@ -559,13 +558,15 @@ void compiler::utils::Barrier::SplitBlockwithBarrier() {
     exit_stub = MakeStubFunction("__barrier_exit", module_, stub_cc);
   }
 
-  barrier_graph.emplace_back();
-  auto &node = barrier_graph.back();
+  auto &node = barrier_region_id_map_[kBarrier_FirstID];
   node.entry = &func_.getEntryBlock();
   node.id = kBarrier_FirstID;
 
-  unsigned barrier_id = kBarrier_StartNewID;
   for (CallInst *split_point : barriers_) {
+    // ID identifying which barrier invoked stub used as argument to call.
+    auto *id = cast<ConstantInt>(split_point->getOperand(0));
+    const auto barrier_id = kBarrier_StartNewID + id->getZExtValue();
+
     if (is_debug_) {
       assert(entry_stub != nullptr);  // Guaranteed as is_debug_ is const.
       assert(exit_stub != nullptr);   // Guaranteed as is_debug_ is const.
@@ -575,10 +576,6 @@ void compiler::utils::Barrier::SplitBlockwithBarrier() {
       // them at a point where live variables have already been loaded. This
       // info won't be available till later.
 
-      // ID identifying which barrier invoked stub used as argument to call.
-      // This number monotonically increases from 0 for each barrier.
-      auto id = ConstantInt::get(Type::getInt32Ty(module_.getContext()),
-                                 barrier_id - kBarrier_StartNewID);
       // Call invoking entry stub
       auto entry_caller = CallInst::Create(entry_stub, id);
       entry_caller->setDebugLoc(split_point->getDebugLoc());
@@ -594,10 +591,9 @@ void compiler::utils::Barrier::SplitBlockwithBarrier() {
           std::make_pair(entry_caller, exit_caller);
     }
 
-    barrier_graph.emplace_back();
-    auto &node = barrier_graph.back();
+    auto &node = barrier_region_id_map_[barrier_id];
     node.barrier_inst = split_point;
-    node.id = barrier_id++;
+    node.id = barrier_id;
     node.schedule = getBarrierSchedule(*split_point);
 
     // Our scan implementation requires a linear work-item ordering, to loop
@@ -614,7 +610,7 @@ void compiler::utils::Barrier::SplitBlockwithBarrier() {
   // We have to gather the basic block data after splitting, because we
   // might not be processing barriers in program order, and things can get
   // awfully confused.
-  for (auto &node : barrier_graph) {
+  for (auto &[i, node] : barrier_region_id_map_) {
     if (node.barrier_inst) {
       auto *const bb = node.barrier_inst->getParent();
       barrier_id_map_[bb] = node.id;
@@ -781,7 +777,7 @@ void compiler::utils::Barrier::FindLiveVariables() {
     }
   }
 
-  for (auto &region : barrier_graph) {
+  for (auto &[i, region] : barrier_region_id_map_) {
     GatherBarrierRegionBlocks(region);
     GatherBarrierRegionUses(region, func_args);
     whole_live_variables_set_.set_union(region.uses_int);
@@ -1161,9 +1157,9 @@ Function *compiler::utils::Barrier::GenerateNewKernel(BarrierRegion &region) {
     } else if (ReturnInst *ret =
                    dyn_cast<ReturnInst>(cloned_bb->getTerminator())) {
       // Change return instruction with end barrier number.
-      ConstantInt *cst_zero =
+      ConstantInt *cst_endid =
           ConstantInt::get(Type::getInt32Ty(context), kBarrier_EndID);
-      ReturnInst *new_ret = ReturnInst::Create(context, cst_zero);
+      ReturnInst *new_ret = ReturnInst::Create(context, cst_endid);
       new_ret->insertBefore(ret->getIterator());
       ret->replaceAllUsesWith(new_ret);
       ret->eraseFromParent();
@@ -1461,7 +1457,7 @@ BasicBlock *compiler::utils::Barrier::CloneBasicBlock(
 void compiler::utils::Barrier::SeperateKernelWithBarrier() {
   if (barriers_.empty()) return;
 
-  for (auto &region : barrier_graph) {
+  for (auto &[i, region] : barrier_region_id_map_) {
     kernel_id_map_[region.id] = GenerateNewKernel(region);
   }
 
@@ -1478,15 +1474,10 @@ void compiler::utils::Barrier::SeperateKernelWithBarrier() {
 
   LLVM_DEBUG({
     for (const auto &Kid : kernel_id_map_) {
-      dbgs() << "1. kernel_id[" << Kid.first << "] = " << Kid.second->getName()
+      dbgs() << "kernel_id[" << Kid.first << "] = " << Kid.second->getName()
              << "\n";
     }
 
-    for (unsigned I = kBarrier_FirstID;
-         I < kernel_id_map_.size() + kBarrier_FirstID; I++) {
-      dbgs() << "2. kernel_id[" << I << "] = " << kernel_id_map_[I]->getName()
-             << "\n";
-    }
     dbgs() << "\n\n" << module_ << "\n\n";
   });
 }

--- a/modules/compiler/test/lit/passes/barriers-mismatch.ll
+++ b/modules/compiler/test/lit/passes/barriers-mismatch.ll
@@ -1,0 +1,87 @@
+; Copyright (C) Codeplay Software Limited
+;
+; Licensed under the Apache License, Version 2.0 (the "License") with LLVM
+; Exceptions; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/LICENSE.txt
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+; WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+; License for the specific language governing permissions and limitations
+; under the License.
+;
+; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+; RUN: muxc --passes work-item-loops,verify -S %s  | FileCheck %s
+
+; This test checks the validity of a set of main/tail loops when the
+; barriers between vector and scalar kernels do not match up.
+
+target triple = "spir64-unknown-unknown"
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+
+define spir_kernel void @foo(ptr addrspace(1) %a) !codeplay_ca_vecz.base !0 {
+entry:
+  store i1 false, ptr addrspace(1) %a, align 4
+  call void @__mux_work_group_barrier(i32 0, i32 1, i32 272) #8
+  %load = load i1, ptr addrspace(1) %a, align 4
+  call void @__mux_work_group_barrier(i32 1, i32 1, i32 272) #8
+  br i1 %load, label %bb.1, label %bb.2
+
+bb.1:
+  store i1 poison, ptr addrspace(1) poison
+  call void @__mux_work_group_barrier(i32 2, i32 1, i32 272) #8
+  br label %bb.3
+
+bb.2:
+  store i1 true, ptr addrspace(1) %a
+  call void @__mux_work_group_barrier(i32 3, i32 1, i32 272) #8
+  br label %bb.3
+
+bb.3:
+  call void @__mux_work_group_barrier(i32 4, i32 1, i32 272) #8
+  ret void
+}
+
+define spir_kernel void @__vecz_v2_foo(ptr addrspace(1) %a) #0 !codeplay_ca_vecz.derived !2 {
+entry:
+  store i1 false, ptr addrspace(1) %a, align 4
+  call void @__mux_work_group_barrier(i32 0, i32 1, i32 272)
+  %load = load i1, ptr addrspace(1) %a, align 4
+  call void @__mux_work_group_barrier(i32 1, i32 1, i32 272)
+  %0 = xor i1 %load, true
+  call void @llvm.assume(i1 %0)
+  store i1 true, ptr addrspace(1) %a, align 1
+  call void @__mux_work_group_barrier(i32 3, i32 1, i32 272)
+  call void @__mux_work_group_barrier(i32 4, i32 1, i32 272)
+  ret void
+}
+
+declare void @__mux_work_group_barrier(i32, i32, i32)
+
+attributes #0 = { norecurse nounwind "mux-kernel"="entry-point" "mux-base-fn-name"="foo"}
+attributes #1 = { nounwind "mux-barrier-schedule"="linear" }
+
+; The block which has conditional undefined behavior in the scalar kernel.
+;
+; CHECK-LABEL: define internal spir_func i32 @foo.mux-barrier-region.6(ptr addrspace(1) %0, ptr %1)
+; CHECK:       bb.1:
+; CHECK-NEXT:    store i1 poison, ptr addrspace(1) poison, align 1
+;
+; The block which only follows after undefined behavior in the scalar kernel.
+;
+; CHECK-LABEL: define internal spir_func i32 @foo.mux-barrier-region.7(ptr addrspace(1) %0, ptr %1)
+; CHECK-NEXT:  barrier2:
+;
+; Check that we do not call the unreachable region.
+;
+; CHECK-LABEL: define spir_kernel void @foo.mux-barrier-wrapper(ptr addrspace(1) %a)
+; CHECK:         call spir_func i32 @foo.mux-barrier-region.6(
+; CHECK-NOT:     call spir_func i32 @foo.mux-barrier-region.7(
+
+; Vectorized by 2
+!0 = !{!1, ptr @__vecz_v2_foo}
+!1 = !{i32 2, i32 0, i32 0, i32 0}
+!2 = !{!1, ptr @foo}


### PR DESCRIPTION
# Overview

[vecz] Track barriers by ID.

# Reason for change

We were tracking barriers by their index, which can (rarely) break when optimizations on vectorized kernels cause barriers to be optimized away before the work item loops pass runs.

# Description of change

All barriers have a unique ID at this point already, which we can use to track them instead.

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-19](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
