### PR TITLE
Additional clarification on Vulkan SDK removal

### DIFF
--- a/rfc-0003.md
+++ b/rfc-0003.md
@@ -37,14 +37,23 @@ reduces the maintenance overhead.
 
 Remove everything under source/vk and from all documentation that refers to it,
 as well as any github workflow or docker requirements such as installing the
-vulkan SDK. This should also be reflected in the CHANGELOG.md file ready for the
-release notes.
+vulkan SDK. Anything that exists purely for the sake of Vulkan should also be
+removed, such as the descriptor binding lists. This can be analyzed by reviewing
+the removed Vulkan code for dependencies. This should also be reflected in the
+CHANGELOG.md file ready for the release notes.
+
+There will be no references to the Vulkan API or connected code beyond 4.0.0,
+beyond what is needed for release notes.
 
 # Backwards Compatibility
 
 Since the Vulkan API will no longer be supported, there will be no backward
-compatibility in this regard. However the default build will still work for the
-OpenCL API, so current customers are unlikely to be affected.
+compatibility in this regard. Codeplay will no longer provide support for Vulkan
+API for any versions. Users may fork from 4.0.0 and fix any issues themselves if
+they wish to use the Vulkan API.
+
+The default build will still work for the OpenCL API, so current customers are
+unlikely to be affected.
 
 # Security Implications
 


### PR DESCRIPTION
# Overview

Additional clarification on Vulkan SDK removal

# Reason for change

Some comments were not fully addressed in discussions and further discussion has taken place.

# Description of change

Mention code removal and support.