### PR TITLE
Update cookiecutter analyzeBuiltin.

### DIFF
--- a/modules/compiler/cookie/{{cookiecutter.target_name}}/source/module.cpp
+++ b/modules/compiler/cookie/{{cookiecutter.target_name}}/source/module.cpp
@@ -47,7 +47,7 @@ namespace {{cookiecutter.target_name}} {
     // Will be filled out by each example
     CLTargetBuiltinInfo(std::unique_ptr<compiler::utils::CLBuiltinLoader> L)
         : compiler::utils::CLBuiltinInfo(std::move(L)) {}
-    compiler::utils::Builtin analyzeBuiltin(
+    std::optional<compiler::utils::Builtin> analyzeBuiltin(
         llvm::Function const &Builtin) const override {
       compiler::utils::NameMangler mangler(&Builtin.getParent()->getContext());
       llvm::StringRef BaseName = mangler.demangleName(Builtin.getName());


### PR DESCRIPTION
# Overview

Update cookiecutter analyzeBuiltin.

# Reason for change

In #789 I changed the signature of analyzeBuiltin to use std::optional, but did not update the cookiecutter override of it to match.

# Description of change

This commit fixes that.

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-19](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
