### PR TITLE
SYCL-CTS scalars_interopability_types: remove XFail.

### DIFF
--- a/scripts/testing/sycl_cts/override_native_cpu.csv
+++ b/scripts/testing/sycl_cts/override_native_cpu.csv
@@ -4,4 +4,3 @@ SYCL_CTS,test_kernel "Behavior of kernel attribute*",MayFail
 SYCL_CTS,test_opencl_interop opencl_interop_constructors,Ignore
 SYCL_CTS,test_opencl_interop opencl_interop_get,Ignore
 SYCL_CTS,test_opencl_interop opencl_interop_kernel,Ignore
-SYCL_CTS,test_scalars scalars_interopability_types,XFail

--- a/scripts/testing/sycl_cts/tests.csv
+++ b/scripts/testing/sycl_cts/tests.csv
@@ -418,7 +418,7 @@ SYCL_CTS,test_reduction reduction_without_identity_param_no_one_item_core --allo
 SYCL_CTS,test_sampler sampler_apis
 SYCL_CTS,test_sampler sampler_constructors
 SYCL_CTS,test_scalars "Fixed width types size equality"
-SYCL_CTS,test_scalars scalars_interopability_types
+SYCL_CTS,test_scalars scalars_interopability_types --allow-running-no-tests
 SYCL_CTS,test_scalars scalars_sycl_types
 SYCL_CTS,test_spec_constants "specialization_id api"
 SYCL_CTS,test_spec_constants specialization_constants_class_with_member_fun


### PR DESCRIPTION
# Overview

SYCL-CTS scalars_interopability_types: remove XFail.

# Reason for change

We marked this as failing on NativeCPU because there are no interoperability tests there, but that is inconsistent with how we handle possibly nonexistent tests elsewhere.

# Description of change

We can just run with --allow-running-no-tests to not treat that as an error.

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-19](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
