### PR TITLE
Add LLVM patch to DPC++ to fix crashes on RISC-V.

### DIFF
--- a/scripts/testing/patches/DPCPP-0004-Revert-SelectionDAG-Introducing-a-new-ISD-POISON-SDN.patch
+++ b/scripts/testing/patches/DPCPP-0004-Revert-SelectionDAG-Introducing-a-new-ISD-POISON-SDN.patch
@@ -1,0 +1,101 @@
+From 630c2f8fd12c5e0a14196cabbacb1fac26c14bd5 Mon Sep 17 00:00:00 2001
+From: zhijian lin <zhijian@ca.ibm.com>
+Date: Thu, 10 Apr 2025 11:29:14 -0400
+Subject: [PATCH] Revert "[SelectionDAG] Introducing a new ISD::POISON SDNode
+ to represent the poison value in the IR." (#135060)
+
+Reverts llvm/llvm-project#125883
+
+This PR causes crashes in RISC-V codegen around f16/f64 poison values:
+https://github.com/llvm/llvm-project/pull/125883#issuecomment-2787048206
+
+Reland "[SelectionDAG] Introducing a new ISD::POISON SDNode to represent the poison value in the IR." (#135056)
+
+A new ISD::POISON SDNode is introduced to represent the poison value in
+the IR, replacing the previous use of ISD::UNDEF
+---
+ .../SelectionDAG/LegalizeFloatTypes.cpp       |  3 +++
+ .../CodeGen/PowerPC/poison-legalization.ll    | 11 +++++++++
+ .../test/CodeGen/RISCV/poison-legalization.ll | 24 +++++++++++++++++++
+ 3 files changed, 38 insertions(+)
+ create mode 100644 llvm/test/CodeGen/PowerPC/poison-legalization.ll
+ create mode 100644 llvm/test/CodeGen/RISCV/poison-legalization.ll
+
+diff --git a/llvm/lib/CodeGen/SelectionDAG/LegalizeFloatTypes.cpp b/llvm/lib/CodeGen/SelectionDAG/LegalizeFloatTypes.cpp
+index 5ed83060e150..432209e8ecb0 100644
+--- a/llvm/lib/CodeGen/SelectionDAG/LegalizeFloatTypes.cpp
++++ b/llvm/lib/CodeGen/SelectionDAG/LegalizeFloatTypes.cpp
+@@ -165,6 +165,7 @@ void DAGTypeLegalizer::SoftenFloatResult(SDNode *N, unsigned ResNo) {
+     case ISD::STRICT_UINT_TO_FP:
+     case ISD::SINT_TO_FP:
+     case ISD::UINT_TO_FP:  R = SoftenFloatRes_XINT_TO_FP(N); break;
++    case ISD::POISON:
+     case ISD::UNDEF:       R = SoftenFloatRes_UNDEF(N); break;
+     case ISD::VAARG:       R = SoftenFloatRes_VAARG(N); break;
+     case ISD::VECREDUCE_FADD:
+@@ -1501,6 +1502,7 @@ void DAGTypeLegalizer::ExpandFloatResult(SDNode *N, unsigned ResNo) {
+     report_fatal_error("Do not know how to expand the result of this "
+                        "operator!");
+     // clang-format off
++  case ISD::POISON:
+   case ISD::UNDEF:        SplitRes_UNDEF(N, Lo, Hi); break;
+   case ISD::SELECT:       SplitRes_Select(N, Lo, Hi); break;
+   case ISD::SELECT_CC:    SplitRes_SELECT_CC(N, Lo, Hi); break;
+@@ -3319,6 +3321,7 @@ void DAGTypeLegalizer::SoftPromoteHalfResult(SDNode *N, unsigned ResNo) {
+   case ISD::STRICT_UINT_TO_FP:
+   case ISD::SINT_TO_FP:
+   case ISD::UINT_TO_FP:  R = SoftPromoteHalfRes_XINT_TO_FP(N); break;
++  case ISD::POISON:
+   case ISD::UNDEF:       R = SoftPromoteHalfRes_UNDEF(N); break;
+   case ISD::ATOMIC_SWAP: R = BitcastToInt_ATOMIC_SWAP(N); break;
+   case ISD::VECREDUCE_FADD:
+diff --git a/llvm/test/CodeGen/PowerPC/poison-legalization.ll b/llvm/test/CodeGen/PowerPC/poison-legalization.ll
+new file mode 100644
+index 000000000000..579130180a66
+--- /dev/null
++++ b/llvm/test/CodeGen/PowerPC/poison-legalization.ll
+@@ -0,0 +1,11 @@
++; RUN: llc < %s -mtriple=powerpc64-unknown-linux-gnu  | FileCheck %s
++
++define void @ExpandFloat(ptr %p1 )  {
++; CHECK:      stfd 0, 8(3)
++; CHECK-NEXT: stfd 0, 0(3)
++; CHECK-NEXT: blr
++entry:
++   store volatile ppc_fp128 poison, ptr %p1
++   ret void
++}
++
+diff --git a/llvm/test/CodeGen/RISCV/poison-legalization.ll b/llvm/test/CodeGen/RISCV/poison-legalization.ll
+new file mode 100644
+index 000000000000..f0954b74e937
+--- /dev/null
++++ b/llvm/test/CodeGen/RISCV/poison-legalization.ll
+@@ -0,0 +1,24 @@
++; RUN: llc < %s -mtriple=riscv32  | FileCheck %s
++
++define void @SoftenFloat(ptr %p1)  {
++; CHECK-LABEL: SoftenFloat:
++; CHECK:       # %bb.0:                                # %entry
++; CHECK-NEXT:     sw      a0, 4(a0)
++; CHECK-NEXT:     sw      a0, 0(a0)
++; CHECK-NEXT:     ret
++
++entry:
++  store volatile double poison, ptr %p1
++  ret void
++}
++
++define void @PromoteHalf(ptr %p1 )  {
++; CHECK-LABEL: PromoteHalf:
++; CHECK:       # %bb.0:                                # %entry
++; CHECK-NEXT:     sh      a0, 0(a0)
++; CHECK-NEXT:     ret
++entry:
++   store volatile half poison, ptr %p1
++   ret void
++}
++
+-- 
+2.47.2
+


### PR DESCRIPTION
# Overview

Add LLVM patch to DPC++ to fix crashes on RISC-V.

# Reason for change

We see crashes building SYCL-CTS for RISC-V.

# Description of change

The fix for this has been merged in upstream LLVM but will not be included in DPC++ until their next pulldown. Apply it as a patch until then.

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-19](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
