### PR TITLE
Stop using gold.

### DIFF
--- a/.github/actions/do_build_pr/run_ubuntu_clang_x86_llvm_latest_cl3_0_offline/action.yml
+++ b/.github/actions/do_build_pr/run_ubuntu_clang_x86_llvm_latest_cl3_0_offline/action.yml
@@ -22,7 +22,6 @@ runs:
           build_targets: ${{ inputs.cache_seed == 'true' && 'UnitCL clc' || 'check-ock' }}
           enable_api: ""
           builtin_kernel: ON
-          use_linker: gold
           debug_support: ON
           offline_kernel_tests: ${{ inputs.cache_seed == 'true' && 'OFF' || 'ON' }}
           
@@ -35,7 +34,6 @@ runs:
           runtime_compiler_enabled: OFF
           assemble_spirv_ll_lit_test_offline: ${{ inputs.cache_seed == 'true' && 'OFF' || 'ON' }}
           external_clc: ${GITHUB_WORKSPACE}/build/bin/clc
-          use_linker: gold
           debug_support: ON
           install_dir: $GITHUB_WORKSPACE/install_offline
           build_dir: $GITHUB_WORKSPACE/build_offline

--- a/.github/actions/do_build_pr/run_ubuntu_gcc_aarch64_llvm_latest_cl3_0_fp16/action.yml
+++ b/.github/actions/do_build_pr/run_ubuntu_gcc_aarch64_llvm_latest_cl3_0_fp16/action.yml
@@ -18,7 +18,6 @@ runs:
         with:
           build_targets: ${{ inputs.cache_seed == 'true' && 'UnitCL clc' || 'check-ock' }}
           host_fp16: ON
-          use_linker: gold
           debug_support: ON
           builtin_kernel: ON
           enable_api: "cl"

--- a/.github/actions/do_build_pr/run_ubuntu_gcc_x86_64_refsi_g1_wi_cl3_0/action.yml
+++ b/.github/actions/do_build_pr/run_ubuntu_gcc_x86_64_refsi_g1_wi_cl3_0/action.yml
@@ -24,7 +24,6 @@ runs:
           disable_unitcl_vecz_checks: ON
           enable_rvv_scalable_vecz_check: ON
           enable_rvv_scalable_vp_vecz_check: ON
-          use_linker: gold
           hal_description: RV64GCV
           hal_refsi_soc: G1
           hal_refsi_thread_mode: WI

--- a/.github/actions/do_build_pr/run_ubuntu_gcc_x86_64_refsi_tutorial/action.yml
+++ b/.github/actions/do_build_pr/run_ubuntu_gcc_x86_64_refsi_tutorial/action.yml
@@ -33,7 +33,6 @@ runs:
         with:
           build_targets: install
           mux_targets_enable: refsi_tutorial
-          use_linker: gold
           debug_support: ON
           offline_kernel_tests: OFF
           source_dir: $GITHUB_WORKSPACE/refsi_tutorial

--- a/.github/actions/do_build_pr/run_ubuntu_gcc_x86_64_riscv_fp16_cl3_0/action.yml
+++ b/.github/actions/do_build_pr/run_ubuntu_gcc_x86_64_riscv_fp16_cl3_0/action.yml
@@ -25,7 +25,6 @@ runs:
           enable_rvv_scalable_vecz_check: ON
           enable_rvv_scalable_vp_vecz_check: ON
           host_enable_builtins: OFF
-          use_linker: gold
           hal_description: RV64GCV_Zfh
           hal_refsi_soc: G1
           hal_refsi_thread_mode: WG

--- a/.github/actions/do_build_pr/run_ubuntu_gcc_x86_64_riscv_fp16_cl3_0_unitcl_vecz/action.yml
+++ b/.github/actions/do_build_pr/run_ubuntu_gcc_x86_64_riscv_fp16_cl3_0_unitcl_vecz/action.yml
@@ -23,7 +23,6 @@ runs:
           riscv_enabled: ON
           enable_rvv_scalable_vecz_check: ON
           enable_rvv_scalable_vp_vecz_check: ON
-          use_linker: gold
           hal_description: RV64GCV_Zfh
           hal_refsi_soc: G1
           hal_refsi_thread_mode: WG

--- a/.github/actions/do_build_pr/run_ubuntu_gcc_x86_llvm_latest_x86_64_images_cl3_0_release/action.yml
+++ b/.github/actions/do_build_pr/run_ubuntu_gcc_x86_llvm_latest_x86_64_images_cl3_0_release/action.yml
@@ -20,7 +20,6 @@ runs:
           build_type: Release
           build_targets: ${{ inputs.cache_seed == 'true' && 'UnitCL clc' || 'check-ock' }}
           host_image: ON
-          use_linker: gold
           enable_api: ""
           builtin_kernel: ON
           offline_kernel_tests: ${{ inputs.cache_seed == 'true' && 'OFF' || 'ON' }}

--- a/.github/workflows/run_pr_tests_caller.yml
+++ b/.github/workflows/run_pr_tests_caller.yml
@@ -10,6 +10,7 @@ on:
       - 'cmake/**'
       - 'hal/**'
       - '.github/actions/do_build_ock/**'
+      - '.github/actions/do_build_pr/**'
       - '.github/actions/setup_build/**'
       - '.github/workflows/run_ock_internal_tests.yml'
       - '.github/workflows/run_pr_tests_caller.yml'


### PR DESCRIPTION
# Overview

Stop using gold.

# Reason for change

[gold has been deprecated][1] and so we should stop relying on it.

[1]: https://lists.gnu.org/archive/html/info-gnu/2025-02/msg00001.html

# Description of change

Use the default linker instead.

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-19](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.