### PR TITLE
[CI] Specify specific OCK commit to fetch when building DPC++.

### DIFF
--- a/.github/actions/do_build_dpcpp/action.yml
+++ b/.github/actions/do_build_dpcpp/action.yml
@@ -4,10 +4,6 @@ description: build dpc++
 inputs:
   target:
     description: 'target architecture'
-  ock_git_tag:
-    description: 'dpcpp build config uses this ock Git tag.  Note: "github.sha" is good for both schedule and pull_request events.'
-    type: string
-    default: ${{ github.sha }}
   download_dpcpp_artefact:
     description: 'download ock artefact rather than building, of form <target>=id;<target2=id2>. Special value of download_release applies to all targets.'
     type: string
@@ -70,10 +66,9 @@ runs:
         cd llvm
         set -x
         # Note: Although CMake FetchContent will currently only handle branches and tags by default in
-        #       OCK_GIT_TAG, other refs are accessible via the formatting work-around used below, i.e.:
-        #         "${{ inputs.ock_git_tag }};GIT_CONFIG;remote.origin.fetch=+refs/pull/*:refs/pull/*"
+        #       OCK_GIT_TAG, other refs are accessible by specifying the fetch configuration.
         python3 buildbot/configure.py -o build/${{steps.calc_vars.outputs.arch}}-linux \
-                -DOCK_GIT_TAG="${{ inputs.ock_git_tag }};GIT_CONFIG;remote.origin.fetch=+refs/pull/*:refs/pull/*" \
+                -DOCK_GIT_TAG="${{ github.sha }};GIT_CONFIG;remote.origin.fetch=+${{ github.sha }}:refs/ock-commit" \
                 --host-target="X86;AArch64;RISCV" --native_cpu \
                 --llvm-external-projects=lld --cmake-opt=-DNATIVECPU_USE_OCK=ON \
                 $CROSS_OPTS \

--- a/.github/workflows/planned_testing_caller_20.yml
+++ b/.github/workflows/planned_testing_caller_20.yml
@@ -29,5 +29,3 @@ jobs:
       # We can set ock, test_sycl_cts etc here optionally if this is used as a
       # pull request. Any parameters below this is intended for local testing
       # and should not be merged nor reviewed (other than checking it should not be merged).
-
-


### PR DESCRIPTION
# Overview

[CI] Specify specific OCK commit to fetch when building DPC++.

# Reason for change

We were fetching refs/pull/* in order to ensure that we would always have pull/<id>/merge available, without accounting for the fact that pull/<id>/merge may change after CI has been triggered.

# Description of change

We should not need to fetch all PRs anyway, we only need the specific commit that we are trying to build, so explicitly fetch that instead.

# Anything else we should know?

This approach cannot be used with arbitrary ock_git_tag. We were not using that functionality so this removes the option.

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-19](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
