### PR TITLE
Mark OpenCL interop tests as ignored for NativeCPU.

### DIFF
--- a/scripts/testing/sycl_cts/override_native_cpu.csv
+++ b/scripts/testing/sycl_cts/override_native_cpu.csv
@@ -1,7 +1,7 @@
 SYCL_CTS,test_host_task host_task_interop_api,XFail
 SYCL_CTS,test_kernel "Test kernel info",XFail
 SYCL_CTS,test_kernel "Behavior of kernel attribute*",MayFail
-SYCL_CTS,test_opencl_interop opencl_interop_constructors,XFail
-SYCL_CTS,test_opencl_interop opencl_interop_get,XFail
-SYCL_CTS,test_opencl_interop opencl_interop_kernel,XFail
+SYCL_CTS,test_opencl_interop opencl_interop_constructors,Ignore
+SYCL_CTS,test_opencl_interop opencl_interop_get,Ignore
+SYCL_CTS,test_opencl_interop opencl_interop_kernel,Ignore
 SYCL_CTS,test_scalars scalars_interopability_types,XFail


### PR DESCRIPTION
# Overview

Mark OpenCL interop tests as ignored for NativeCPU.

# Reason for change

Marking them as Xfail gets confusing in the error log. These tests make no sense for NativeCPU and are not built, so should not be run.

# Description of change

*Describe the intended behaviour your changes are meant to introduce to the
project and explain how they resolve the problem stated above. Detail any
relevant changes that may affect other users of the project, such as
compilation options, runtime flags, expected inputs and outputs, API entry
points, etc.*

*If you have added new testing, provide details on what tests you have added
and what the purpose of them is.*

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-19](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
