### PR TITLE
Update to use smaller docker with a few extra installs

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -16,7 +16,7 @@ jobs:
       packages: read
     runs-on: ubuntu-22.04
     container:
-      image: 'ghcr.io/uxlfoundation/ock_ubuntu_22.04-x86-64@sha256:11930b4367fb364589419475a36406b94e835b1b4431af301d23c7dfa94b4539'
+      image: 'ghcr.io/uxlfoundation/ock_ubuntu_22.04-x86-64:latest'
       volumes:
         - ${{github.workspace}}:${{github.workspace}}
 
@@ -67,7 +67,7 @@ jobs:
       packages: read
     runs-on: ubuntu-22.04
     container:
-      image: 'ghcr.io/uxlfoundation/ock_ubuntu_22.04-x86-64@sha256:11930b4367fb364589419475a36406b94e835b1b4431af301d23c7dfa94b4539'
+      image: 'ghcr.io/uxlfoundation/ock_ubuntu_22.04-x86-64:latest'
       volumes:
         - ${{github.workspace}}:${{github.workspace}}
 

--- a/.github/workflows/create_publish_artifacts.yml
+++ b/.github/workflows/create_publish_artifacts.yml
@@ -17,7 +17,7 @@ jobs:
   run_riscv_m1_nightly_package:
     runs-on: ubuntu-22.04
     container:
-      image: 'ghcr.io/uxlfoundation/ock_ubuntu_22.04-x86-64@sha256:11930b4367fb364589419475a36406b94e835b1b4431af301d23c7dfa94b4539'
+      image: 'ghcr.io/uxlfoundation/ock_ubuntu_22.04-x86-64:latest'
       volumes:
         - ${{github.workspace}}:${{github.workspace}}
 

--- a/.github/workflows/planned_testing_caller_19.yml
+++ b/.github/workflows/planned_testing_caller_19.yml
@@ -41,3 +41,5 @@ jobs:
       # download_ock_artefact: host_x86_64_linux=14225268091;host_aarch64_linux=14225268091;host_riscv64_linux=14225268091
       # download_dpcpp_artefact: host_x86_64_linux=14225268091;host_aarch64_linux=14225268091;host_riscv64_linux=14225268091
       # download_sycl_cts_artefact: host_x86_64_linux=14225268091;host_aarch64_linux=14225268091;host_riscv64_linux=14225268091
+
+# Force running L19 on PR

--- a/.github/workflows/pr_tests_cache.yml
+++ b/.github/workflows/pr_tests_cache.yml
@@ -33,7 +33,7 @@ jobs:
     if: github.repository == 'uxlfoundation/oneapi-construction-kit' || github.event_name != 'schedule'
     runs-on: ubuntu-22.04
     container:
-      image: ghcr.io/uxlfoundation/ock_ubuntu_22.04-x86-64@sha256:11930b4367fb364589419475a36406b94e835b1b4431af301d23c7dfa94b4539
+      image: ghcr.io/uxlfoundation/ock_ubuntu_22.04-x86-64:latest
       volumes:
         - ${{github.workspace}}:${{github.workspace}}    
     steps:
@@ -63,7 +63,7 @@ jobs:
     needs: [ubuntu_22_llvm_prev_jobs]
     runs-on: ubuntu-22.04
     container:
-      image: ghcr.io/uxlfoundation/ock_ubuntu_22.04-x86-64@sha256:11930b4367fb364589419475a36406b94e835b1b4431af301d23c7dfa94b4539
+      image: ghcr.io/uxlfoundation/ock_ubuntu_22.04-x86-64:latest
       volumes:
         - ${{github.workspace}}:${{github.workspace}}    
     steps:

--- a/.github/workflows/run_ock_demo.yml
+++ b/.github/workflows/run_ock_demo.yml
@@ -19,7 +19,7 @@ jobs:
   run_riscv_m1_ock_demo:
     runs-on: ubuntu-22.04
     container:
