### PR TITLE
Added refsi_tutorial as an internal test

### DIFF
--- a/.github/actions/do_build_ock/action.yml
+++ b/.github/actions/do_build_ock/action.yml
@@ -110,6 +110,9 @@ inputs:
   toolchain_file:
     description: "Path to toolchain file"
     default: ""
+  source_dir:
+    description: 'cmake source directory'
+    default: '.'
 
 runs:
   # We don't want a new docker just a list of steps, so mark as composite
@@ -168,7 +171,7 @@ runs:
               -DCA_BUILD_32_BITS=${{ inputs.build_32_bit }}
               -DCMAKE_TOOLCHAIN_FILE=${{ inputs.toolchain_file }}
                ${{ inputs.extra_flags }}
-               .
+               ${{ inputs.source_dir }}
     - name: build_ock
       shell: ${{ inputs.shell_to_use }}
       run:

--- a/.github/actions/do_build_pr/run_ubuntu_gcc_x86_64_refsi_tutorial/action.yml
+++ b/.github/actions/do_build_pr/run_ubuntu_gcc_x86_64_refsi_tutorial/action.yml
@@ -1,0 +1,42 @@
+name: build_pr_ubuntu_gcc_x86_64_refsi_tutorial
+description: Build pr ubuntu_gcc_x86_64_refsi_tutorial
+
+inputs:
+  cache_seed:
+    type: boolean
+    default: false
+
+runs:
+  using: "composite"
+  steps:
+      # TODO: refsi_tutorial start
+      - name: remove any old dirs and set up new target
+        shell: bash  
+        run: |
+          rm -rf build
+          git config --global --add safe.directory $GITHUB_WORKSPACE
+          virtualenv newenv
+          source newenv/bin/activate
+          pip install cookiecutter
+          scripts/setup_new_target_tutorial.sh -s end -e $GITHUB_WORKSPACE/refsi_tutorial -f "refsi_wrapper_pass;clmul;replace_mem" $PWD
+
+      - name: build refsi_tutorial
+        uses: ./.github/actions/do_build_ock
+        with:
+          build_targets: install
+          mux_targets_enable: refsi_tutorial
+          use_linker: gold
+          debug_support: ON
+          offline_kernel_tests: OFF
+          source_dir: $GITHUB_WORKSPACE/refsi_tutorial
+          extra_flags: '-DCA_REFSI_TUTORIAL_ENABLED=ON -DCA_EXTERNAL_ONEAPI_CON_KIT_DIR=$GITHUB_WORKSPACE -DCA_EXTERNAL_REFSI_TUTORIAL_HAL_DIR=$GITHUB_WORKSPACE/refsi_tutorial/hal_refsi_tutorial'
+
+      - name: run test
+        if: inputs.cache_seed != 'true'
+        shell: bash
+         # Run just a quick UnitCL test for now, hal_tutorial causes some failures at present
+        run: |
+          ninja -Cbuild check-ock-refsi_tutorial-lit
+          OCL_ICD_VENDORS=/dev/null OCL_ICD_FILENAMES=$PWD/build/oneAPIConstructionKit/lib/libCL.so \
+            $PWD/build/oneAPIConstructionKit/bin/UnitCL \
+            --gtest_filter=Execution/Execution.Task_01_02_Add/OpenCLC

--- a/.github/workflows/pr_tests_cache.yml
+++ b/.github/workflows/pr_tests_cache.yml
@@ -99,7 +99,10 @@ jobs:
         uses: ./.github/actions/do_build_pr/run_ubuntu_gcc_x86_64_refsi_g1_wi_cl3_0          
         with:
           cache_seed: true
-
+      - name: build ubuntu_gcc_x86_64_refsi_tutorial
+        uses: ./.github/actions/do_build_pr/run_ubuntu_gcc_x86_64_refsi_tutorial
+        with:
+          cache_seed: true
   # aarch 64
   ubuntu_22_llvm_current_aarch64_jobs:
     if: github.repository == 'uxlfoundation/oneapi-construction-kit' || github.event_name != 'schedule'

--- a/.github/workflows/run_ock_internal_tests.yml
+++ b/.github/workflows/run_ock_internal_tests.yml
@@ -388,3 +388,24 @@ jobs:
     #    path: |
     #      oneapi-construction-kit/build/*.fail
     #      oneapi-construction-kit/build/*.log
+
+ # Based on: mr-run-ubuntu-gcc-x86_64-refsi-tutorial-end:
+  run-ubuntu-gcc-x86_64-refsi-tutorial-end:
+    if: contains(inputs.target_list, 'host_refsi_linux')
+    runs-on: ubuntu-22.04
+    container:
+      image: ghcr.io/uxlfoundation/ock_ubuntu_22.04-x86-64:latest
+      volumes:
+        - ${{github.workspace}}:${{github.workspace}}
+    timeout-minutes: 60
+    steps:
+    - name: Checkout repo
+      uses: actions/checkout@v4
+    - name: setup-ubuntu
+      uses: ./.github/actions/setup_build
+      with:
+        llvm_version: ${{ inputs.llvm_current }}
+        llvm_source: ${{ inputs.llvm_source}}
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+    - name: build ock
+      uses: ./.github/actions/do_build_pr/run_ubuntu_gcc_x86_64_refsi_tutorial


### PR DESCRIPTION
# Overview

 Added refsi_tutorial as an internal test
    
This tests the "end" part of refsi_tutorial as a PR job. "start" is to follow in a separate PR.

# Reason for change

Test not yet ported over. We were getting breakages from changes.

# Description of change

*Describe the intended behaviour your changes are meant to introduce to the
project and explain how they resolve the problem stated above. Detail any
relevant changes that may affect other users of the project, such as
compilation options, runtime flags, expected inputs and outputs, API entry
points, etc.*

*If you have added new testing, provide details on what tests you have added
and what the purpose of them is.*

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-19](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
