### PR TITLE
Simplify dockers, including removing vulkan sdk and clang-tidy

### DIFF
--- a/.github/dockerfiles/Dockerfile_22.04-aarch64
+++ b/.github/dockerfiles/Dockerfile_22.04-aarch64
@@ -10,8 +10,7 @@ RUN pip install cmakelint colorama lit
 RUN apt-get install --yes spirv-tools
 RUN apt-get install --yes wget gpg
 RUN wget -qO - https://apt.llvm.org/llvm-snapshot.gpg.key | gpg --dearmor - | tee /usr/share/keyrings/llvm-archive-keyring.gpg >/dev/null
-RUN echo 'deb [signed-by=/usr/share/keyrings/llvm-archive-keyring.gpg] http://apt.llvm.org/jammy/ llvm-toolchain-jammy-18 main' | tee /etc/apt/sources.list.d/llvm.list >/dev/null
-RUN echo 'deb [signed-by=/usr/share/keyrings/llvm-archive-keyring.gpg] http://apt.llvm.org/jammy/ llvm-toolchain-jammy-19 main' | tee -a /etc/apt/sources.list.d/llvm.list >/dev/null
+RUN echo 'deb [signed-by=/usr/share/keyrings/llvm-archive-keyring.gpg] http://apt.llvm.org/jammy/ llvm-toolchain-jammy-19 main' | tee /etc/apt/sources.list.d/llvm.list >/dev/null
 RUN echo 'deb [signed-by=/usr/share/keyrings/llvm-archive-keyring.gpg] http://apt.llvm.org/jammy/ llvm-toolchain-jammy-20 main' | tee -a /etc/apt/sources.list.d/llvm.list >/dev/null
 
 RUN apt-get install --yes zstd

--- a/.github/dockerfiles/Dockerfile_22.04-x86-64
+++ b/.github/dockerfiles/Dockerfile_22.04-x86-64
@@ -1,10 +1,7 @@
 FROM ubuntu:22.04
 
 RUN apt-get update 
-RUN apt-get install -y git git-crypt wget curl jq xz-utils build-essential zlib1g-dev lsb-release libssl-dev
-# Set the timezone, required to avoid hanging on input
-ENV TZ=Europe/London
-RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+RUN apt-get install -y wget git build-essential
 
 # Enable ability to install foreign packages for cross compilation
 RUN dpkg --add-architecture i386
@@ -14,50 +11,30 @@ RUN dpkg --add-architecture riscv64
 # The main archive only hosts amd64 and i386, we need to add ports for arm64 and riscv64.
 RUN sed -i -e '/^deb /{h;s|deb |&[arch=amd64,i386] |p;g;s|deb http://[^ ]*|deb [arch=arm64,riscv64] http://ports.ubuntu.com/ubuntu-ports|p;d}' /etc/apt/sources.list
 
-# Add VulkanSDK latest package repository
-RUN wget -qO - https://packages.lunarg.com/lunarg-signing-key-pub.asc | apt-key add -
-RUN wget -qO /etc/apt/sources.list.d/lunarg-vulkan-1.3.243-jammy.list https://packages.lunarg.com/vulkan/1.3.243/lunarg-vulkan-1.3.243-jammy.list
-# Sync the two above package repositories
-RUN apt-get update
-
-# Add clang-tidy
+# Add llvm repos
 RUN wget -qO - https://apt.llvm.org/llvm-snapshot.gpg.key | gpg --dearmor - | tee /usr/share/keyrings/llvm-archive-keyring.gpg >/dev/null
-RUN echo 'deb [signed-by=/usr/share/keyrings/llvm-archive-keyring.gpg] http://apt.llvm.org/jammy/ llvm-toolchain-jammy-18 main' | tee /etc/apt/sources.list.d/llvm.list >/dev/null
-RUN echo 'deb [signed-by=/usr/share/keyrings/llvm-archive-keyring.gpg] http://apt.llvm.org/jammy/ llvm-toolchain-jammy-19 main' | tee -a /etc/apt/sources.list.d/llvm.list >/dev/null
+RUN echo 'deb [signed-by=/usr/share/keyrings/llvm-archive-keyring.gpg] http://apt.llvm.org/jammy/ llvm-toolchain-jammy-19 main' | tee /etc/apt/sources.list.d/llvm.list >/dev/null
 RUN echo 'deb [signed-by=/usr/share/keyrings/llvm-archive-keyring.gpg] http://apt.llvm.org/jammy/ llvm-toolchain-jammy-20 main' | tee -a /etc/apt/sources.list.d/llvm.list >/dev/null
 RUN apt-get update