-      image: 'ghcr.io/uxlfoundation/ock_ubuntu_22.04-x86-64@sha256:11930b4367fb364589419475a36406b94e835b1b4431af301d23c7dfa94b4539'
+      image: 'ghcr.io/uxlfoundation/ock_ubuntu_22.04-x86-64:latest'
       volumes:
         - ${{github.workspace}}:${{github.workspace}}
 

--- a/.github/workflows/run_ock_external_tests.yml
+++ b/.github/workflows/run_ock_external_tests.yml
@@ -152,9 +152,9 @@ jobs:
     # build llvm. Otherwise we choose ubuntu-22.04 (use a container for both for consistency).
     runs-on: ${{ contains(matrix.target, 'host_aarch64') && 'ubuntu-22.04-arm' || (contains(matrix.target, 'host_riscv64') && 'ubuntu-24.04' || 'ubuntu-22.04') }}
     container:
-      image: ${{  contains(matrix.target, 'host_riscv')   && 'ghcr.io/uxlfoundation/ock_ubuntu_24.04-x86-64@sha256:8f027f97c3c84b60041a294bfb2363ac81971ef8e81f884fbab40d079587ad22'
+      image: ${{  contains(matrix.target, 'host_riscv')   && 'ghcr.io/uxlfoundation/ock_ubuntu_24.04-x86-64:latest'
              || ( contains(matrix.target, 'host_aarch64') && 'ghcr.io/uxlfoundation/ock_ubuntu_22.04-aarch64:latest'
-             ||                                              'ghcr.io/uxlfoundation/ock_ubuntu_22.04-x86-64@sha256:11930b4367fb364589419475a36406b94e835b1b4431af301d23c7dfa94b4539' ) }}
+             ||                                              'ghcr.io/uxlfoundation/ock_ubuntu_22.04-x86-64:latest' ) }}
       volumes:
         - ${{github.workspace}}:${{github.workspace}}
     if: inputs.ock && contains(inputs.target_list, 'linux')
@@ -184,9 +184,9 @@ jobs:
 
     runs-on: ${{ contains(matrix.target, 'host_aarch64') && 'ubuntu-22.04-arm' || (contains(matrix.target, 'host_riscv64') && 'ubuntu-24.04' || 'ubuntu-22.04') }}
     container:
-      image: ${{  contains(matrix.target, 'host_riscv')   && 'ghcr.io/uxlfoundation/ock_ubuntu_24.04-x86-64@sha256:8f027f97c3c84b60041a294bfb2363ac81971ef8e81f884fbab40d079587ad22'
+      image: ${{  contains(matrix.target, 'host_riscv')   && 'ghcr.io/uxlfoundation/ock_ubuntu_24.04-x86-64:latest'
              || ( contains(matrix.target, 'host_aarch64') && 'ghcr.io/uxlfoundation/ock_ubuntu_22.04-aarch64:latest'
-             ||                                              'ghcr.io/uxlfoundation/ock_ubuntu_22.04-x86-64@sha256:11930b4367fb364589419475a36406b94e835b1b4431af301d23c7dfa94b4539' ) }}
+             ||                                              'ghcr.io/uxlfoundation/ock_ubuntu_22.04-x86-64:latest' ) }}
       volumes:
         - ${{github.workspace}}:${{github.workspace}}
     steps:
@@ -241,9 +241,9 @@ jobs:
 
     runs-on: ${{ contains(matrix.target, 'host_aarch64') && 'ubuntu-22.04-arm' || (contains(matrix.target, 'host_riscv64') && 'cp-ubuntu-24.04' || 'ubuntu-22.04') }}
     container:
