### PR TITLE
Set SPIR-V ByVal and Sret alignment

### DIFF
--- a/modules/compiler/spirv-ll/test/spvasm/op_function_call_regression.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_function_call_regression.spvasm
@@ -58,13 +58,13 @@
 ; CHECK: store i64 1, {{(ptr|i64\*)}} %a
                OpStore %a %ulong_1 Aligned 8
 ; Check we also apply call-site attributes to this function
-; CHECK: call spir_func void @foo(i64 [[TMP]], {{(ptr|i64\*)}} byval(i64) %a)
+; CHECK: call spir_func void @foo(i64 [[TMP]], {{(ptr|i64\*)}} byval(i64) align 1 %a)
         %272 = OpFunctionCall %void %foo %call0 %a
                OpReturn
                OpFunctionEnd
 
 
-; CHECK: define private spir_func void @foo(i64 {{%.*}}, {{(ptr|i64\*)}} byval(i64) {{%.*}}) #0 {
+; CHECK: define private spir_func void @foo(i64 {{%.*}}, {{(ptr|i64\*)}} byval(i64) align 1 {{%.*}}) #0 {
 %foo = OpFunction %void None %foo_fn_ty
   %0 = OpFunctionParameter %ulong
 %ptr = OpFunctionParameter %ptr_ty


### PR DESCRIPTION
# Overview

Set SPIR-V ByVal and Sret alignment

# Reason for change

In SPIR-V, the ByVal and Sret attributes on function parameters are not stated to specify any requirements on alignment. In LLVM, the byval attribute on function parameters implies "a target-specific assumption" on alignment if no explicit alignment is specified, which is an incorrect translation: we need to ensure that no invalid assumptions are made.

# Description of change

Explicitly set the alignment to 1.

# Anything else we should know?

Setting an explicit alignment also works around LLVM bug 138356 where the ARM backend assumes that alignment is always set.

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-19](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
