### PR TITLE
Remove CA_ENABLE_API as a CMake option

### DIFF
--- a/.github/actions/do_build_ock/action.yml
+++ b/.github/actions/do_build_ock/action.yml
@@ -67,9 +67,6 @@ inputs:
   assemble_spirv_ll_lit_test_offline:
     description: "Enable Spir-V LL tests offline (Default OFF)"
     default: OFF
-  enable_api:
-    description: "APIs to enable (default CL)"
-    default: cl
   enable_rvv_scalable_vecz_check:
     description: "Enable RVV scalable vecz check (default OFF)"
     default: OFF
@@ -139,7 +136,6 @@ runs:
               -DCMAKE_C_COMPILER_LAUNCHER=ccache
               -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
               -DCA_MUX_TARGETS_TO_ENABLE=${{ inputs.mux_targets_enable }}
-              -DCA_ENABLE_API=${{ inputs.enable_api }}
               -DCA_LLVM_INSTALL_DIR=${{ inputs.llvm_install_dir }}
               -DCA_ENABLE_DEBUG_SUPPORT=${{ inputs.debug_support }}
               -DCMAKE_BUILD_TYPE=${{ inputs.build_type }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Build Documentation
         working-directory: ${{github.workspace}}
         run: |
-          cmake -DCA_ENABLE_API=cl -DCMAKE_BUILD_TYPE=Debug -DCA_RUNTIME_COMPILER_ENABLED=OFF -DCA_CL_ENABLE_OFFLINE_KERNEL_TESTS=OFF -DOCL_EXTENSION_cl_khr_il_program=OFF -Bbuild_doc
+          cmake -DCMAKE_BUILD_TYPE=Debug -DCA_RUNTIME_COMPILER_ENABLED=OFF -DCA_CL_ENABLE_OFFLINE_KERNEL_TESTS=OFF -DOCL_EXTENSION_cl_khr_il_program=OFF -Bbuild_doc
           cmake --build build_doc --target doc_html
 
       - name: Upload artifact

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ Upgrade guidance:
 * Support for LLVM versions before 19 has been removed.
 * Vulkan API support has been removed and will no longer be supported for any
   versions. Users may fork from the 4.0.0 version if they wish to use it.
+* The CMake option CA_ENABLE_API has been removed; OpenCL will always be enabled
+  as the API.
 
 ## Version 4.0.0
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,8 +75,6 @@ endif()
 
 ca_option(CA_LLVM_INSTALL_DIR STRING
   "LLVM install directory" "")
-ca_option(CA_ENABLE_API STRING
-  "Semi-colon separated list of APIs to enable, empty enables cl" "")
 ca_option(CA_ENABLE_TESTS BOOL
   "Enable building tests" ON)
 ca_option(CA_ENABLE_EXAMPLES BOOL

--- a/cmake/AddCA.cmake
+++ b/cmake/AddCA.cmake
@@ -1053,10 +1053,7 @@ function(add_ca_copy_file)
     COMMENT "Copying file ${relOut}")
 endfunction()
 
-if(EXISTS ${PROJECT_SOURCE_DIR}/source/cl AND
-    (CA_ENABLE_API STREQUAL "" OR CA_ENABLE_API MATCHES cl))
-  # Cleared to ensure reconfigures behave correctly.
-  set(CA_CL_RUNTIME_EXTENSION_TAGS ""
+set(CA_CL_RUNTIME_EXTENSION_TAGS ""
     CACHE INTERNAL "List of runtime extension names.")
 
 #[=======================================================================[.rst:
@@ -1098,30 +1095,30 @@ if(EXISTS ${PROJECT_SOURCE_DIR}/source/cl AND
 
       Internally cached List of source files for ``${tag}`` extensions.
 #]=======================================================================]
-  function(add_ca_cl_runtime_extension tag)
-    cmake_parse_arguments(args "" ""
-      "EXTENSIONS;HEADER;INCLUDE_DIRS;SOURCES" ${ARGN})
-    if(args_UNPARSED_ARGUMENTS)
-      message(FATAL_ERROR "invalid arguments: ${args_UNPARSED_ARGUMENTS}")
-    endif()
-    # Add the tag to the list of runtime extension tags.
-    list(APPEND CA_CL_RUNTIME_EXTENSION_TAGS ${tag})
-    set(CA_CL_RUNTIME_EXTENSION_TAGS ${CA_CL_RUNTIME_EXTENSION_TAGS}
-      CACHE INTERNAL "List of runtime extension names.")
-    # Cache the extension information for later use.
-    set(${tag}_RUNTIME_EXTENSIONS ${args_EXTENSIONS}
-      CACHE INTERNAL "List of ${tag} extensions.")
-    set(${tag}_RUNTIME_HEADER ${args_HEADER}
-      CACHE INTERNAL "Extension header for ${tag} extensions.")
-    set(${tag}_RUNTIME_INCLUDE_DIRS ${args_INCLUDE_DIRS}
-      CACHE INTERNAL "Include directory for ${tag} extensions.")
-    set(${tag}_RUNTIME_SOURCES ${args_SOURCES}
-      CACHE INTERNAL "List of source files for ${tag} extensions.")
-  endfunction()
+function(add_ca_cl_runtime_extension tag)
+  cmake_parse_arguments(args "" ""
+    "EXTENSIONS;HEADER;INCLUDE_DIRS;SOURCES" ${ARGN})
+  if(args_UNPARSED_ARGUMENTS)
+    message(FATAL_ERROR "invalid arguments: ${args_UNPARSED_ARGUMENTS}")
+  endif()
+  # Add the tag to the list of runtime extension tags.
+  list(APPEND CA_CL_RUNTIME_EXTENSION_TAGS ${tag})
+  set(CA_CL_RUNTIME_EXTENSION_TAGS ${CA_CL_RUNTIME_EXTENSION_TAGS}
+    CACHE INTERNAL "List of runtime extension names.")
+  # Cache the extension information for later use.
+  set(${tag}_RUNTIME_EXTENSIONS ${args_EXTENSIONS}
+    CACHE INTERNAL "List of ${tag} extensions.")
+  set(${tag}_RUNTIME_HEADER ${args_HEADER}
+    CACHE INTERNAL "Extension header for ${tag} extensions.")
+  set(${tag}_RUNTIME_INCLUDE_DIRS ${args_INCLUDE_DIRS}
+    CACHE INTERNAL "Include directory for ${tag} extensions.")
+  set(${tag}_RUNTIME_SOURCES ${args_SOURCES}
+    CACHE INTERNAL "List of source files for ${tag} extensions.")
+endfunction()
 
-  # Cleared to ensure reconfigures behave correctly.
-  set(CA_CL_COMPILER_EXTENSION_TAGS ""
-    CACHE INTERNAL "List of compiler extension tags.")
+# Cleared to ensure reconfigures behave correctly.
+set(CA_CL_COMPILER_EXTENSION_TAGS ""
+  CACHE INTERNAL "List of compiler extension tags.")
 
 #[=======================================================================[.rst:
 .. cmake:command:: add_ca_cl_compiler_extension
@@ -1162,27 +1159,26 @@ if(EXISTS ${PROJECT_SOURCE_DIR}/source/cl AND
 
       Internally cached list of source files for ``${tag}`` extensions.
 #]=======================================================================]
-  function(add_ca_cl_compiler_extension tag)
-    cmake_parse_arguments(args "" ""
-      "EXTENSIONS;HEADER;INCLUDE_DIRS;SOURCES" ${ARGN})
-    if(args_UNPARSED_ARGUMENTS)
-      message(FATAL_ERROR "invalid arguments: ${args_UNPARSED_ARGUMENTS}")
-    endif()
-    # Add the tag to the list of compiler extension tags.
-    list(APPEND CA_CL_COMPILER_EXTENSION_TAGS ${tag})
-    set(CA_CL_COMPILER_EXTENSION_TAGS ${CA_CL_COMPILER_EXTENSION_TAGS}
-      CACHE INTERNAL "List of compiler extension names.")
-    # Cache the compiler extension information for later use.
-    set(${tag}_COMPILER_EXTENSIONS ${args_EXTENSIONS}
-      CACHE INTERNAL "List of ${tag} compiler extensions.")
-    set(${tag}_COMPILER_HEADER ${args_HEADER}
-      CACHE INTERNAL "Extension header for ${tag} extensions.")
-    set(${tag}_COMPILER_INCLUDE_DIRS ${args_INCLUDE_DIRS}
-      CACHE INTERNAL "Include directory for ${tag} extensions.")
-    set(${tag}_COMPILER_SOURCES ${args_SOURCES}
-      CACHE INTERNAL "List of source files for ${tag} extensions.")
-  endfunction()
-endif()
+function(add_ca_cl_compiler_extension tag)
+  cmake_parse_arguments(args "" ""
+    "EXTENSIONS;HEADER;INCLUDE_DIRS;SOURCES" ${ARGN})
+  if(args_UNPARSED_ARGUMENTS)
+    message(FATAL_ERROR "invalid arguments: ${args_UNPARSED_ARGUMENTS}")
+  endif()
+  # Add the tag to the list of compiler extension tags.
+  list(APPEND CA_CL_COMPILER_EXTENSION_TAGS ${tag})
+  set(CA_CL_COMPILER_EXTENSION_TAGS ${CA_CL_COMPILER_EXTENSION_TAGS}
+    CACHE INTERNAL "List of compiler extension names.")
+  # Cache the compiler extension information for later use.
+  set(${tag}_COMPILER_EXTENSIONS ${args_EXTENSIONS}
+    CACHE INTERNAL "List of ${tag} compiler extensions.")
+  set(${tag}_COMPILER_HEADER ${args_HEADER}
+    CACHE INTERNAL "Extension header for ${tag} extensions.")
+  set(${tag}_COMPILER_INCLUDE_DIRS ${args_INCLUDE_DIRS}
+    CACHE INTERNAL "Include directory for ${tag} extensions.")
+  set(${tag}_COMPILER_SOURCES ${args_SOURCES}
+    CACHE INTERNAL "List of source files for ${tag} extensions.")
+endfunction()
 
 #[=======================================================================[.rst:
 .. cmake:command:: add_ca_install_components

--- a/doc/developer-guide.md
+++ b/doc/developer-guide.md
@@ -249,9 +249,6 @@ The builtin CMake options used when invoking CMake on the command line.
   relevant llvm headers and support tools, and their version must match
   a supported LLVM version.
 
-* `CA_ENABLE_API`: Semi-colon separated list of APIs to enable. Valid values are
-  `cl` or '' for OpenCL.
-
 * `CA_BUILD_32_BITS`: Enable compiling in 32-bit mode on Linux, this requires
   to have the proper 32-bit toolchain installed. When used in combination with
   an external LLVM, the external LLVM also needs to be built in 32-bit mode.
@@ -648,8 +645,7 @@ cmake . -GNinja \
   -DCMAKE_BUILD_TYPE=Release \
   -DCMAKE_INSTALL_PREFIX=$PWD/build-offline/install \
   -DCA_RUNTIME_COMPILER_ENABLED=OFF \
-  -DCA_EXTERNAL_CLC=$ONEAPI_CON_KIT_INSTALL/bin/clc \
-  -DCA_ENABLE_API=cl
+  -DCA_EXTERNAL_CLC=$ONEAPI_CON_KIT_INSTALL/bin/clc
 ```
 
 Now the build directory is configured, build the `install` target.
@@ -674,8 +670,7 @@ cmake . -G"Visual Studio 16 2019 Win64" ^
   -DCMAKE_BUILD_TYPE=Release ^
   -DCMAKE_INSTALL_PREFIX=%CD%\build-offline\install ^
   -DCA_RUNTIME_COMPILER_ENABLED=OFF ^
-  -DCA_EXTERNAL_CLC=%ONEAPI_CON_KIT_INSTALL%\bin\clc ^
-  -DCA_ENABLE_API=cl
+  -DCA_EXTERNAL_CLC=%ONEAPI_CON_KIT_INSTALL%\bin\clc
 ```
 
 Now the build directory is configured, build the `install` target. This can be
@@ -702,8 +697,7 @@ cmake . -GNinja ^
   -DCMAKE_BUILD_TYPE=Release ^
   -DCMAKE_INSTALL_PREFIX=%CD%\build-offline\install ^
   -DCA_RUNTIME_COMPILER_ENABLED=OFF ^
-  -DCA_CL_ENABLE_OFFLINE_KERNEL_TESTS=OFF ^
-  -DCA_ENABLE_API=cl
+  -DCA_CL_ENABLE_OFFLINE_KERNEL_TESTS=OFF
 ```
 
 Then, install with:

--- a/doc/modules/mux/targets/host/lit.md
+++ b/doc/modules/mux/targets/host/lit.md
@@ -31,8 +31,7 @@ pattern matching with the `CHECK` directive.
 
 While the lit tests themselves do not need to be compiled, their configuration
 files are configured through CMake in order to set up correct paths and other
-parameters. The tests are built together with the other test suites when the
-`cl` API is enabled via the `CA_ENABLE_API` CMake option, but they
+parameters. The tests are built together with the other test suites, but they
 can also be built individually through the `host-lit` target.
 
 In order for the tests to be built, the `opt`, `FileCheck`, and `lit` tools need

--- a/doc/overview/tutorials/creating-a-new-mux-target/building-and-running-tests.rst
+++ b/doc/overview/tutorials/creating-a-new-mux-target/building-and-running-tests.rst
@@ -29,7 +29,7 @@ Firstly we set up the `CMake` directive.
     $ export LLVM_INSTALL_DIR=<your_llvm_install_dir>
     $ export ONEAPI_CON_KIT_PATH=<your_oneapi_construction_kit_dir>    
     $ cmake -GNinja -DCA_MUX_TARGETS_TO_ENABLE="refsi_tutorial" \
-        -DCA_REFSI_TUTORIAL_ENABLED=ON -DCA_ENABLE_API=cl \
+        -DCA_REFSI_TUTORIAL_ENABLED=ON \
         -DCMAKE_BUILD_TYPE=Debug \
         -DCA_LLVM_INSTALL_DIR=$LLVM_INSTALL_DIR \
         -DCA_ENABLE_DEBUG_SUPPORT=ON \

--- a/examples/hal_cpu_remote_server/README.md
+++ b/examples/hal_cpu_remote_server/README.md
@@ -52,7 +52,6 @@ The client can built in-tree (for risc-v) as follows:
   cmake -Bbuild_client -GNinja \
     -DCA_MUX_TARGETS_TO_ENABLE="riscv" \
     -DCA_RISCV_ENABLED=ON \
-    -DCA_ENABLE_API=cl \
     -DCA_LLVM_INSTALL_DIR=<path_to_llvm_install> \
     -DCA_CL_ENABLE_ICD_LOADER=ON  \
     -DCA_HAL_NAME=cpu_client
@@ -73,7 +72,6 @@ for different architectures. For example:
   cmake -Bbuild_client -GNinja \
     -DCA_MUX_TARGETS_TO_ENABLE="cpu_client" \
     -DCA_CPU_CLIENT_ENABLED=ON \
-    -DCA_ENABLE_API=cl \
     -DCA_LLVM_INSTALL_DIR=<path_to_llvm_install> \
     -DCA_CL_ENABLE_ICD_LOADER=ON  \
     -DCA_EXTERNAL_ONEAPI_CON_KIT_DIR=<path_to_ock> 

--- a/examples/technical_blogs/refsi_simple_blog1/run_tech_blog_1.sh
+++ b/examples/technical_blogs/refsi_simple_blog1/run_tech_blog_1.sh
@@ -70,7 +70,6 @@ cmake -Bbuild \
       -DCA_MUX_TARGETS_TO_ENABLE="refsi_g1" \
       -DCA_REFSI_G1_ENABLED=ON \
       -DCA_CL_ENABLE_OFFLINE_KERNEL_TESTS=OFF \
-      -DCA_ENABLE_API=cl \
       -DCA_LLVM_INSTALL_DIR=$LLVM_INSTALL_DIR -GNinja .
 
 

--- a/modules/compiler/targets/riscv/test/lit/CMakeLists.txt
+++ b/modules/compiler/targets/riscv/test/lit/CMakeLists.txt
@@ -16,11 +16,6 @@
 
 set(SUITE riscv-compiler)
 
-if(NOT CA_ENABLE_API MATCHES "(^$|cl)")
-  message(WARNING "${SUITE}-lit disabled: requires CL API")
-  return()
-endif()
-
 add_ca_configure_lit_site_cfg(
   ${SUITE}
   ${CMAKE_CURRENT_SOURCE_DIR}/lit.site.cfg.in

--- a/modules/mux/targets/host/CMakeLists.txt
+++ b/modules/mux/targets/host/CMakeLists.txt
@@ -168,11 +168,9 @@ add_mux_target(host CAPABILITIES ${hostCapabilities}
   HEADER_DIR ${CMAKE_CURRENT_SOURCE_DIR}/include/host
   DEVICE_NAMES "${host_CA_HOST_CL_DEVICE_NAME}")
 
-if(CA_ENABLE_API MATCHES "(^$|cl)")
-  add_subdirectory(extension/cl_ext_codeplay)
-  if(CA_ENABLE_EXAMPLES)
-    add_ca_example_subdirectory(extension/example)
-  endif()
+add_subdirectory(extension/cl_ext_codeplay)
+if(CA_ENABLE_EXAMPLES)
+  add_ca_example_subdirectory(extension/example)
 endif()
 
 if(CA_ENABLE_TESTS)

--- a/modules/mux/targets/host/test/lit/CMakeLists.txt
+++ b/modules/mux/targets/host/test/lit/CMakeLists.txt
@@ -15,11 +15,6 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 set(SUITE host-mux)
 
-if(NOT CA_ENABLE_API MATCHES "(^$|cl)")
-  message(WARNING "${SUITE}-lit disabled: requires CL API")
-  return()
-endif()
-
 set(HOST_TARGET_ARCH_NAME '')
 get_ca_host_arch(HOST_TARGET_ARCH_NAME)
 string(TOUPPER ${HOST_TARGET_ARCH_NAME} HOST_TARGET_ARCH_NAME)

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -14,25 +14,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-macro(add_ca_api_subdirectory api)
-  string(TOUPPER "${api}" apiToUpper)
-  list(FIND CA_ENABLE_API "${api}" apiIndex)
-  if(CA_ENABLE_API STREQUAL "" OR NOT ${apiIndex} EQUAL -1)
-    if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/${api})
-      message(STATUS "API enabled: ${api}")
-      set(CA_${apiToUpper}_ENABLED ON CACHE INTERNAL "${api} enabled flag")
-      add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/${api})
-    else()
-      message(STATUS "API disabled: ${api} - source is not available!")
-    endif()
-  else()
-    message(STATUS "API disabled: ${api}")
-    set(CA_${apiToUpper}_ENABLED OFF CACHE INTERNAL "${api} enabled flag")
-  endif()
-endmacro()
-
 # The modules source directory is not a subdirectory of source so we must also
 # set the binary directory.
 add_subdirectory(${PROJECT_SOURCE_DIR}/modules ${PROJECT_BINARY_DIR}/modules)
-
-add_ca_api_subdirectory(cl)
+add_subdirectory(cl)


### PR DESCRIPTION
# Overview

Remove CA_ENABLE_API as a CMake option

# Reason for change

We only support OpenCL as a an API now, so it makes sense to remove this option.
