### PR TITLE
Add missing clean-up.

### DIFF
--- a/source/cl/test/UnitCL/source/cl_khr_command_buffer/clCommandNDRangeKernelKHR.cpp
+++ b/source/cl/test/UnitCL/source/cl_khr_command_buffer/clCommandNDRangeKernelKHR.cpp
@@ -138,6 +138,7 @@ TEST_F(CommandNDRangeKernelTest, ZeroNDRange) {
 
   // Clean up.
   ASSERT_SUCCESS(clReleaseCommandBufferKHR(command_buffer));
+  ASSERT_SUCCESS(clReleaseMemObject(dst_buffer));
   ASSERT_SUCCESS(clReleaseKernel(kernel));
   ASSERT_SUCCESS(clReleaseProgram(program));
 }


### PR DESCRIPTION
# Overview

Add missing clean-up.

# Reason for change

The newly added command_buffer created a memory buffer without releasing it.

# Description of change

*Describe the intended behaviour your changes are meant to introduce to the
project and explain how they resolve the problem stated above. Detail any
relevant changes that may affect other users of the project, such as
compilation options, runtime flags, expected inputs and outputs, API entry
points, etc.*

*If you have added new testing, provide details on what tests you have added
and what the purpose of them is.*

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-19](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
