### PR TITLE
Fixes for Windows on ARM.

### DIFF
--- a/modules/mux/targets/host/test/UnitCL/host_clGetDeviceInfo.cpp
+++ b/modules/mux/targets/host/test/UnitCL/host_clGetDeviceInfo.cpp
@@ -49,7 +49,7 @@ TEST_F(host_clGetDeviceInfoTest, Name) {
 #if defined(__arm__) || defined(__thumb__) || defined(_M_ARM) || \
     defined(_M_ARMT)
   const char *arch = "Arm";
-#elif defined(__aarch64__)
+#elif defined(__aarch64__) || defined(_M_ARM64)
   const char *arch = "AArch64";
 #elif defined(__i386__) || defined(_M_IX86)
   const char *arch = "x86";

--- a/modules/utils/include/utils/system.h
+++ b/modules/utils/include/utils/system.h
@@ -27,14 +27,14 @@
 /// @{
 
 #if defined(__x86_64__) || defined(_M_X64) || defined(__aarch64__) || \
-    (defined(__riscv) && __riscv_xlen == 64)
+    defined(_M_ARM64) || (defined(__riscv) && __riscv_xlen == 64)
 #define UTILS_SYSTEM_64_BIT 1
 #else
 #define UTILS_SYSTEM_32_BIT 1
 #endif
 
 #if defined(__arm__) || defined(__thumb__) || defined(_M_ARM) || \
-    defined(_M_ARMT) || defined(__aarch64__)
+    defined(_M_ARMT) || defined(__aarch64__) || defined(_M_ARM64)
 #define UTILS_SYSTEM_ARM 1
 #elif defined(__i386__) || defined(_M_IX86) || defined(__x86_64__) || \
     defined(_M_X64)

--- a/modules/utils/targets/host/source/relocations.cpp
+++ b/modules/utils/targets/host/source/relocations.cpp
@@ -42,21 +42,21 @@
 extern "C" {
 
 // Windows uses chkstk() to ensure there is enough stack space paged in.
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) || defined(__MINGW32__) || defined(__MINGW64__)
+#if defined(_MSC_VER) || !defined(UTILS_SYSTEM_X86)
 #if defined(UTILS_SYSTEM_64_BIT)
 extern void __chkstk();
 #else
 extern void _chkstk();
-#endif
-#endif  // _MSC_VER
-
-#if defined(__MINGW32__) || defined(__MINGW64__)
+#endif  // UTILS_SYSTEM_64_BIT
+#else   // _MSC_VER || !UTILS_SYSTEM_X86
 #if defined(UTILS_SYSTEM_64_BIT)
 extern void ___chkstk_ms();
 #else
 extern void(_alloca)();
-#endif
-#endif
+#endif  // UTILS_SYSTEM_64_BIT
+#endif  // _MSC_VER || !UTILS_SYSTEM_X86
+#endif  // _MSC_VER || __MINGW32__ || __MINGW64__
 
 #if defined(UTILS_SYSTEM_32_BIT)
 // On 32-bit (both x86 and Arm) long division is done in software.
@@ -165,21 +165,21 @@ std::vector<std::pair<std::string, uint64_t>> getRelocations() {
 #endif  // NDEBUG
       {"memmove", reinterpret_cast<uint64_t>(&memmove)},
 
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) || defined(__MINGW32__) || defined(__MINGW64__)
+#if defined(_MSC_VER) || !defined(UTILS_SYSTEM_X86)
 #if defined(UTILS_SYSTEM_64_BIT)
       {"__chkstk", reinterpret_cast<uint64_t>(&__chkstk)},
 #else
       {"_chkstk", reinterpret_cast<uint64_t>(&_chkstk)},
 #endif  // UTILS_SYSTEM_64_BIT
-#endif  // _MSC_VER
-
-#if defined(__MINGW32__) || defined(__MINGW64__)
+#else   // _MSC_VER || !UTILS_SYSTEM_X86
 #if defined(UTILS_SYSTEM_64_BIT)
       {"___chkstk_ms", reinterpret_cast<uint64_t>(&___chkstk_ms)},
 #else
       {"_alloca", reinterpret_cast<uint64_t>(&_alloca)},
 #endif  // UTILS_SYSTEM_64_BIT
-#endif  // _MSC_VER
+#endif  // _MSC_VER || !UTILS_SYSTEM_X86
+#endif  // _MSC_VER || __MINGW32__ || __MINGW64__
 
 #if defined(UTILS_SYSTEM_32_BIT)
       {"__divdi3", reinterpret_cast<uint64_t>(&__divdi3)},


### PR DESCRIPTION
# Overview

Fixes for Windows on ARM.

# Reason for change

*Describe how the current behaviour of the project is causing problems for you
or is otherwise unsatisfactory for your use case.*

# Description of change

* HostTarget::initWithBuiltins was overly complicated in a way that needs each triple to be spelled out. For non-Linux, we do not support cross-compilation and can just always use llvm::sys::getProcessTriple() + "-elf".
* MSVC on ARM defines _M_ARM64, not __aarch64__. Check that.
* We have special MinGW exceptions for where they use different function names than MSVC, but MinGW (MSYS) on ARM matches MSVC.

# Anything else we should know?

This change is not to mark Windows for ARM as a supported target. Although it works after this pull request, it is not a platform we test regularly and future changes may inadvertently break it again.

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-19](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
