### PR TITLE
Added e2e native cpu xfail overrides for new FreeFunctionKernels fails

### DIFF
--- a/scripts/testing/sycl_e2e/override_native_cpu.csv
+++ b/scripts/testing/sycl_e2e/override_native_cpu.csv
@@ -83,3 +83,8 @@ SYCL,KernelAndProgram/spec_constants_after_link.cpp,XFail
 SYCL,KernelAndProgram/fp32-precise-fdiv.cpp,XFail
 SYCL,KernelAndProgram/multiple-kernel-linking.cpp,XFail
 SYCL,KernelAndProgram/kernel-bundle-get-kernel.cpp,XFail
+SYCL,FreeFunctionKernels/range_as_kernel_parameter.cpp,XFail
+SYCL,FreeFunctionKernels/id_as_kernel_parameter.cpp,XFail
+SYCL,FreeFunctionKernels/vec_as_kernel_parameter.cpp,XFail
+SYCL,FreeFunctionKernels/marray_as_kernel_parameter.cpp,XFail
+SYCL,FreeFunctionKernels/usm_compatibility.cpp,XFail


### PR DESCRIPTION
# Overview

*Provide a brief overview of what your changes do, summarizing their effects
and consequences.*

# Reason for change

*Describe how the current behaviour of the project is causing problems for you
or is otherwise unsatisfactory for your use case.*

# Description of change

*Describe the intended behaviour your changes are meant to introduce to the
project and explain how they resolve the problem stated above. Detail any
relevant changes that may affect other users of the project, such as
compilation options, runtime flags, expected inputs and outputs, API entry
points, etc.*

*If you have added new testing, provide details on what tests you have added
and what the purpose of them is.*

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-19](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
