### PR TITLE
Add overrides for e2e fails Graph,ThreadSanitizer and FreeFunctionKernels

### DIFF
--- a/scripts/testing/sycl_e2e/override_all.csv
+++ b/scripts/testing/sycl_e2e/override_all.csv
@@ -12,6 +12,8 @@ SYCL,ThreadSanitizer/check_unaligned_access.cpp,XFail
 SYCL,ThreadSanitizer/check_host_usm.cpp,XFail
 SYCL,ThreadSanitizer/check_device_usm.cpp,XFail
 SYCL,ThreadSanitizer/check_shared_usm.cpp,XFail
+SYCL,ThreadSanitizer/local_accessor.cpp,XFail
+SYCL,ThreadSanitizer/group_local_memory.cpp,XFail
 SYCL,Assert/assert_in_multiple_tus.cpp,XFail
 SYCL,Assert/assert_in_simultaneous_kernels.cpp,XFail
 SYCL,Assert/check_resource_leak.cpp,XFail

--- a/scripts/testing/sycl_e2e/override_native_cpu.csv
+++ b/scripts/testing/sycl_e2e/override_native_cpu.csv
@@ -81,6 +81,7 @@ SYCL,KernelAndProgram/spec_constants_after_link.cpp,XFail
 SYCL,KernelAndProgram/fp32-precise-fdiv.cpp,XFail
 SYCL,KernelAndProgram/multiple-kernel-linking.cpp,XFail
 SYCL,KernelAndProgram/kernel-bundle-get-kernel.cpp,XFail
+SYCL,FreeFunctionKernels/accessor_as_kernel_parameter.cpp,XFail
 SYCL,FreeFunctionKernels/range_as_kernel_parameter.cpp,XFail
 SYCL,FreeFunctionKernels/id_as_kernel_parameter.cpp,XFail
 SYCL,FreeFunctionKernels/vec_as_kernel_parameter.cpp,XFail

--- a/scripts/testing/sycl_e2e/override_opencl.csv
+++ b/scripts/testing/sycl_e2e/override_opencl.csv
@@ -56,6 +56,7 @@ SYCL,Graph/Explicit/node_ordering.cpp,XFail
 SYCL,Graph/Explicit/sub_graph.cpp,XFail
 SYCL,Graph/Explicit/local_accessor_multiple_accessors.cpp,XFail
 SYCL,Graph/Explicit/work_group_memory.cpp,XFail
+SYCL,Graph/Explicit/buffer_interleave_eager.cpp,XFail
 SYCL,Graph/Explicit/buffer_ordering.cpp,XFail
 SYCL,Graph/Explicit/spec_constants_kernel_bundle_api.cpp,XFail
 SYCL,Graph/Explicit/sub_graph_two_parent_graphs.cpp,XFail
@@ -68,6 +69,7 @@ SYCL,Graph/Explicit/usm_fill_host.cpp,XFail
 SYCL,Graph/Explicit/usm_fill.cpp,XFail
 SYCL,Graph/Explicit/usm_copy.cpp,XFail
 SYCL,Graph/Explicit/usm_fill_shared.cpp,XFail
+SYCL,Graph/RecordReplay/buffer_interleave_eager.cpp,XFail
 SYCL,Graph/RecordReplay/free_function_kernels.cpp,XFail
 SYCL,Graph/RecordReplay/buffer_fill_2d.cpp,XFail
 SYCL,Graph/RecordReplay/sub_graph_execute_without_parent.cpp,XFail


### PR DESCRIPTION
# Overview

Add overrides for e2e fails Graph,ThreadSanitizer and FreeFunctionKernels
