### PR TITLE
[NFC] Address LLVM 21's BinOp additions in a better way.

### DIFF
--- a/modules/compiler/multi_llvm/include/multi_llvm/instructions.inc
+++ b/modules/compiler/multi_llvm/include/multi_llvm/instructions.inc
@@ -1,0 +1,84 @@
+// Copyright (C) Codeplay Software Limited
+//
+// Licensed under the Apache License, Version 2.0 (the "License") with LLVM
+// Exceptions; you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/LICENSE.txt
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#if LLVM == 19
+template <typename T>
+struct BinOpHelper<T, std::enable_if_t<T::LAST_BINOP - T::FIRST_BINOP == 16>>
+#define BINOP_LLVM20(OP, STR)
+#define BINOP_LLVM21(OP, STR)
+#elif LLVM == 20
+template <typename T>
+struct BinOpHelper<T, std::enable_if_t<T::LAST_BINOP - T::FIRST_BINOP == 18>>
+#define BINOP_LLVM20(OP, STR) BINOP(OP, STR)
+#define BINOP_LLVM21(OP, STR)
+#elif LLVM == 21
+template <typename T, typename>
+struct BinOpHelper
+#define BINOP_LLVM20(OP, STR) BINOP(OP, STR)
+#define BINOP_LLVM21(OP, STR) BINOP(OP, STR)
+#endif
+{
+#define BINOPS()                     \
+  BINOP(Xchg, "xchg")                \
+  BINOP(Add, "add")                  \
+  BINOP(Sub, "sub")                  \
+  BINOP(And, "and")                  \
+  BINOP(Nand, "nand")                \
+  BINOP(Or, "or")                    \
+  BINOP(Xor, "xor")                  \
+  BINOP(Max, "max")                  \
+  BINOP(Min, "min")                  \
+  BINOP(UMax, "umax")                \
+  BINOP(UMin, "umin")                \
+  BINOP(FAdd, "fadd")                \
+  BINOP(FSub, "fsub")                \
+  BINOP(FMax, "fmax")                \
+  BINOP(FMin, "fmin")                \
+  BINOP_LLVM21(FMaximum, "fmaximum") \
+  BINOP_LLVM21(FMinimum, "fminumum") \
+  BINOP(UIncWrap, "uincwrap")        \
+  BINOP(UDecWrap, "udecwrap")        \
+  BINOP_LLVM20(USubCond, "usubcond") \
+  BINOP_LLVM20(USubSat, "usubsat")
+
+  static std::optional<T> consume_front_with_underscore(
+      llvm::StringRef &String) {
+#define BINOP(BINOP, STR)              \
+  if (String.consume_front(STR "_")) { \
+    return T::BINOP;                   \
+  }
+    BINOPS()
+#undef BINOP
+    return std::nullopt;
+  }
+
+  static llvm::StringRef to_string(T BinOp) {
+    switch (BinOp) {
+#define BINOP(BINOP, STR) \
+  case T::BINOP:          \
+    return STR;
+      BINOPS()
+#undef BINOP
+      case T::BAD_BINOP:
+        break;
+    }
+    llvm_unreachable("Unexpected BinOp");
+  }
+
+#undef BINOPS
+#undef BINOP_LLVM20
+#undef BINOP_LLVM21
+};


### PR DESCRIPTION
# Overview

[NFC] Address LLVM 21's BinOp additions in a better way.

# Reason for change

The earlier change to restore compatibility with LLVM 21 required suppressing compiler warnings and made it so that we would not be alerted when we need to account for future BinOp additions.

# Description of change

This change moves the complexity of dealing with the different LLVM versions from vectorization_context.cpp into multi_llvm, and handles it in a way that does not require suppressing compiler warnings.

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-19](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
