### PR TITLE
[spirv-ll][NFC] Remove shader-specific SPIR-V support.

### DIFF
--- a/modules/compiler/include/compiler/module.h
+++ b/modules/compiler/include/compiler/module.h
@@ -500,23 +500,8 @@ struct SpecializationInfo {
   const void *data;
 };
 
-/// @brief Struct describing a descriptor binding.
-struct DescriptorBinding {
-  /// @brief Descriptor set number.
-  uint32_t set;
-  /// @brief Binding number within `set`.
-  uint32_t binding;
-
-  /// @brief Less than comparison operator to enable sort by binding.
-  bool operator<(const DescriptorBinding &other) const {
-    return set < other.set || (set == other.set && binding < other.binding);
-  }
-};
-
 /// @brief Information about a SPIR-V module after compilation.
 struct ModuleInfo {
-  /// @brief List of used descriptor bindings.
-  std::vector<DescriptorBinding> used_descriptor_bindings;
   /// @brief Work group size.
   std::array<uint32_t, 3> workgroup_size;
 };

--- a/modules/compiler/source/base/source/module.cpp
+++ b/modules/compiler/source/base/source/module.cpp
@@ -850,9 +850,6 @@ cargo::expected<spirv::ModuleInfo, Result> BaseModule::compileSPIRV(
     }
 
     // Fill the SPIR-V module info data structure.
-    for (const auto &db : spvModule->getUsedDescriptorBindings()) {
-      module_info.used_descriptor_bindings.push_back({db.set, db.binding});
-    }
     module_info.workgroup_size = spvModule->getWGS();
 
     // Transfer ownership of the llvm::Module.