-      image: ${{  contains(matrix.target, 'host_riscv')   && 'ghcr.io/uxlfoundation/ock_ubuntu_24.04-x86-64@sha256:8f027f97c3c84b60041a294bfb2363ac81971ef8e81f884fbab40d079587ad22'
+      image: ${{  contains(matrix.target, 'host_riscv')   && 'ghcr.io/uxlfoundation/ock_ubuntu_24.04-x86-64:latest'
              || ( contains(matrix.target, 'host_aarch64') && 'ghcr.io/uxlfoundation/ock_ubuntu_22.04-aarch64:latest'
-             ||                                              'ghcr.io/uxlfoundation/ock_ubuntu_22.04-x86-64@sha256:11930b4367fb364589419475a36406b94e835b1b4431af301d23c7dfa94b4539' ) }}
+             ||                                              'ghcr.io/uxlfoundation/ock_ubuntu_22.04-x86-64:latest' ) }}
       volumes:
         - ${{github.workspace}}:${{github.workspace}}
     steps:
@@ -273,7 +273,7 @@ jobs:
     needs: [workflow_vars]
     runs-on: 'ubuntu-22.04'
     container:
-      image: 'ghcr.io/uxlfoundation/ock_ubuntu_22.04-x86-64@sha256:11930b4367fb364589419475a36406b94e835b1b4431af301d23c7dfa94b4539'
+      image: 'ghcr.io/uxlfoundation/ock_ubuntu_22.04-x86-64:latest'
       volumes:
         - ${{github.workspace}}:${{github.workspace}}
 
@@ -325,7 +325,7 @@ jobs:
 
     runs-on: ubuntu-24.04
     container:
-      image: 'ghcr.io/uxlfoundation/ock_ubuntu_24.04-x86-64@sha256:8f027f97c3c84b60041a294bfb2363ac81971ef8e81f884fbab40d079587ad22'
+      image: 'ghcr.io/uxlfoundation/ock_ubuntu_24.04-x86-64:latest'
       volumes:
         - ${{github.workspace}}:${{github.workspace}}
 
@@ -352,7 +352,7 @@ jobs:
         subset: [ 'A', 'B', 'C' ]
     runs-on: 'ubuntu-24.04'
     container:
-      image: 'ghcr.io/uxlfoundation/ock_ubuntu_22.04-x86-64@sha256:11930b4367fb364589419475a36406b94e835b1b4431af301d23c7dfa94b4539'
+      image: 'ghcr.io/uxlfoundation/ock_ubuntu_22.04-x86-64:latest'
       volumes:
         - ${{github.workspace}}:${{github.workspace}}
 
@@ -397,7 +397,7 @@ jobs:
         subset: [ 'A', 'B', 'C' ]
     runs-on: 'ubuntu-24.04'
     container:
-      image: 'ghcr.io/uxlfoundation/ock_ubuntu_22.04-x86-64@sha256:11930b4367fb364589419475a36406b94e835b1b4431af301d23c7dfa94b4539'
+      image: 'ghcr.io/uxlfoundation/ock_ubuntu_22.04-x86-64:latest'
       volumes:
         - ${{github.workspace}}:${{github.workspace}}
 
@@ -532,7 +532,7 @@ jobs:
         subset: [ 'A', 'B', 'C' ]
     runs-on: 'ubuntu-24.04'
     container:
-      image: 'ghcr.io/uxlfoundation/ock_ubuntu_24.04-x86-64@sha256:8f027f97c3c84b60041a294bfb2363ac81971ef8e81f884fbab40d079587ad22'
+      image: 'ghcr.io/uxlfoundation/ock_ubuntu_24.04-x86-64:latest'
       volumes:
         - ${{github.workspace}}:${{github.workspace}}
 
@@ -577,7 +577,7 @@ jobs:
         subset: [ 'A', 'B', 'C' ]
     runs-on: 'ubuntu-24.04'
     container:
-      image: 'ghcr.io/uxlfoundation/ock_ubuntu_24.04-x86-64@sha256:8f027f97c3c84b60041a294bfb2363ac81971ef8e81f884fbab40d079587ad22'
+      image: 'ghcr.io/uxlfoundation/ock_ubuntu_24.04-x86-64:latest'
       volumes:
         - ${{github.workspace}}:${{github.workspace}}
 
