### PR TITLE
[NFC] Fix comments.

### DIFF
--- a/examples/refsi/refsi_m1/compiler/refsi_m1/source/refsi_mux_builtin_info.cpp
+++ b/examples/refsi/refsi_m1/compiler/refsi_m1/source/refsi_mux_builtin_info.cpp
@@ -61,7 +61,7 @@ static IntegerType *getTransferIDTy(Module &M) {
 // Materialize the address of a DMA memory-mapped register in a basic block.
 static Value *getDmaRegAddress(IRBuilder<> &B, unsigned RegIdx) {
   Type *const DmaRegTy = getDmaRegTy(B.getContext());
-  Type *const PtrTy = B.getPtrTy(/*AddressSpace=*/0);
+  Type *const PtrTy = B.getPtrTy(/*AddrSpace=*/0);
   Value *const DmaRegAddr = ConstantInt::get(
       DmaRegTy, REFSI_DMA_REG_ADDR(REFSI_DMA_IO_ADDRESS, RegIdx));
   return B.CreateIntToPtr(DmaRegAddr, PtrTy);

--- a/modules/compiler/compiler_pipeline/source/cl_builtin_info.cpp
+++ b/modules/compiler/compiler_pipeline/source/cl_builtin_info.cpp
@@ -2635,7 +2635,7 @@ Value *CLBuiltinInfo::emitBuiltinInlinePrintf(BuiltinID, IRBuilder<> &B,
   // Declare printf if needed.
   Function *Printf = M.getFunction("printf");
   if (!Printf) {
-    PointerType *PtrTy = B.getPtrTy(/*AddressSpace=*/0);
+    PointerType *PtrTy = B.getPtrTy(/*AddrSpace=*/0);
     FunctionType *PrintfTy = FunctionType::get(B.getInt32Ty(), {PtrTy}, true);
     Printf =
         Function::Create(PrintfTy, GlobalValue::ExternalLinkage, "printf", &M);

--- a/modules/compiler/spirv-ll/source/builder_core.cpp
+++ b/modules/compiler/spirv-ll/source/builder_core.cpp
@@ -1783,7 +1783,7 @@ llvm::Error Builder::create<OpFunction>(const OpFunction *op) {
         // interface block types
         for ([[maybe_unused]] auto _ : binding_list) {
           // Blocks are always passed by pointer
-          llvm::Type *type = IRBuilder.getPtrTy(/*AddressSpace=*/1);
+          llvm::Type *type = IRBuilder.getPtrTy(/*AddrSpace=*/1);
           SPIRV_LL_ASSERT_PTR(type);
 
           arg_types.push_back(type);
@@ -1798,7 +1798,7 @@ llvm::Error Builder::create<OpFunction>(const OpFunction *op) {
         // if this module has used any descriptor bindings add the buffer sizes
         // buffer to the argument list (1 == global address space)
         if (module.hasDescriptorBindings()) {
-          arg_types.push_back(IRBuilder.getPtrTy(/*AddressSpace=*/1));
+          arg_types.push_back(IRBuilder.getPtrTy(/*AddrSpace=*/1));
         }
 
         // create a new function type with the same return type as the original


### PR DESCRIPTION
# Overview

[NFC] Fix comments.

# Reason for change

*Describe how the current behaviour of the project is causing problems for you
or is otherwise unsatisfactory for your use case.*

# Description of change

getPtrTy()'s parameter is called AddrSpace, not AddressSpace. Adjust comments accordingly.

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-19](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
