### PR TITLE
Pick up correct Python for ca-lit.

### DIFF
--- a/cmake/AddCA.cmake
+++ b/cmake/AddCA.cmake
@@ -1434,7 +1434,7 @@ function(add_ca_lit_check target comment)
     list(APPEND LIT_ARGS "--param" emulator="${CMAKE_CROSSCOMPILING_EMULATOR}")
   endif()
 
-  set(LIT_COMMAND "${PYTHON_EXECUTABLE};${CA_LIT_PATH}")
+  set(LIT_COMMAND "${Lit_PYTHON_EXECUTABLE};${CA_LIT_PATH}")
   list(APPEND LIT_COMMAND ${LIT_ARGS})
   foreach(param ${args_PARAMS})
     list(APPEND LIT_COMMAND --param ${param})

--- a/cmake/FindLit.cfg
+++ b/cmake/FindLit.cfg
@@ -1,0 +1,2 @@
+print(sys.executable)
+exit(0)

--- a/cmake/FindLit.cmake
+++ b/cmake/FindLit.cmake
@@ -60,6 +60,14 @@ if(NOT Lit_EXECUTABLE STREQUAL Lit_EXECUTABLE-NOTFOUND)
     set_target_properties(lit PROPERTIES
       IMPORTED_LOCATION ${Lit_EXECUTABLE})
   endif()
+  if(NOT Lit_PYTHON_EXECUTABLE)
+    execute_process(COMMAND ${Lit_EXECUTABLE}
+      --config-prefix FindLit ${CMAKE_CURRENT_LIST_DIR}
+      OUTPUT_VARIABLE Lit_PYTHON_EXECUTABLE
+      OUTPUT_STRIP_TRAILING_WHITESPACE)
+    message(STATUS "Found Lit Python: ${Lit_PYTHON_EXECUTABLE}")
+    set(Lit_PYTHON_EXECUTABLE "${Lit_PYTHON_EXECUTABLE}" CACHE STRING "Path to a Python executable supporting the LLVM lit module.")
+  endif()
 endif()
 
 include(FindPackageHandleStandardArgs)

--- a/modules/lit/ca-lit.in
+++ b/modules/lit/ca-lit.in
@@ -1,4 +1,4 @@
-#! /usr/bin/env python3
+#! @Lit_PYTHON_EXECUTABLE@
 # -*- coding: utf-8 -*-
 
 """ A convenience testing wrapper which allows running of lit tests directly


### PR DESCRIPTION
# Overview

Pick up correct Python for ca-lit.

# Reason for change

When lit has been installed in a venv (possibly using pipx), a Python outside of that venv will not be able to load any lit module.

# Description of change

Make sure we use whatever Python lit itself uses.

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-19](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