@@ -618,7 +618,7 @@ jobs:
     needs: [workflow_vars, create_ock_artefacts_ubuntu, build_dpcpp_native_x86_64, build_sycl_cts_x86_64_opencl_combine]
     runs-on: 'ubuntu-22.04'
     container:
-      image: 'ghcr.io/uxlfoundation/ock_ubuntu_22.04-x86-64@sha256:11930b4367fb364589419475a36406b94e835b1b4431af301d23c7dfa94b4539'
+      image: 'ghcr.io/uxlfoundation/ock_ubuntu_22.04-x86-64:latest'
       volumes:
         - ${{github.workspace}}:${{github.workspace}}
 
@@ -637,7 +637,7 @@ jobs:
     needs: [workflow_vars, build_dpcpp_native_x86_64, build_sycl_cts_x86_64_native_cpu_combine]
     runs-on: 'ubuntu-22.04'
     container:
-      image: 'ghcr.io/uxlfoundation/ock_ubuntu_22.04-x86-64@sha256:11930b4367fb364589419475a36406b94e835b1b4431af301d23c7dfa94b4539'
+      image: 'ghcr.io/uxlfoundation/ock_ubuntu_22.04-x86-64:latest'
       volumes:
         - ${{github.workspace}}:${{github.workspace}}
 
@@ -694,7 +694,7 @@ jobs:
     needs: [workflow_vars, create_ock_artefacts_ubuntu, build_dpcpp_native_x86_64, build_dpcpp_riscv64, build_sycl_cts_riscv64_opencl_combine]
     runs-on: 'cp-ubuntu-24.04' # note: the job will time-out (>6 hrs) if default github runners are used
     container:
-      image: 'ghcr.io/uxlfoundation/ock_ubuntu_24.04-x86-64@sha256:8f027f97c3c84b60041a294bfb2363ac81971ef8e81f884fbab40d079587ad22'
+      image: 'ghcr.io/uxlfoundation/ock_ubuntu_24.04-x86-64:latest'
       volumes:
         - ${{github.workspace}}:${{github.workspace}}
 
@@ -713,7 +713,7 @@ jobs:
     needs: [workflow_vars, build_dpcpp_native_x86_64, build_dpcpp_riscv64, build_sycl_cts_riscv64_native_cpu_combine]
     runs-on: 'ubuntu-24.04'
     container:
-      image: 'ghcr.io/uxlfoundation/ock_ubuntu_24.04-x86-64@sha256:8f027f97c3c84b60041a294bfb2363ac81971ef8e81f884fbab40d079587ad22'
+      image: 'ghcr.io/uxlfoundation/ock_ubuntu_24.04-x86-64:latest'
       volumes:
         - ${{github.workspace}}:${{github.workspace}}
 
@@ -732,7 +732,7 @@ jobs:
     needs: [workflow_vars, build_dpcpp_native_x86_64]
     runs-on: 'ubuntu-22.04'
     container:
-      image: 'ghcr.io/uxlfoundation/ock_ubuntu_22.04-x86-64@sha256:11930b4367fb364589419475a36406b94e835b1b4431af301d23c7dfa94b4539'
+      image: 'ghcr.io/uxlfoundation/ock_ubuntu_22.04-x86-64:latest'
       volumes:
         - ${{github.workspace}}:${{github.workspace}}
 
@@ -750,7 +750,7 @@ jobs:
     needs: [workflow_vars, build_dpcpp_native_x86_64]
     runs-on: 'ubuntu-22.04'
     container:
-      image: 'ghcr.io/uxlfoundation/ock_ubuntu_22.04-x86-64@sha256:11930b4367fb364589419475a36406b94e835b1b4431af301d23c7dfa94b4539'
+      image: 'ghcr.io/uxlfoundation/ock_ubuntu_22.04-x86-64:latest'
       volumes:
         - ${{github.workspace}}:${{github.workspace}}
 