-RUN apt-get install --yes clang-tidy-19
 
 # Install minimum requirements
 RUN apt-get install --yes cmake libtinfo-dev
-# Install vulkan-sdk
-RUN apt-get install --yes vulkan-sdk
 # Install 32-bit requirements
 RUN apt-get install --yes gcc-multilib g++-multilib libc6-dev:i386 lib32tinfo-dev lib32ncurses-dev
-# Install Arm requirements
-RUN apt-get install --yes gcc-arm-linux-gnueabihf g++-arm-linux-gnueabihf
 # Install AArch64 requirements
 RUN apt-get install --yes gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
 # Install RISC-V requirements
 RUN apt-get install --yes gcc-riscv64-linux-gnu g++-riscv64-linux-gnu
 # Install recommended packages
-RUN apt-get install --yes python3 python3-pip ninja-build doxygen
-# Install documentation packages
-RUN apt-get install --yes graphviz latexmk texlive-xetex xindy texlive-fonts-extra
+RUN apt-get install --yes python3 python3-pip ninja-build
 # Install CI utility packages
-RUN apt-get install --yes parallel
-# Install QEMU for testing cross compilation.
-RUN apt-get install --yes qemu-user
 # Install pkg-config for dpc++ builds and locally built spir-v
 RUN apt-get install --yes pkg-config
 # Install spirv tools
 RUN apt-get install --yes spirv-tools
 
-# Set-up pip
-RUN update-alternatives --install /usr/bin/pip pip `which pip3` 30
-
 # Install python packages
-RUN pip install cmakelint colorama flake8 lit pylint requests virtualenv yapf python-gitlab distro clang-format==19.1.0
+RUN pip install colorama lit virtualenv
 
 # Install libhwloc-dev for dpc++ dependency
 RUN apt-get install --yes libhwloc-dev:amd64 libhwloc-dev:arm64 libhwloc-dev:i386 libhwloc-dev:riscv64
@@ -65,7 +42,5 @@ RUN apt-get install --yes libhwloc-dev:amd64 libhwloc-dev:arm64 libhwloc-dev:i38
 RUN apt-get -y install sudo
 RUN apt-get -y install gh
 RUN apt install -y zstd
-RUN apt install -y gnupg
 RUN apt install -y gcc g++
-RUN apt install -y file
 RUN apt install -y ccache

--- a/.github/dockerfiles/Dockerfile_24.04-x86-64
+++ b/.github/dockerfiles/Dockerfile_24.04-x86-64
@@ -1,12 +1,8 @@
 FROM ubuntu:24.04
 
 RUN apt-get update 
-RUN apt-get install -y git git-crypt wget curl jq xz-utils build-essential zlib1g-dev lsb-release libssl-dev
-# Set the timezone, required to avoid hanging on input
-ENV TZ=Europe/London
-RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+RUN apt-get install -y wget git build-essential
 
-# Enable ability to install foreign packages for cross compilation
 RUN dpkg --add-architecture i386
 RUN dpkg --add-architecture arm64
 RUN dpkg --add-architecture riscv64
@@ -14,37 +10,23 @@ RUN dpkg --add-architecture riscv64
 # The main archive only hosts amd64 and i386, we need to add ports for arm64 and riscv64.
 RUN sed -i -e '/^Types:/,/^Signed-By:/{/Types:/{h;d};H;/^Signed-By:/{g;s|$|\nArchitectures: amd64,i386\n|p;g;s|URIs: [^\n]*|URIs: http://ports.ubuntu.com/ubuntu-ports|;s|$|\nArchitectures: arm64,riscv64|p;};d}' /etc/apt/sources.list.d/ubuntu.sources
 
-# Add VulkanSDK latest package repository
-RUN wget -qO - https://packages.lunarg.com/lunarg-signing-key-pub.asc | apt-key add -
-RUN wget -qO /etc/apt/sources.list.d/lunarg-vulkan-noble.list https://packages.lunarg.com/vulkan/lunarg-vulkan-noble.list
-# Sync the two above package repositories
 RUN apt-get update
 