--- a/modules/compiler/spirv-ll/include/spirv-ll/builder.h
+++ b/modules/compiler/spirv-ll/include/spirv-ll/builder.h
@@ -769,16 +769,6 @@ class Builder {
   /// very top of the function.
   void generateSpecConstantOps();
 
-  /// @brief Generate the IR needed to give entry point parameters global scope.
-  ///
-  /// This is called after the first basic block in a function is created. If
-  /// the function is an entry point it has stores generated to put its
-  /// arguments in global variables, otherwise it has loads generated to get the
-  /// contents of those globals into local scope. This is only necessary for
-  /// GLCompute modules, as their inputs are represented as global pointers but
-  /// they must be translated into entry point parameters for core.
-  void handleGlobalParameters();
-
   /// @brief Registers an extended instruction set handler with an instruction
   /// set ID.
   ///

--- a/modules/compiler/spirv-ll/include/spirv-ll/module.h
+++ b/modules/compiler/spirv-ll/include/spirv-ll/module.h
@@ -163,19 +163,6 @@ inline void swap(iterator &lhs, iterator &rhs) {
   rhs = std::move(tmp);
 }
 
-/// @brief Struct describing a descriptor binding.
-struct DescriptorBinding {
-  /// @brief Descriptor set number.
-  uint32_t set;
-  /// @brief Binding number within `set`.
-  uint32_t binding;
-
-  /// @brief Less than comparison operator to enable sort by binding.
-  bool operator<(const DescriptorBinding &other) const {
-    return set < other.set || (set == other.set && binding < other.binding);
-  }
-};
-
 /// @brief Container class for translating a binary SPIR-V module.
 class Module : public ModuleHeader {
  public:
@@ -520,73 +507,6 @@ class Module : public ModuleHeader {
   /// @param id An ID with decorations to resolve.
   void resolveDecorations(spv::Id id);
 
-  /// @brief Struct containing information about an interface block.
-  struct InterfaceBlock {
-    /// @brief `DescriptorBinding` struct that has the binding info.
-    DescriptorBinding binding;
-
-    /// @brief Global variable that stores a reference to the interface block.
-    llvm::GlobalVariable *variable;
-
-    /// @brief Underlying interface block type. The global variable's value
-    /// type will be a pointer to this type.
-    llvm::Type *block_type;
-
-    /// @brief `OpVariable` that declared the interface block.
-    const spirv_ll::OpVariable *op;
-  };
-
-  /// @brief Add an interface block ID and its descriptor set to the module.
-  ///
-  /// @param[in] id The ID of an interface block.
-  /// @param[in] set The descriptor set number of the interface block.
-  void addSet(spv::Id id, uint32_t set);
-
-  /// @brief Add an interface block ID and its descriptor binding to the module.
-  ///
-  /// @param[in] id ID of an interface block already added to the module with.
-  /// @param[in] binding The binding number of the interface block.
-  void addBinding(spv::Id id, uint32_t binding);
-
-  /// @brief Return a list of interface block IDs, sorted by their descriptor
-  /// bindings.
-  ///
-  /// @return List of IDs.
-  llvm::SmallVector<spv::Id, 4> getDescriptorBindingList() const;
-
-  /// @brief Fill a list with descriptor set/binding slots used in the module.
-  ///
-  /// @return Returns the list of descriptor set/binding slots used.
-  std::vector<DescriptorBinding> getUsedDescriptorBindings() const;
-
-  /// @brief Whether or not the module uses any descriptor bindings.
-  ///
-  /// @return True if bindings were used, false otherwise.
-  bool hasDescriptorBindings() const;
-
-  /// @brief Look up the `OpCode` object associated with an interface block ID.
-  ///
-  /// @param id ID of the interface block to look up.
-  ///
-  /// @return `OpCode` object that originally created the variable.
-  const OpCode *getBindingOp(spv::Id id) const;
-
-  /// @brief Add an interface block variable to the module.
-  ///
-  /// @param id SPIR-V ID of the block.
-  /// @param op `OpVariable` that declared the block.
-  /// @param variable LLVM global variable object created for the block.
-  void addInterfaceBlockVariable(const spv::Id id,
-                                 const spirv_ll::OpVariable *op, llvm::Type *ty,
-                                 llvm::GlobalVariable *variable);
-
-  /// @brief Return the type of an interface block referred to by an ID.
-  ///
-  /// @param[in] id ID of an interface block.
-  ///
-  /// @return Type of the interface block.
-  llvm::Type *getBlockType(const spv::Id id) const;
-
   /// @brief Create a new `OpCode` derivative object.
   ///
   /// @tparam Op Type of the derived `OpCode`.
@@ -891,35 +811,6 @@ class Module : public ModuleHeader {
   /// `std::nullopt` otherwise.
   std::optional<uint32_t> getSpecId(spv::Id id) const;
 
-  /// @brief Get a pointer to the push constant struct type defined in the
-  /// module.
-  ///
-  /// @return Pointer to the push constant struct type defined in the module or
-  /// `nullptr` if one was not defined.
-  llvm::Type *getPushConstantStructType() const;
-
-  /// @brief Get the ID that will be used to access the push constant struct.
-  ///
-  /// @return Push constant struct ID.
-  spv::Id getPushConstantStructID() const;
-
-  /// @brief Get the previously stored buffer size array `Value`
-  ///
-  /// @return Buffer size array `Value`
-  llvm::Value *getBufferSizeArray() const;
-
-  /// @brief Set a global variable for the push constant struct.
-  ///
-  /// The push constant struct is passed into the entry point of the module as
-  /// an argument, so to make it available globally like it should be the
-  /// argument is stored in this global variable at the start of the entry point
-  /// and loaded from it at the start of every other function.
-  ///
-  /// @param id SPIR-V ID the push constant struct will be accessed with.
-  /// @param variable LLVM global variable object.
-  void setPushConstantStructVariable(spv::Id id,
-                                     llvm::GlobalVariable *variable);
-
   /// @brief Store local workgroup size specified by module in the module.
   ///
   /// @param x The x dimension of the workgroup size.
@@ -933,11 +824,6 @@ class Module : public ModuleHeader {
   /// order.
   const std::array<uint32_t, 3> &getWGS() const;
 
-  /// @brief Save the buffer size array `Value`.
-  ///
-  /// @param buffer_size_array Buffer size array `Value`.
-  void setBufferSizeArray(llvm::Value *buffer_size_array);
-
   /// @brief Store an OpSpecConstantOp that can't be translated immediately.
   ///
   /// @param op `OpSpecConstantOp` object representing the instruction to defer.
@@ -946,10 +832,6 @@ class Module : public ModuleHeader {
   /// @brief Accessor for `deferredSpecConstantOps`.
   const llvm::SmallVector<const OpSpecConstantOp *, 2> &
   getDeferredSpecConstants();
-
-  /// @brief Get a list of entry point arguments that need to have global scope.
-  llvm::SmallVector<std::pair<spv::Id, llvm::GlobalVariable *>, 4>
-  getGlobalArgs() const;
 
   /// @brief The context that this module is using.
   spirv_ll::Context &context;
@@ -1041,8 +923,6 @@ class Module : public ModuleHeader {
       DecorationMap;
   /// @brief Map to keep track of decorations applied by `OpMemberDecorate`.
   llvm::DenseMap<spv::Id, DecoratedStruct> MemberDecorations;
-  /// @brief Map of IDs to the interface blocks they reference.
-  llvm::DenseMap<spv::Id, InterfaceBlock> InterfaceBlocks;
 
   /// @brief Owning container for all the OpCodes in this module.
   // TODO: Could use a slab allocator for `OpCode` derived object storage and
@@ -1097,19 +977,8 @@ class Module : public ModuleHeader {
   llvm::DenseMap<spv::Id, spv::Id> SpecIDs;
   /// @brief Information about specialization constants.
   cargo::optional<const spirv_ll::SpecializationInfo &> specInfo;
-  /// @brief Global variable that stores a reference to the push constant
-  /// struct.
-  llvm::GlobalVariable *PushConstantStructVariable;
-  /// @brief ID used throughout the module to access the push constant struct.
-  spv::Id PushConstantStructID;
   /// @brief Array of values that represent local workgroup size of the module.
   std::array<uint32_t, 3> WorkgroupSize;
-  /// @brief Handle to an array of sizes of descriptor bindings in the module.
-  ///
-  /// More specifically, it contains the sizes of the buffers the descriptors
-  /// are backed by. This exists as a function argument and will be passed in by
-  /// the api if any descriptor bindings are used.
-  llvm::Value *BufferSizeArray;
   /// @brief List of `OpSpecConstantOp` instructions whose translation had to be
   /// deferred.
   llvm::SmallVector<const spirv_ll::OpSpecConstantOp *, 2>
@@ -1122,14 +991,6 @@ class Module : public ModuleHeader {
   /// instructions are to be obeyed.
   bool ImplicitDebugScopes = true;
 };
-
-/// @brief Less than operator that compares the descriptor binding in each `ID`
-/// `InterfaceBlock` pair to allow for a list of IDs sorted by their associated
-/// descriptor set bindings.
-inline bool operator<(const std::pair<spv::Id, Module::InterfaceBlock> &lhs,
-                      const std::pair<spv::Id, Module::InterfaceBlock> &rhs) {
-  return lhs.second.binding < rhs.second.binding;
-}
 
 }  // namespace spirv_ll
 

--- a/modules/compiler/spirv-ll/source/builder.cpp
+++ b/modules/compiler/spirv-ll/source/builder.cpp
@@ -1464,24 +1464,6 @@ void spirv_ll::Builder::generateSpecConstantOps() {
   IRBuilder.SetInsertPoint(oldBasicBlock, oldInsertPoint);
 }
 
-void spirv_ll::Builder::handleGlobalParameters() {
-  auto functionOp = module.get<OpFunction>(getCurrentFunction());
-  auto uniformGlobals = module.getGlobalArgs();
-  if (module.getEntryPoint(functionOp->IdResult())) {
-    for (const auto &iter : uniformGlobals) {
-      auto var = module.getValue(iter.first);
-      IRBuilder.CreateStore(var, iter.second);
-    }
-  } else {
-    for (const auto &iter : uniformGlobals) {
-      auto paramOp = module.get<OpResult>(iter.first);
-      auto loaded =
-          IRBuilder.CreateLoad(iter.second->getValueType(), iter.second);
-      module.replaceID(paramOp, loaded);
-    }
-  }
-}
-
 llvm::Type *spirv_ll::Builder::getRelationalReturnType(llvm::Value *operand) {
   // If the operand is a vector the result of the builtin will be a vector of
   // ints of the same size as the operand's scalar type, e.g. double2 will

--- a/modules/compiler/spirv-ll/source/builder_core.cpp
+++ b/modules/compiler/spirv-ll/source/builder_core.cpp
@@ -1698,15 +1698,6 @@ llvm::Error Builder::create<OpSpecConstantOp>(const OpSpecConstantOp *op) {
   return llvm::Error::success();
 }
 
-namespace {
-// OpArrayLength: Array member is an unsigned 32-bit integer index of the last
-// member of the structure that Structure points to. That member’s type must be
-// from OpTypeRuntimeArray.
-llvm::Type *getBufferSizeTy(llvm::LLVMContext &ctx) {
-  return llvm::IntegerType::getInt32Ty(ctx);
-}
-}  // namespace
-
 static std::optional<std::pair<uint32_t, const char *>> getLinkage(
     Module &module, spv::Id id) {
   if (auto decoration =
@@ -1779,93 +1770,6 @@ llvm::Error Builder::create<OpFunction>(const OpFunction *op) {
     }
 
     switch (ep_op->ExecutionModel()) {
-      case spv::ExecutionModelGLCompute: {
-        // deal with descriptor sets
-
-        // get the sorted list of descriptor bindings
-        const llvm::SmallVector<spv::Id, 4> binding_list =
-            module.getDescriptorBindingList();
-
-        llvm::SmallVector<llvm::Type *, 4> arg_types;
-
-        // turn the list of descriptor binding IDs into a sorted list of the
-        // interface block types
-        for ([[maybe_unused]] auto _ : binding_list) {
-          // Blocks are always passed by pointer
-          llvm::Type *type = IRBuilder.getPtrTy(/*AddrSpace=*/1);
-          SPIRV_LL_ASSERT_PTR(type);
-
-          arg_types.push_back(type);
-        }
-
-        llvm::Type *push_constant_struct_type =
-            module.getPushConstantStructType();
-        if (push_constant_struct_type) {
-          arg_types.push_back(push_constant_struct_type);
-        }
-
-        // if this module has used any descriptor bindings add the buffer sizes
-        // buffer to the argument list (1 == global address space)
-        if (module.hasDescriptorBindings()) {
-          arg_types.push_back(IRBuilder.getPtrTy(/*AddrSpace=*/1));
-        }
-
-        // create a new function type with the same return type as the original
-        // (should be void) and the new list of argument types we just created
-        function_type = llvm::FunctionType::get(function_type->getReturnType(),
-                                                arg_types, false);
-
-        function = llvm::Function::Create(
-            function_type, llvm::GlobalValue::LinkageTypes::ExternalLinkage,
-            entry_point_name, module.llvmModule.get());
-        function->setCallingConv(llvm::CallingConv::SPIR_KERNEL);
-
-        // setCurrentFunction copies the new function's argument list into the
-        // module, and lets us access them as values with popFunctionArg
-        setCurrentFunction(function);
-
-        for (auto id : binding_list) {
-          // iterate through the descriptor bindings, adding their IDs to the
-          // module with the new function arguments as their value
-          auto binding_op = spirv_ll::cast<OpVariable>(module.getBindingOp(id));
-          SPIRV_LL_ASSERT_PTR(binding_op);
-          module.replaceID(binding_op, popFunctionArg());
-        }
-
-        // if a push constant struct type was added there will be one last
-        // function arg to pop and be added to the module with the ID from the
-        // OpVariable that would have declared the push constant struct
-        if (push_constant_struct_type) {
-          auto push_constant_op =
-              module.get<OpVariable>(module.getPushConstantStructID());
-          module.addID(module.getPushConstantStructID(), push_constant_op,
-                       popFunctionArg());
-        }
-
-        // deal with any built-in variables used
-
-        // number of interfaces in an OpEntryPoint is its word count minus the
-        // base word count (4) and the length of name in 32 bit words
-        // TODO CA-2650: This divide rounds down, but should round up.
-        const uint32_t num_interfaces =
-            ep_op->wordCount() - (4 + (entry_point_name.size() / 4));
-
-        if (num_interfaces) {
-          const llvm::SmallVector<llvm::Function *, 2> initializers;
-
-          // for each input builtin used in the entry point push its ID to a
-          // list of IDs that will be iterated through and used to lookup the
-          // appropriate init function when the first basic block is added to
-          // the function
-          for (uint32_t interface_index = 0; interface_index < num_interfaces;
-               interface_index++) {
-            pushBuiltinID(ep_op->Interface()[interface_index]);
-          }
-        }
-        if (module.hasDescriptorBindings()) {
-          module.setBufferSizeArray(popFunctionArg());
-        }
-      } break;
       case spv::ExecutionModelKernel: {
         kernel_function = llvm::Function::Create(
             function_type, llvm::GlobalValue::LinkageTypes::ExternalLinkage,
@@ -2218,11 +2122,9 @@ llvm::Error Builder::create<OpFunctionParameter>(
       }
     }
 
-    // NonReadable and NonWritable only apply to OpTypeImage or Uniform Storage
-    // Class with BufferBlock decoration.
+    // NonReadable and NonWritable only apply to OpTypeImage.
     auto opResultType = module.getResultType(op);
-    if (opResultType->isImageType() ||
-        module.getFirstDecoration(op->IdResult(), spv::DecorationBufferBlock)) {
+    if (opResultType->isImageType()) {
       if (module.getFirstDecoration(op->IdResult(),
                                     spv::DecorationNonReadable)) {
         attrs.addAttribute(llvm::Attribute::ReadNone);
@@ -2578,9 +2480,6 @@ llvm::Error Builder::create<OpFunctionCall>(const OpFunctionCall *op) {
 
 template <>
 llvm::Error Builder::create<OpVariable>(const OpVariable *op) {
-  llvm::Type *varPtrTy = module.getLLVMType(op->IdResultType());
-  SPIRV_LL_ASSERT_PTR(varPtrTy);
-
   auto *resultTy = module.get<OpTypePointer>(op->IdResultType());
   SPIRV_LL_ASSERT(resultTy, "Result type is not a pointer");
   auto varTy = module.getLLVMType(resultTy->getTypePointer()->Type());
@@ -2758,83 +2657,6 @@ llvm::Error Builder::create<OpVariable>(const OpVariable *op) {
           alloca->setAlignment(align);
         }
       }
-    }
-  } else if (module.hasCapability(spv::CapabilityShader)) {
-    switch (op->StorageClass()) {
-      case spv::StorageClassFunction: {
-        SPIRV_LL_ASSERT_PTR(getCurrentFunction());
-        auto *alloca = IRBuilder.CreateAlloca(varTy);
-        alloca->setName(name);
-        if (initializer) {
-          IRBuilder.CreateStore(initializer, alloca);
-        }
-        value = alloca;
-      } break;
-      case spv::StorageClassPrivate: {
-        value = new llvm::GlobalVariable(
-            *module.llvmModule, varTy, false,
-            llvm::GlobalValue::LinkageTypes::PrivateLinkage, initializer, name);
-      } break;
-      case spv::StorageClassUniformConstant: {
-        value = new llvm::GlobalVariable(
-            *module.llvmModule, varTy, true,
-            llvm::GlobalValue::LinkageTypes::ExternalLinkage, initializer,
-            name);
-      } break;
-      case spv::StorageClassCrossWorkgroup: {
-        value = new llvm::GlobalVariable(
-            *module.llvmModule, varTy, false,
-            llvm::GlobalValue::LinkageTypes::ExternalLinkage, initializer,
-            name);
-      } break;
-      case spv::StorageClassWorkgroup: {
-        value = new llvm::GlobalVariable(
-            *module.llvmModule, varTy, false,
-            llvm::GlobalValue::LinkageTypes::InternalLinkage, initializer, name,
-            nullptr, llvm::GlobalValue::ThreadLocalMode::NotThreadLocal, 3);
-      } break;
-      case spv::StorageClassGeneric:
-        // This requires the GenericPointer capability, which is not supported
-        // by OpenCL 1.2 (see the OpenCL SPIR-V environment spec section 6.1)
-        SPIRV_LL_ABORT("StorageClass Generic not supported");
-        break;
-      case spv::StorageClassInput: {
-        // the only IDs making use of the input storage class with this tool
-        // should be decorated input builtins
-        if (module.getFirstDecoration(op->IdResult(), spv::DecorationBuiltIn)) {
-          module.addBuiltInID(op->IdResult());
-
-          // this is a dummy variable that will later be used to inline the
-          // builtin variable wherever it is used
-          value = new llvm::GlobalVariable(
-              *module.llvmModule, varTy, false,
-              llvm::GlobalValue::LinkageTypes::ExternalLinkage,
-              llvm::UndefValue::get(varTy), name);
-        }
-      } break;
-      // TODO: the rest of the storage classes
-      case spv::StorageClassUniform:
-      case spv::StorageClassStorageBuffer:
-        module.addInterfaceBlockVariable(
-            op->IdResult(), op, varTy,
-            new llvm::GlobalVariable(
-                *module.llvmModule, varPtrTy, false,
-                llvm::GlobalValue::LinkageTypes::PrivateLinkage,
-                llvm::UndefValue::get(varPtrTy)));
-        return llvm::Error::success();
-      case spv::StorageClassPushConstant:
-        module.setPushConstantStructVariable(
-            op->IdResult(), new llvm::GlobalVariable(
-                                *module.llvmModule, varPtrTy, false,
-                                llvm::GlobalValue::LinkageTypes::PrivateLinkage,
-                                llvm::UndefValue::get(varPtrTy)));
-        return llvm::Error::success();
-      case spv::StorageClassOutput:
-      case spv::StorageClassAtomicCounter:
-      case spv::StorageClassImage:
-      default:
-        SPIRV_LL_ASSERT_PTR(value);
-        break;
     }
   }
 
@@ -3149,78 +2971,6 @@ llvm::Error Builder::create<OpPtrAccessChain>(const OpPtrAccessChain *op) {
   }
 
   module.addID(op->IdResult(), op, inst);
-  return llvm::Error::success();
-}
-
-template <>
-llvm::Error Builder::create<OpArrayLength>(const OpArrayLength *op) {
-  llvm::Type *blockType = module.getBlockType(op->Structure());
-
-  if (blockType) {
-    llvm::StructType *blockStructType = llvm::cast<llvm::StructType>(blockType);
-
-    // total the sizes of all but the last element in the interface block struct
-    uint32_t blockMembersSize = 0;
-
-    for (const auto &type : blockStructType->elements()) {
-      // the last element has to be the array we are getting the size of, so
-      // skip it
-      if (type != blockStructType->elements().back()) {
-        const uint64_t typeSizeInBits =
-            module.llvmModule->getDataLayout().getTypeSizeInBits(type);
-        // we want the size in bytes
-        blockMembersSize += typeSizeInBits / 8;
-      }
-    }
-
-    // figure out the offset into the buffer sizes array we need to be looking
-    // at, first get the sorted (in order of set 0 binding 0 to set n binding n,
-    // this is the order the buffer sizes will be in when they are passed
-    // through by the api) list of interface block struct IDs
-    llvm::SmallVector<spv::Id, 4> descriptorBindingList =
-        module.getDescriptorBindingList();
-
-    // find our target struct ID in the list
-    auto bindingIter = std::find(descriptorBindingList.begin(),
-                                 descriptorBindingList.end(), op->Structure());
-    SPIRV_LL_ASSERT(
-        bindingIter != descriptorBindingList.end(),
-        "Struct ID provided to OpArrayLength wasn't a descriptor binding!");
-
-    // and figure out where in the list it is
-    const uint32_t bindingIndex =
-        std::distance(descriptorBindingList.begin(), bindingIter);
-
-    // create a load to get the total size of the buffer that backs our block
-    auto bufSizeArray = module.getBufferSizeArray();
-    auto *const bufSizeTy = getBufferSizeTy(*context.llvmContext);
-    SPIRV_LL_ASSERT(bufSizeArray->getType()->isPointerTy(),
-                    "Incompatible buffer size type");
-    llvm::Value *bufferSizePtr = IRBuilder.CreateGEP(
-        bufSizeTy, bufSizeArray, IRBuilder.getInt32(bindingIndex));
-
-    llvm::Value *totalBufferSize =
-        IRBuilder.CreateLoad(bufSizeTy, bufferSizePtr);
-
-    // size of the array is the size of the whole buffer minus the size of the
-    // other members in the block
-    llvm::Value *arraySizeInBytes = IRBuilder.CreateSub(
-        totalBufferSize, IRBuilder.getInt32(blockMembersSize));
-
-    // use data layout to get the size of the array element type of the last
-    // member of the block struct type (this instruction must be called on the
-    // last member of the struct, which must be an array)
-    const uint32_t arrayElementSize =
-        module.llvmModule->getDataLayout().getTypeAllocSize(
-            blockStructType->elements().back()->getArrayElementType());
-
-    // final result is the size of the array in bytes divided by the size of an
-    // array element in bytes, since llvm div operations round towards zero this
-    // will always give us the max possible size of the array
-    module.addID(op->IdResult(), op,
-                 IRBuilder.CreateUDiv(arraySizeInBytes,
-                                      IRBuilder.getInt32(arrayElementSize)));
-  }
   return llvm::Error::success();
 }
 
@@ -6035,9 +5785,6 @@ llvm::Error Builder::create<OpLabel>(const OpLabel *op) {
   // constant instructions that may have been deferred, and deal with any
   // interface blocks that need to be loaded/stored.
   if (current_function->size() == 1) {
-    if (module.hasCapability(spv::CapabilityShader)) {
-      handleGlobalParameters();
-    }
     generateSpecConstantOps();
   }
 

--- a/modules/compiler/spirv-ll/source/context.cpp
+++ b/modules/compiler/spirv-ll/source/context.cpp
@@ -242,9 +242,6 @@ cargo::expected<spirv_ll::Module, spirv_ll::Error> spirv_ll::Context::translate(
       case spv::OpTypeArray:
         error = builder.create<OpTypeArray>(op);
         break;
-      case spv::OpTypeRuntimeArray:
-        error = builder.create<OpTypeRuntimeArray>(op);
-        break;
       case spv::OpTypeStruct:
         error = builder.create<OpTypeStruct>(op);
         break;
@@ -357,9 +354,6 @@ cargo::expected<spirv_ll::Module, spirv_ll::Error> spirv_ll::Context::translate(
         break;
       case spv::OpPtrAccessChain:
         error = builder.create<OpPtrAccessChain>(op);
-        break;
-      case spv::OpArrayLength:
-        error = builder.create<OpArrayLength>(op);
         break;
       case spv::OpGenericPtrMemSemantics:
         error = builder.create<OpGenericPtrMemSemantics>(op);


### PR DESCRIPTION
# Overview

[spirv-ll][NFC] Remove shader-specific SPIR-V support.

# Reason for change

This was only used with the Vulkan API which we no longer support.

# Description of change

*Describe the intended behaviour your changes are meant to introduce to the
project and explain how they resolve the problem stated above. Detail any
relevant changes that may affect other users of the project, such as
compilation options, runtime flags, expected inputs and outputs, API entry
points, etc.*

*If you have added new testing, provide details on what tests you have added
and what the purpose of them is.*

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-19](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
