### PR TITLE
Fix CMake target clash with Abseil; add “clik_tests”

### DIFF
--- a/clik/README.md
+++ b/clik/README.md
@@ -45,7 +45,7 @@ ComputeMux examples can optionally be built by passing additional options to CMa
 Examples included with clik can be used as a test suite for basic validation:
 
     $ cd path/to/clik/build/clik-debug
-    $ ninja check
+    $ ninja clik_tests
     [100 %] [0:0:11/11] PASS matrix_multiply_tiled
 
     Passed:           11 (100.0 %)

--- a/clik/test/CMakeLists.txt
+++ b/clik/test/CMakeLists.txt
@@ -15,12 +15,12 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 set(SCRIPT_PATH ${CMAKE_CURRENT_SOURCE_DIR}/run_tests.py)
-add_custom_target(check
+add_custom_target(clik_tests
     COMMAND ${Python3_EXECUTABLE} ${SCRIPT_PATH} -L lib -b bin --strict --timeout 00:01:00
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
     USES_TERMINAL)
 
-add_dependencies(check ClikExamples)
+add_dependencies(clik_tests ClikExamples)
 if(NOT CLIK_HAL_NAME STREQUAL "")
-  add_dependencies(check hal_${CLIK_HAL_NAME})
+  add_dependencies(clik_tests hal_${CLIK_HAL_NAME})
 endif()

--- a/doc/modules/mux/targets/host/lit.md
+++ b/doc/modules/mux/targets/host/lit.md
@@ -76,7 +76,7 @@ $ llvm-lit host/test/lit/ --xunit-xml-output=lit_junit.xml
 -- Testing: 172 tests, 4 threads --
 ```
 
-A third way is by invoking the CMake `check` target.
+A third way is by invoking the CMake `clik_tests` target.
 
 Sample usage:
 

--- a/doc/overview/tutorials/creating-new-hal/runing-clik-tests.rst
+++ b/doc/overview/tutorials/creating-new-hal/runing-clik-tests.rst
@@ -21,7 +21,7 @@ clik tests as a suite and obtain the number of passed and failed tests
 
 .. code:: console
 
-    $ ninja check
+    $ ninja clik_tests
       [100 %] [11:0:0/11] FAIL concatenate_dma
       ******************** concatenate_dma FAIL in 0:00:00.006947 ********************
       Unable to create a clik device.
@@ -47,7 +47,7 @@ clik tests as a suite and obtain the number of passed and failed tests
 
 As can be seen above, all clik tests are currently failing. This is to be
 expected when the RefSi HAL is still at the skeleton stage. Nevertheless, it is
-useful to run ``ninja check`` periodically while developing the HAL, to confirm
+useful to run ``ninja clik_tests`` periodically while developing the HAL, to confirm
 that a particular operation has been implemented correctly or that a new change
 to the source code has not caused any regression.
 


### PR DESCRIPTION
…heck'

# Overview

Abseil 202401 introduces an interface target named check.
Our test driver used the same name, so CMake fails with CMP0002.
This patch adds a new target clik_tests that runs the existing Python test-runner and leaves Abseil’s check untouched.

# Reason for change

With the current main branch + Abseil 202401 the build aborts during the configure step, so no one can compile the Construction Kit on an up-to-date toolchain.

# Description of change

* Replace add_custom_target(check …) with add_custom_target(clik_tests …).
* clik_tests still depends on ClikExamples and the selected HAL.
* Tests are now launched with ninja clik_tests.
No other targets, flags or APIs are affected.

# Anything else we should know?

Verified on Ubuntu 22.04 with GCC 11, CMake 3.26, Ninja 1.11;
ninja clik_tests completes and all tests pass.

# Checklist

*  Project builds successfully with the change
*  Tests run locally (ninja clik_tests)
* clang-format-19 run on modified files
* Code of Conduct respected