--- a/.github/workflows/run_ock_internal_tests.yml
+++ b/.github/workflows/run_ock_internal_tests.yml
@@ -65,7 +65,7 @@ jobs:
     if: contains(inputs.target_list, 'host_x86_64_linux')
     runs-on: ubuntu-22.04
     container:
-      image: ghcr.io/uxlfoundation/ock_ubuntu_22.04-x86-64@sha256:11930b4367fb364589419475a36406b94e835b1b4431af301d23c7dfa94b4539
+      image: ghcr.io/uxlfoundation/ock_ubuntu_22.04-x86-64:latest
       volumes:
         - ${{github.workspace}}:${{github.workspace}}
     steps:
@@ -100,7 +100,7 @@ jobs:
     if: contains(inputs.target_list, 'host_x86_64_linux')
     runs-on: ubuntu-22.04
     container:
-      image: ghcr.io/uxlfoundation/ock_ubuntu_22.04-x86-64@sha256:11930b4367fb364589419475a36406b94e835b1b4431af301d23c7dfa94b4539
+      image: ghcr.io/uxlfoundation/ock_ubuntu_22.04-x86-64:latest
       volumes:
         - ${{github.workspace}}:${{github.workspace}}
     steps:
@@ -114,6 +114,13 @@ jobs:
           llvm_version: ${{ inputs.llvm_current }}
           llvm_source: ${{ inputs.llvm_source}}
           github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      # Install requirements
+      - name: Install clang-tidy and parallel
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes clang-tidy-19 parallel
+
       - name: build initial config files
         uses: ./.github/actions/do_build_ock
         with:
@@ -193,7 +200,7 @@ jobs:
     if: contains(inputs.target_list, 'host_refsi_linux')
     runs-on: ubuntu-22.04
     container:
-      image: ghcr.io/uxlfoundation/ock_ubuntu_22.04-x86-64@sha256:11930b4367fb364589419475a36406b94e835b1b4431af301d23c7dfa94b4539
+      image: ghcr.io/uxlfoundation/ock_ubuntu_22.04-x86-64:latest
       volumes:
         - ${{github.workspace}}:${{github.workspace}}
     timeout-minutes: 60
@@ -215,7 +222,7 @@ jobs:
     if: ${{ !inputs.is_pull_request && contains(inputs.target_list, 'host_i686_linux') }}
     runs-on: ubuntu-22.04
     container:
-      image: ghcr.io/uxlfoundation/ock_ubuntu_22.04-x86-64@sha256:11930b4367fb364589419475a36406b94e835b1b4431af301d23c7dfa94b4539
+      image: ghcr.io/uxlfoundation/ock_ubuntu_22.04-x86-64:latest
       volumes:
         - ${{github.workspace}}:${{github.workspace}}
     timeout-minutes: 90 # offline needs longer timeout
@@ -237,7 +244,7 @@ jobs:
     if: contains(inputs.target_list, 'host_refsi_linux')
     runs-on: ubuntu-22.04
     container:
-      image: ghcr.io/uxlfoundation/ock_ubuntu_22.04-x86-64@sha256:11930b4367fb364589419475a36406b94e835b1b4431af301d23c7dfa94b4539
+      image: ghcr.io/uxlfoundation/ock_ubuntu_22.04-x86-64:latest
       volumes:
         - ${{github.workspace}}:${{github.workspace}}
     timeout-minutes: 60
@@ -258,7 +265,7 @@ jobs:
     if: contains(inputs.target_list, 'host_riscv64_linux')
     runs-on: ubuntu-22.04
     container:
