### PR TITLE
Define BENCHMARK_STATIC_DEFINE.

### DIFF
--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -94,7 +94,9 @@ if(NOT (CMAKE_CROSSCOMPILING AND CA_PLATFORM_WINDOWS AND
     CXX_STANDARD 17 CXX_STANDARD_REQUIRED ON CXX_EXTENSIONS OFF)
   target_include_directories(ca-benchmark SYSTEM
     PUBLIC benchmark/include PRIVATE benchmark/src)
-  target_compile_definitions(ca-benchmark PRIVATE HAVE_STD_REGEX)
+  target_compile_definitions(ca-benchmark
+    PRIVATE HAVE_STD_REGEX
+    PUBLIC BENCHMARK_STATIC_DEFINE)
   target_compile_options(ca-benchmark PRIVATE
     $<$<PLATFORM_ID:Linux>:-fstrict-aliasing>
     $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:GNU>,$<CXX_COMPILER_ID:QCC>>:


### PR DESCRIPTION
# Overview

Define BENCHMARK_STATIC_DEFINE.

# Reason for change

For Windows builds, BENCHMARK_STATIC_DEFINE needs to be defined to tell Google Benchmark not to apply DLL attributes.

# Description of change

*Describe the intended behaviour your changes are meant to introduce to the
project and explain how they resolve the problem stated above. Detail any
relevant changes that may affect other users of the project, such as
compilation options, runtime flags, expected inputs and outputs, API entry
points, etc.*

*If you have added new testing, provide details on what tests you have added
and what the purpose of them is.*

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-19](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
