### PR TITLE
[LLVM 21] Update for CreateTargetInfo API change.

### DIFF
--- a/modules/compiler/multi_llvm/include/multi_llvm/targetinfo.h
+++ b/modules/compiler/multi_llvm/include/multi_llvm/targetinfo.h
@@ -1,0 +1,58 @@
+// Copyright (C) Codeplay Software Limited
+//
+// Licensed under the Apache License, Version 2.0 (the "License") with LLVM
+// Exceptions; you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/LICENSE.txt
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef MULTI_LLVM_TARGET_TARGETINFO_H_INCLUDED
+#define MULTI_LLVM_TARGET_TARGETINFO_H_INCLUDED
+
+#include <clang/Basic/TargetInfo.h>
+#include <multi_llvm/llvm_version.h>
+
+namespace multi_llvm {
+
+namespace detail {
+
+#if LLVM_VERSION_GREATER_EQUAL(21, 0)
+
+template <typename TargetInfo = clang::TargetInfo>
+auto createTargetInfo(clang::DiagnosticsEngine &Diags,
+                      clang::TargetOptions &Opts)
+    -> decltype(TargetInfo::CreateTargetInfo(Diags, Opts)) {
+  return TargetInfo::CreateTargetInfo(Diags, Opts);
+}
+
+#endif
+
+template <typename TargetInfo = clang::TargetInfo>
+auto createTargetInfo(clang::DiagnosticsEngine &Diags,
+                      clang::TargetOptions &Opts)
+    -> decltype(TargetInfo::CreateTargetInfo(
+        Diags, std::make_shared<clang::TargetOptions>(Opts))) {
+  return TargetInfo::CreateTargetInfo(
+      Diags, std::make_shared<clang::TargetOptions>(Opts));
+}
+
+}  // namespace detail
+
+struct TargetInfo {
+  static clang::TargetInfo *CreateTargetInfo(clang::DiagnosticsEngine &Diags,
+                                             clang::TargetOptions &Opts) {
+    return multi_llvm::detail::createTargetInfo(Diags, Opts);
+  }
+};
+
+}  // namespace multi_llvm
+
+#endif  // MULTI_LLVM_TARGET_TARGETINFO_H_INCLUDED

--- a/modules/compiler/source/base/source/module.cpp
+++ b/modules/compiler/source/base/source/module.cpp
@@ -90,6 +90,7 @@
 #include <llvm/Transforms/Vectorize/SLPVectorizer.h>
 #include <multi_llvm/llvm_version.h>
 #include <multi_llvm/multi_llvm.h>
+#include <multi_llvm/targetinfo.h>
 #include <mux/mux.hpp>
 #include <spirv-ll/module.h>
 
@@ -1253,9 +1254,8 @@ clang::FrontendInputFile BaseModule::prepareOpenCLInputFile(
       clang::DisableValidationForModuleKind::All;
   pp_opts.AllowPCHWithCompilerErrors = true;
 
-  instance.setTarget(clang::TargetInfo::CreateTargetInfo(
-      instance.getDiagnostics(),
-      std::make_shared<clang::TargetOptions>(instance.getTargetOpts())));
+  instance.setTarget(multi_llvm::TargetInfo::CreateTargetInfo(
+      instance.getDiagnostics(), instance.getTargetOpts()));
 
   // We add the supported OpenCL opts now as we need an existing target before
   // we can do so.


### PR DESCRIPTION
# Overview

[LLVM 21] Update for CreateTargetInfo API change.

# Reason for change

CreateTargetInfo no longer receives a shared_ptr, it receives a reference instead.

# Description of change

*Describe the intended behaviour your changes are meant to introduce to the
project and explain how they resolve the problem stated above. Detail any
relevant changes that may affect other users of the project, such as
compilation options, runtime flags, expected inputs and outputs, API entry
points, etc.*

*If you have added new testing, provide details on what tests you have added
and what the purpose of them is.*

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-19](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
