### PR TITLE
[LLVM 21] Pass diags by reference.

### DIFF
--- a/modules/compiler/source/base/include/base/module.h
+++ b/modules/compiler/source/base/include/base/module.h
@@ -326,11 +326,7 @@ class BaseModule : public Module {
   class FrontendDiagnosticPrinter : public clang::TextDiagnosticPrinter {
    public:
     FrontendDiagnosticPrinter(BaseModule &base_module,
-                              clang::DiagnosticOptions *diags)
-        : clang::TextDiagnosticPrinter(TempOS, diags,
-                                       /*OwnsOutputStream*/ false),
-          base_module(base_module),
-          TempOS(TempStr) {}
+                              clang::DiagnosticOptions &diags);
 
     void HandleDiagnostic(clang::DiagnosticsEngine::Level Level,
                           const clang::Diagnostic &Info) override;


### PR DESCRIPTION
# Overview

[LLVM 21] Pass diags by reference.

# Reason for change

LLVM 21 changes who owns a clang::DiagnosticOptions and changes the API to match, changing pointers to references.

# Description of change

Update accordingly.

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-19](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