-      image: ghcr.io/uxlfoundation/ock_ubuntu_22.04-x86-64@sha256:11930b4367fb364589419475a36406b94e835b1b4431af301d23c7dfa94b4539
+      image: ghcr.io/uxlfoundation/ock_ubuntu_22.04-x86-64:latest
       volumes:
         - ${{github.workspace}}:${{github.workspace}}
     timeout-minutes: 60
@@ -280,7 +287,7 @@ jobs:
     if: contains(inputs.target_list, 'host_riscv64_linux')
     runs-on: ubuntu-22.04
     container:
-      image: ghcr.io/uxlfoundation/ock_ubuntu_22.04-x86-64@sha256:11930b4367fb364589419475a36406b94e835b1b4431af301d23c7dfa94b4539
+      image: ghcr.io/uxlfoundation/ock_ubuntu_22.04-x86-64:latest
       volumes:
         - ${{github.workspace}}:${{github.workspace}}
     timeout-minutes: 60
@@ -305,7 +312,7 @@ jobs:
     if: contains(inputs.target_list, 'host_i686_linux')
     runs-on: ubuntu-22.04
     container:
-      image: ghcr.io/uxlfoundation/ock_ubuntu_22.04-x86-64@sha256:11930b4367fb364589419475a36406b94e835b1b4431af301d23c7dfa94b4539
+      image: ghcr.io/uxlfoundation/ock_ubuntu_22.04-x86-64:latest
       volumes:
         - ${{github.workspace}}:${{github.workspace}}
     timeout-minutes: 60
@@ -348,7 +355,7 @@ jobs:
     if: contains(inputs.target_list, 'host_refsi_linux')
     runs-on: ubuntu-22.04
     container:
-      image: ghcr.io/uxlfoundation/ock_ubuntu_22.04-x86-64@sha256:11930b4367fb364589419475a36406b94e835b1b4431af301d23c7dfa94b4539
+      image: ghcr.io/uxlfoundation/ock_ubuntu_22.04-x86-64:latest
       volumes:
         - ${{github.workspace}}:${{github.workspace}}
     timeout-minutes: 60
@@ -373,7 +380,7 @@ jobs:
     if: ${{ !inputs.is_pull_request && contains(inputs.target_list, 'host_refsi_linux') }}
     runs-on: ubuntu-22.04
     container:
-      image: ghcr.io/uxlfoundation/ock_ubuntu_22.04-x86-64@sha256:11930b4367fb364589419475a36406b94e835b1b4431af301d23c7dfa94b4539
+      image: ghcr.io/uxlfoundation/ock_ubuntu_22.04-x86-64:latest
       volumes:
         - ${{github.workspace}}:${{github.workspace}}
     timeout-minutes: 60
@@ -399,7 +406,7 @@ jobs:
     if: contains(inputs.target_list, 'host_refsi_linux')
     runs-on: ubuntu-22.04
     container:
-      image: ghcr.io/uxlfoundation/ock_ubuntu_22.04-x86-64@sha256:11930b4367fb364589419475a36406b94e835b1b4431af301d23c7dfa94b4539
+      image: ghcr.io/uxlfoundation/ock_ubuntu_22.04-x86-64:latest
       volumes:
         - ${{github.workspace}}:${{github.workspace}}
     timeout-minutes: 60
@@ -420,7 +427,7 @@ jobs:
     if: contains(inputs.target_list, 'host_refsi_linux')
     runs-on: ubuntu-22.04
     container:
-      image: ghcr.io/uxlfoundation/ock_ubuntu_22.04-x86-64@sha256:11930b4367fb364589419475a36406b94e835b1b4431af301d23c7dfa94b4539
+      image: ghcr.io/uxlfoundation/ock_ubuntu_22.04-x86-64:latest
       volumes:
         - ${{github.workspace}}:${{github.workspace}}
     timeout-minutes: 60


### PR DESCRIPTION


# Overview

Some additional installs are added to take into account the smaller docker

# Reason for change

The docker is being shrunk slightly - see
https://github.com/uxlfoundation/oneapi-construction-kit/pull/852. 