-# Add clang-tidy
 RUN wget -qO - https://apt.llvm.org/llvm-snapshot.gpg.key | gpg --dearmor - | tee /usr/share/keyrings/llvm-archive-keyring.gpg >/dev/null
-RUN echo 'deb [signed-by=/usr/share/keyrings/llvm-archive-keyring.gpg] http://apt.llvm.org/noble/ llvm-toolchain-noble-18 main' | tee /etc/apt/sources.list.d/llvm.list >/dev/null
-RUN echo 'deb [signed-by=/usr/share/keyrings/llvm-archive-keyring.gpg] http://apt.llvm.org/noble/ llvm-toolchain-noble-19 main' | tee -a /etc/apt/sources.list.d/llvm.list >/dev/null
+RUN echo 'deb [signed-by=/usr/share/keyrings/llvm-archive-keyring.gpg] http://apt.llvm.org/noble/ llvm-toolchain-noble-19 main' | tee /etc/apt/sources.list.d/llvm.list >/dev/null
 RUN echo 'deb [signed-by=/usr/share/keyrings/llvm-archive-keyring.gpg] http://apt.llvm.org/noble/ llvm-toolchain-noble-20 main' | tee -a /etc/apt/sources.list.d/llvm.list >/dev/null
 RUN apt-get update
-RUN apt-get install --yes clang-tidy-19
 
 # Install minimum requirements
 RUN apt-get install --yes cmake libtinfo-dev
-RUN apt-get install --yes vulkan-sdk
 # Install 32-bit requirements
 RUN apt-get install --yes gcc-multilib g++-multilib libc6-dev:i386 lib32ncurses-dev
-# Install Arm requirements
-RUN apt-get install --yes gcc-arm-linux-gnueabihf g++-arm-linux-gnueabihf
 # Install AArch64 requirements
 RUN apt-get install --yes gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
 # Install RISC-V requirements
 RUN apt-get install --yes gcc-riscv64-linux-gnu g++-riscv64-linux-gnu
 # Install recommended packages
-RUN apt-get install --yes python3 python3-pip ninja-build doxygen
-# Install documentation packages
-RUN apt-get install --yes graphviz latexmk texlive-xetex xindy texlive-fonts-extra
-# Install CI utility packages
-RUN apt-get install --yes parallel
+RUN apt-get install --yes python3 python3-pip ninja-build
 # Install QEMU for testing cross compilation.
 RUN apt-get install --yes qemu-user
 # Install pkgconf for dpc++ builds and locally built spir-v
@@ -56,7 +38,7 @@ RUN apt-get install --yes spirv-tools
 RUN update-alternatives --install /usr/bin/pip pip `which pip3` 30
 
 # Install python packages
-RUN apt-get install --yes python3-colorama python3-distro python3-flake8 python3-gitlab python3-requests python3-virtualenv python3-yapf pipx
+RUN apt-get install --yes python3-colorama python3-virtualenv pipx
 RUN PIPX_HOME=/usr/local/share/pipx PIPX_BIN_DIR=/usr/local/bin PIPX_MAN_DIR=/usr/local/share/man pipx install cmakelint lit pylint clang-format==19.1.0
 
 # Install libhwloc-dev for dpc++ dependency
@@ -65,7 +47,5 @@ RUN apt-get install --yes libhwloc-dev:amd64 libhwloc-dev:arm64 libhwloc-dev:i38
 RUN apt-get -y install sudo
 RUN apt-get -y install gh
 RUN apt install -y zstd
-RUN apt install -y gnupg
 RUN apt install -y gcc g++
-RUN apt install -y file
 RUN apt install -y ccache


### PR DESCRIPTION

These can be simplified to be useful for the vast majority to jobs, but still have most of the useful installations present, so installing things will still be mostly not required.

# Overview

Simplify dockers, including removing vulkan sdk and clang-tidy

# Reason for change

The current dockers take about 1m20s to load.  Vulkan SDK is also no longer needed, along with llvm 18.

# Description of change

Removed a lot of installs, particularly llvm ones that only apply to single jobs like clang-tidy. Where it doesn't add too much to the docker and is used in multiple jobs, I've tried to keep it with the aim of having the load under 25 seconds. https://github.com/uxlfoundation/oneapi-construction-kit/pull/819/ shows approximately what would be required beyond now to work with these docker changes.
