### PR TITLE
[builtins] Improve robustness.

### DIFF
--- a/modules/compiler/compiler_pipeline/include/compiler/utils/cl_builtin_info.h
+++ b/modules/compiler/compiler_pipeline/include/compiler/utils/cl_builtin_info.h
@@ -91,7 +91,7 @@ class CLBuiltinInfo : public BILangInfoConcept {
                                      unsigned SimdDimIdx) const override;
 
   /// @see BuiltinInfo::analyzeBuiltin
-  Builtin analyzeBuiltin(const llvm::Function &F) const override;
+  std::optional<Builtin> analyzeBuiltin(const llvm::Function &F) const override;
   /// @see BuiltinInfo::getVectorEquivalent
   llvm::Function *getVectorEquivalent(const Builtin &B, unsigned Width,
                                       llvm::Module *M = nullptr) override;
@@ -106,10 +106,10 @@ class CLBuiltinInfo : public BILangInfoConcept {
   llvm::Instruction *lowerBuiltinToMuxBuiltin(llvm::CallInst &,
                                               BIMuxInfoConcept &) override;
   /// @see BuiltinInfo::getPrintfBuiltin
-  BuiltinID getPrintfBuiltin() const override;
+  std::optional<BuiltinID> getPrintfBuiltin() const override;
 
  private:
-  BuiltinID identifyBuiltin(const llvm::Function &) const;
+  std::optional<BuiltinID> identifyBuiltin(const llvm::Function &) const;
 
   llvm::Function *materializeBuiltin(
       llvm::StringRef BuiltinName, llvm::Module *DestM = nullptr,

--- a/modules/compiler/compiler_pipeline/source/add_scheduling_parameters_pass.cpp
+++ b/modules/compiler/compiler_pipeline/source/add_scheduling_parameters_pass.cpp
@@ -73,10 +73,10 @@ PreservedAnalyses compiler::utils::AddSchedulingParametersPass::run(
       continue;
     }
     const auto B = BI.analyzeBuiltin(F);
-    if (B.isUnknown() || !B.isValid()) {
+    if (!B || B->isUnknown()) {
       continue;
     }
-    if (BI.requiresSchedulingParameters(B.ID)) {
+    if (BI.requiresSchedulingParameters(B->ID)) {
       Visited.insert(&F);
       Worklist.insert(&F);
       LeafBuiltins.insert(&F);

--- a/modules/compiler/compiler_pipeline/source/define_mux_dma_pass.cpp
+++ b/modules/compiler/compiler_pipeline/source/define_mux_dma_pass.cpp
@@ -30,7 +30,7 @@ PreservedAnalyses compiler::utils::DefineMuxDmaPass::run(
   // Define all mux dma builtins
   for (auto &F : M.functions()) {
     auto Builtin = BI.analyzeBuiltin(F);
-    if (!BI.isMuxDmaBuiltinID(Builtin.ID)) {
+    if (!Builtin || !BI.isMuxDmaBuiltinID(Builtin->ID)) {
       continue;
     }
     LLVM_DEBUG(dbgs() << "  Defining mux DMA builtin: " << F.getName()
@@ -39,7 +39,7 @@ PreservedAnalyses compiler::utils::DefineMuxDmaPass::run(
     // Define the builtin. If it declares any new dependent builtins, those
     // will be appended to the module's function list and so will be
     // encountered by later iterations.
-    if (BI.defineMuxBuiltin(Builtin.ID, M, Builtin.mux_overload_info)) {
+    if (BI.defineMuxBuiltin(Builtin->ID, M, Builtin->mux_overload_info)) {
       Changed = true;
     }
   }

--- a/modules/compiler/compiler_pipeline/source/lower_to_mux_builtins_pass.cpp
+++ b/modules/compiler/compiler_pipeline/source/lower_to_mux_builtins_pass.cpp
@@ -27,7 +27,7 @@ PreservedAnalyses compiler::utils::LowerToMuxBuiltinsPass::run(
   SmallVector<CallInst *, 8> Calls;
   for (auto &F : M.functions()) {
     auto B = BI.analyzeBuiltin(F);
-    if (B.properties & eBuiltinPropertyLowerToMuxBuiltin) {
+    if (B && B->properties & eBuiltinPropertyLowerToMuxBuiltin) {
       for (auto *U : F.users()) {
         if (auto *CI = dyn_cast<CallInst>(U)) {
           Calls.push_back(CI);

--- a/modules/compiler/compiler_pipeline/source/replace_wgc_pass.cpp
+++ b/modules/compiler/compiler_pipeline/source/replace_wgc_pass.cpp
@@ -68,7 +68,7 @@ Value *createSubgroupReduction(IRBuilder<> &Builder, llvm::Value *Src,
                                const compiler::utils::GroupCollective &WGC,
                                compiler::utils::BuiltinInfo &BI) {
   using namespace compiler::utils;
-  BuiltinID ReductionID = eBuiltinInvalid;
+  BuiltinID ReductionID;
   switch (WGC.Recurrence) {
     default:
       return nullptr;
@@ -123,7 +123,6 @@ Value *createSubgroupReduction(IRBuilder<> &Builder, llvm::Value *Src,
                                    : eMuxBuiltinSubgroupReduceLogicalXor;
       break;
   }
-  assert(ReductionID != eBuiltinInvalid);
 
   auto *const Ty = Src->getType();
   auto *const M = Builder.GetInsertBlock()->getModule();
@@ -138,7 +137,7 @@ Value *createSubgroupScan(IRBuilder<> &Builder, llvm::Value *Src,
                           RecurKind Kind, bool IsInclusive, bool IsLogical,
                           compiler::utils::BuiltinInfo &BI) {
   using namespace compiler::utils;
-  BuiltinID ScanBuiltinID = eBuiltinInvalid;
+  BuiltinID ScanBuiltinID;
   switch (Kind) {
     default:
       return nullptr;
@@ -212,7 +211,6 @@ Value *createSubgroupScan(IRBuilder<> &Builder, llvm::Value *Src,
       }
       break;
   }
-  assert(ScanBuiltinID != eBuiltinInvalid);
 
   auto *const Ty = Src->getType();
   auto *const M = Builder.GetInsertBlock()->getModule();
@@ -612,10 +610,11 @@ PreservedAnalyses compiler::utils::ReplaceWGCPass::run(
   // iterators.
   SmallVector<std::pair<Function *, GroupCollective>, 8> WGCollectives{};
   for (auto &F : M) {
-    auto Builtin = BI.analyzeBuiltin(F);
-    if (auto WGC = BI.isMuxGroupCollective(Builtin.ID);
-        WGC && WGC->isWorkGroupScope()) {
-      WGCollectives.push_back({&F, *WGC});
+    if (auto Builtin = BI.analyzeBuiltin(F)) {
+      if (auto WGC = BI.isMuxGroupCollective(Builtin->ID);
+          WGC && WGC->isWorkGroupScope()) {
+        WGCollectives.push_back({&F, *WGC});
+      }
     }
   }
 

--- a/modules/compiler/compiler_pipeline/source/sub_group_analysis.cpp
+++ b/modules/compiler/compiler_pipeline/source/sub_group_analysis.cpp
@@ -107,8 +107,11 @@ std::optional<Builtin> GlobalSubgroupInfo::isMuxSubgroupBuiltin(
     return std::nullopt;
   }
   auto SGBuiltin = BI.analyzeBuiltin(*F);
+  if (!SGBuiltin) {
+    return std::nullopt;
+  }
 
-  switch (SGBuiltin.ID) {
+  switch (SGBuiltin->ID) {
     default:
       break;
     case eMuxBuiltinSubGroupBarrier:
@@ -120,7 +123,7 @@ std::optional<Builtin> GlobalSubgroupInfo::isMuxSubgroupBuiltin(
       return SGBuiltin;
   }
 
-  if (auto GroupOp = BI.isMuxGroupCollective(SGBuiltin.ID);
+  if (auto GroupOp = BI.isMuxGroupCollective(SGBuiltin->ID);
       GroupOp && GroupOp->isSubGroupScope()) {
     return SGBuiltin;
   }

--- a/modules/compiler/compiler_pipeline/source/work_item_loops_pass.cpp
+++ b/modules/compiler/compiler_pipeline/source/work_item_loops_pass.cpp
@@ -423,7 +423,8 @@ struct ScheduleGenerator {
     }
 
     auto Builtin = BI.analyzeBuiltin(*BarrierCall->getCalledFunction());
-    return BI.isMuxGroupCollective(Builtin.ID);
+    assert(Builtin && "Barrier call must be a known builtin");
+    return BI.isMuxGroupCollective(Builtin->ID);
   }
 
   std::tuple<BasicBlock *, Value *,
@@ -1600,7 +1601,8 @@ Function *compiler::utils::WorkItemLoopsPass::makeWrapperFunction(
       if (auto *const CI = barrierMain.getBarrierCall(i)) {
         auto *const callee = CI->getCalledFunction();
         const auto builtin = BI.analyzeBuiltin(*callee);
-        if (builtin.ID == compiler::utils::eMuxBuiltinWorkGroupBarrier) {
+        if (builtin &&
+            builtin->ID == compiler::utils::eMuxBuiltinWorkGroupBarrier) {
           IRBuilder<> B(block);
           auto *MemBarrier =
               BI.getOrDeclareMuxBuiltin(eMuxBuiltinMemBarrier, M);

--- a/modules/compiler/source/base/source/set_convergent_attr_pass.cpp
+++ b/modules/compiler/source/base/source/set_convergent_attr_pass.cpp
@@ -42,7 +42,7 @@ PreservedAnalyses compiler::SetConvergentAttrPass::run(
       // been marked correctly already (above) or call to convergent
       // declarations (below).
       auto B = BI.analyzeBuiltin(F);
-      if (!(B.properties & utils::eBuiltinPropertyKnownNonConvergent)) {
+      if (!B || !(B->properties & utils::eBuiltinPropertyKnownNonConvergent)) {
         Worklist.insert(&F);
         ConvergentFns.insert(&F);
       }

--- a/modules/compiler/test/group_ops.cpp
+++ b/modules/compiler/test/group_ops.cpp
@@ -402,23 +402,23 @@ define void @test_wrapper(i32 %i, float %f, i32 %sg_lid, i64 %lid_x, i64 %lid_y,
         continue;
       }
       auto *const CalledFn = CI->getCalledFunction();
-      EXPECT_TRUE(CalledFn);
+      ASSERT_TRUE(CalledFn);
       MuxBuiltins.insert(CalledFn);
 
       auto Builtin = BI.analyzeBuiltin(*CalledFn);
-      const std::string InfoStr = " for function " + CalledFn->getName().str() +
-                                  " identified as ID " +
-                                  std::to_string(Builtin.ID);
-      EXPECT_NE(Builtin.ID, eBuiltinInvalid) << InfoStr;
-      EXPECT_TRUE(BI.isMuxBuiltinID(Builtin.ID)) << InfoStr;
+      std::string InfoStr = " for function " + CalledFn->getName().str();
+      ASSERT_TRUE(Builtin) << InfoStr;
+      if (!Builtin) return;
+      InfoStr += " identified as ID " + std::to_string(Builtin->ID);
+      EXPECT_TRUE(BI.isMuxBuiltinID(Builtin->ID)) << InfoStr;
 
       // Do a get-or-declare, and make sure we're getting back the exact same
       // function.
-      auto *const BuiltinDecl =
-          BI.getOrDeclareMuxBuiltin(Builtin.ID, *M, Builtin.mux_overload_info);
+      auto *const BuiltinDecl = BI.getOrDeclareMuxBuiltin(
+          Builtin->ID, *M, Builtin->mux_overload_info);
       EXPECT_TRUE(BuiltinDecl && BuiltinDecl == CalledFn) << InfoStr;
 
-      auto Info = BI.isMuxGroupCollective(Builtin.ID);
+      auto Info = BI.isMuxGroupCollective(Builtin->ID);
       ASSERT_TRUE(Info) << InfoStr;
 
       // Now check that the returned values are what we expect.
@@ -430,8 +430,8 @@ define void @test_wrapper(i32 %i, float %f, i32 %sg_lid, i64 %lid_x, i64 %lid_y,
       EXPECT_EQ(Info->Recurrence, GroupOps[GroupOpIdx].Collective.Recurrence)
           << InfoStr;
 
-      EXPECT_EQ(Builtin.ID, BI.getMuxGroupCollective(*Info)) << InfoStr;
-      EXPECT_EQ(Builtin.ID,
+      EXPECT_EQ(Builtin->ID, BI.getMuxGroupCollective(*Info)) << InfoStr;
+      EXPECT_EQ(Builtin->ID,
                 BI.getMuxGroupCollective(GroupOps[GroupOpIdx].Collective))
           << InfoStr;
 
@@ -463,9 +463,9 @@ TEST_F(GroupOpsTest, SubgroupShuffles) {
               Shuff->getArg(0)->getType() == F16Ty &&
               Shuff->getArg(1)->getType() == I32Ty);
   auto BIShuff = BI.analyzeBuiltin(*Shuff);
-  EXPECT_TRUE(BIShuff.isValid() && BIShuff.ID == eMuxBuiltinSubgroupShuffle &&
-              BIShuff.mux_overload_info.size() == 1 &&
-              *BIShuff.mux_overload_info.begin() == F16Ty);
+  EXPECT_TRUE(BIShuff && BIShuff->ID == eMuxBuiltinSubgroupShuffle &&
+              BIShuff->mux_overload_info.size() == 1 &&
+              *BIShuff->mux_overload_info.begin() == F16Ty);
 
   auto *ShuffXor =
       BI.getOrDeclareMuxBuiltin(eMuxBuiltinSubgroupShuffleXor, *M, {F16Ty});
@@ -474,9 +474,9 @@ TEST_F(GroupOpsTest, SubgroupShuffles) {
               ShuffXor->getArg(0)->getType() == F16Ty &&
               ShuffXor->getArg(1)->getType() == I32Ty);
   auto BIXor = BI.analyzeBuiltin(*ShuffXor);
-  EXPECT_TRUE(BIXor.isValid() && BIXor.ID == eMuxBuiltinSubgroupShuffleXor &&
-              BIXor.mux_overload_info.size() == 1 &&
-              *BIXor.mux_overload_info.begin() == F16Ty);
+  EXPECT_TRUE(BIXor && BIXor->ID == eMuxBuiltinSubgroupShuffleXor &&
+              BIXor->mux_overload_info.size() == 1 &&
+              *BIXor->mux_overload_info.begin() == F16Ty);
 
   auto *ShuffUp =
       BI.getOrDeclareMuxBuiltin(eMuxBuiltinSubgroupShuffleUp, *M, {F16Ty});
@@ -486,9 +486,9 @@ TEST_F(GroupOpsTest, SubgroupShuffles) {
               ShuffUp->getArg(1)->getType() == F16Ty &&
               ShuffUp->getArg(2)->getType() == I32Ty);
   auto BIUp = BI.analyzeBuiltin(*ShuffUp);
-  EXPECT_TRUE(BIUp.isValid() && BIUp.ID == eMuxBuiltinSubgroupShuffleUp &&
-              BIUp.mux_overload_info.size() == 1 &&
-              *BIUp.mux_overload_info.begin() == F16Ty);
+  EXPECT_TRUE(BIUp && BIUp->ID == eMuxBuiltinSubgroupShuffleUp &&
+              BIUp->mux_overload_info.size() == 1 &&
+              *BIUp->mux_overload_info.begin() == F16Ty);
 
   auto *ShuffDown =
       BI.getOrDeclareMuxBuiltin(eMuxBuiltinSubgroupShuffleDown, *M, {F16Ty});
@@ -499,7 +499,7 @@ TEST_F(GroupOpsTest, SubgroupShuffles) {
               ShuffDown->getArg(1)->getType() == F16Ty &&
               ShuffDown->getArg(2)->getType() == I32Ty);
   auto BIDown = BI.analyzeBuiltin(*ShuffDown);
-  EXPECT_TRUE(BIDown.isValid() && BIDown.ID == eMuxBuiltinSubgroupShuffleDown &&
-              BIDown.mux_overload_info.size() == 1 &&
-              *BIDown.mux_overload_info.begin() == F16Ty);
+  EXPECT_TRUE(BIDown && BIDown->ID == eMuxBuiltinSubgroupShuffleDown &&
+              BIDown->mux_overload_info.size() == 1 &&
+              *BIDown->mux_overload_info.begin() == F16Ty);
 }

--- a/modules/compiler/vecz/source/analysis/instantiation_analysis.cpp
+++ b/modules/compiler/vecz/source/analysis/instantiation_analysis.cpp
@@ -63,7 +63,8 @@ bool analyzeCall(const VectorizationContext &Ctx, CallInst *CI) {
     return true;
   }
 
-  const auto Props = Ctx.builtins().analyzeBuiltin(*Callee).properties;
+  auto B = Ctx.builtins().analyzeBuiltin(*Callee);
+  const auto Props = B ? B->properties : 0;
 
   // Intrinsics without side-effects can be safely instantiated.
   if (Callee->isIntrinsic() &&

--- a/modules/compiler/vecz/source/analysis/simd_width_analysis.cpp
+++ b/modules/compiler/vecz/source/analysis/simd_width_analysis.cpp
@@ -96,11 +96,12 @@ unsigned SimdWidthAnalysis::avoidSpillImpl(Function &F,
   auto ShouldConsider = [&](const Value *V) -> bool {
     // Filter out work item builtin calls such as get_local_id()
     if (auto *const CI = dyn_cast<CallInst>(V)) {
-      const Function *Callee = CI->getCalledFunction();
-      if (Callee &&
-          VU.context().builtins().analyzeBuiltin(*Callee).properties ==
-              compiler::utils::eBuiltinPropertyWorkItem) {
-        return false;
+      if (const Function *Callee = CI->getCalledFunction()) {
+        if (auto B = VU.context().builtins().analyzeBuiltin(*Callee)) {
+          if (B->properties == compiler::utils::eBuiltinPropertyWorkItem) {
+            return false;
+          }
+        }
       }
     }
     return true;

--- a/modules/compiler/vecz/source/analysis/vectorizable_function_analysis.cpp
+++ b/modules/compiler/vecz/source/analysis/vectorizable_function_analysis.cpp
@@ -74,7 +74,7 @@ bool canVectorize(const Instruction &I, const VectorizationContext &Ctx) {
       // correspond to user functions.
       const compiler::utils::BuiltinInfo &BI = Ctx.builtins();
       const auto Builtin = BI.analyzeBuiltin(*Callee);
-      if (!Builtin.isValid()) {
+      if (!Builtin) {
         // If it is a user function missing a definition, we cannot safely
         // instantiate it. For example, what if it contains calls to
         // get_global_id internally?

--- a/modules/compiler/vecz/source/transform/inline_post_vectorization_pass.cpp
+++ b/modules/compiler/vecz/source/transform/inline_post_vectorization_pass.cpp
@@ -62,8 +62,8 @@ Value *processCallSite(CallInst *CI, bool &NeedLLVMInline,
   // Emit builtins inline when they have no vector/scalar equivalent.
   IRBuilder<> B(CI);
   const auto Builtin = BI.analyzeBuiltin(*Callee);
-  if (Builtin.properties &
-      compiler::utils::eBuiltinPropertyInlinePostVectorization) {
+  if (Builtin && Builtin->properties &
+                     compiler::utils::eBuiltinPropertyInlinePostVectorization) {
     const SmallVector<Value *, 4> Args(CI->args());
     if (Value *Impl = BI.emitBuiltinInline(Callee, B, Args)) {
       VECZ_ERROR_IF(

--- a/modules/compiler/vecz/source/transform/instantiation_pass.cpp
+++ b/modules/compiler/vecz/source/transform/instantiation_pass.cpp
@@ -140,8 +140,9 @@ PacketRange InstantiationPass::instantiateCall(CallInst *CI) {
   // Handle special call instructions that return a lane ID.
   const compiler::utils::BuiltinInfo &BI = Ctx.builtins();
   const auto Builtin = BI.analyzeBuiltinCall(*CI, packetizer.dimension());
-  if (Builtin.properties & compiler::utils::eBuiltinPropertyWorkItem) {
-    const auto Uniformity = Builtin.uniformity;
+  if (Builtin &&
+      Builtin->properties & compiler::utils::eBuiltinPropertyWorkItem) {
+    const auto Uniformity = Builtin->uniformity;
     if (Uniformity == compiler::utils::eBuiltinUniformityNever) {
       // can't handle these (global/local linear ID probably)
       VECZ_FAIL();

--- a/modules/compiler/vecz/test/lit/llvm/vector_printf_def.ll
+++ b/modules/compiler/vecz/test/lit/llvm/vector_printf_def.ll
@@ -1,0 +1,43 @@
+; Copyright (C) Codeplay Software Limited
+;
+; Licensed under the Apache License, Version 2.0 (the "License") with LLVM
+; Exceptions; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/LICENSE.txt
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+; WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+; License for the specific language governing permissions and limitations
+; under the License.
+;
+; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+; RUN: veczc -k test -vecz-simd-width=4 -vecz-choices=FullScalarization -S < %s | FileCheck %s
+
+; ModuleID = 'kernel.opencl'
+target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "spir64-unknown-unknown"
+
+@.str = private unnamed_addr addrspace(2) constant [4 x i8] c"%p\0A\00", align 1
+
+define spir_kernel void @test() {
+entry:
+  %gid = call spir_func i64 @__mux_get_global_id(i32 0)
+  %printf = call spir_func i32 (ptr addrspace(2), ...) @printf(ptr addrspace(2) @.str, i64 %gid)
+  ret void
+}
+
+declare spir_func i64 @__mux_get_global_id(i32)
+
+define spir_func i32 @printf(ptr, ...) {
+  ret i32 0
+}
+
+; CHECK: define spir_kernel void @__vecz_v4_test(
+; CHECK: call spir_func i32 (ptr addrspace(2), ...) @printf(ptr addrspace(2) @.str, i64
+; CHECK: call spir_func i32 (ptr addrspace(2), ...) @printf(ptr addrspace(2) @.str, i64
+; CHECK: call spir_func i32 (ptr addrspace(2), ...) @printf(ptr addrspace(2) @.str, i64
+; CHECK: call spir_func i32 (ptr addrspace(2), ...) @printf(ptr addrspace(2) @.str, i64
+; CHECK: ret void


### PR DESCRIPTION
# Overview

[builtins] Improve robustness.

# Reason for change

*Describe how the current behaviour of the project is causing problems for you
or is otherwise unsatisfactory for your use case.*

# Description of change

* Replace eBuiltinInvalid with std::optional to force callers to figure out what to do when a function is not a built-in.
* Do not assert that CallInst::getCalledFunction() returns a function. The called operand is not required to be a function, and even if it is a function, getCalledFunction() can return nullptr on signature mismatches.
* Add a test that we no longer crash on vectorizing a kernel containing calls to printf() when a conflicting definition of printf() has been provided. This cannot happen in OpenCL, but can happen in NativeCPU.

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-19](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
