### PR TITLE
Updated xfails for e2e to include new thread san fails

### DIFF
--- a/scripts/testing/sycl_e2e/override_all.csv
+++ b/scripts/testing/sycl_e2e/override_all.csv
@@ -9,6 +9,9 @@ SYCL,ThreadSanitizer/check_sub_buffer.cpp,XFail
 SYCL,ThreadSanitizer/check_group_barrier.cpp,XFail
 SYCL,ThreadSanitizer/check_access16.cpp,XFail
 SYCL,ThreadSanitizer/check_unaligned_access.cpp,XFail
+SYCL/ThreadSanitizer/check_host_usm.cpp,XFail
+SYCL/ThreadSanitizer/check_device_usm.cpp,XFail
+SYCL/ThreadSanitizer/check_shared_usm.cpp,XFail
 SYCL,Assert/assert_in_multiple_tus.cpp,XFail
 SYCL,Assert/assert_in_simultaneous_kernels.cpp,XFail
 SYCL,Assert/check_resource_leak.cpp,XFail


### PR DESCRIPTION
# Overview

Updated xfails for e2e to include new thread san fails

# Reason for change

New tests have been added, these fail too.
