### PR TITLE
Fix city runner lit profile for windows

### DIFF
--- a/scripts/testing/city_runner/profiles/lit.py
+++ b/scripts/testing/city_runner/profiles/lit.py
@@ -19,6 +19,7 @@ import os
 import sys
 import time
 import csv
+import platform
 
 import lit.cl_arguments
 import lit.discovery
@@ -110,7 +111,7 @@ class LitProfile(DefaultProfile):
             valgrindArgs=[],
             noExecute=False,
             debug=False,
-            isWindows=False,
+            isWindows=(platform.system() == "Windows"),
             order=lit.cl_arguments.TestOrder.SMART,
             params=self.args.lit_param,
             config_prefix=""


### PR DESCRIPTION


# Overview

Fix city runner lit profile for windows

# Reason for change

This was not setting the correct flag for windows when setting up the lit config

# Description of change

*Describe the intended behaviour your changes are meant to introduce to the
project and explain how they resolve the problem stated above. Detail any
relevant changes that may affect other users of the project, such as
compilation options, runtime flags, expected inputs and outputs, API entry
points, etc.*

*If you have added new testing, provide details on what tests you have added
and what the purpose of them is.*

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-19](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
