### PR TITLE
Migrate remote_hal to Github CI

### DIFF
--- a/.github/actions/do_build_run_remote_hal/action.yml
+++ b/.github/actions/do_build_run_remote_hal/action.yml
@@ -15,11 +15,24 @@ runs:
     - name : build client
       shell: bash
       run: |
-        ls -l
         echo build_client
         cmake -Bbuild_client -GNinja -DCA_MUX_TARGETS_TO_ENABLE="riscv" -DCA_RISCV_ENABLED=ON -DCA_LLVM_INSTALL_DIR=$GITHUB_WORKSPACE/llvm_install -DCA_CL_ENABLE_ICD_LOADER=ON -DCA_HAL_NAME=cpu_client
         ninja -Cbuild_client UnitCL
     - name : run remote_hal
       shell: bash
       run: |
+        ls -l
         echo run remote_hal
+        cd build_server
+        export HAL_REMOTE_PORT=9999
+        # Limit number of threads to 1 due to hal cpu use of temporary threads causing excessive qemu memory usage.
+        export CA_CPU_HAL_NUM_THREADS=1
+        /usr/bin/qemu-riscv64 -L /usr/riscv64-linux-gnu ./hal_cpu_server_bin $HAL_REMOTE_PORT &
+        # This gives enough time for the server to start. We should consider whether a better
+        # design could avoid this - see OR-380
+        sleep 1
+        cd $GITHUB_WORKSPACE/build_client
+        exitcode=0
+        OCL_ICD_FILENAMES=$PWD/lib/libCL.so.4.0 ./bin/UnitCL || exitcode=$?
+        kill %1
+        exit $exitcode

--- a/.github/actions/do_build_run_remote_hal/action.yml
+++ b/.github/actions/do_build_run_remote_hal/action.yml
@@ -1,0 +1,22 @@
+name: build run remote_hal
+description: build run remote_hal
+
+runs:
+  # We don't want a new docker just a list of steps, so mark as composite
+  using: "composite"
+  steps:
+    - name : build server
+      run: |
+        echo build_server
+        mkdir build_server
+        cmake -GNinja $GITHUB_WORKSPACE/examples/hal_cpu_remote_server -Bbuild_server -DCMAKE_TOOLCHAIN_FILE=$GITHUB_WORKSPACE/platform/riscv64-linux/riscv64-gcc-toolchain.cmake
+        ninja -Cbuild_server
+    - name : build client
+      run: |
+        ls -l
+        echo build_client
+        cmake -Bbuild_client -GNinja -DCA_MUX_TARGETS_TO_ENABLE="riscv" -DCA_RISCV_ENABLED=ON -DCA_LLVM_INSTALL_DIR=$GITHUB_WORKSPACE/llvm_install -DCA_CL_ENABLE_ICD_LOADER=ON -DCA_HAL_NAME=cpu_client
+        ninja -Cbuild_client UnitCL
+    - name : run remote_hal
+      run: |
+        echo run remote_hal

--- a/.github/actions/do_build_run_remote_hal/action.yml
+++ b/.github/actions/do_build_run_remote_hal/action.yml
@@ -11,21 +11,21 @@ runs:
         mkdir build_server
         cmake -GNinja $GITHUB_WORKSPACE/examples/hal_cpu_remote_server -Bbuild_server -DCMAKE_TOOLCHAIN_FILE=$GITHUB_WORKSPACE/platform/riscv64-linux/riscv64-gcc-toolchain.cmake
         ninja -Cbuild_server
-    - name : build client
-      uses: ./.github/actions/do_build_ock
-      with:
-        build_dir: build_client
-        mux_targets_enable: riscv
-        riscv_enabled: ON
-        llvm_install_dir: $GITHUB_WORKSPACE/llvm_install
-        command_buffer: OFF
-        extra_flags: -DCA_HAL_NAME=cpu_client
-        build_targets: 'UnitCL'
     #- name : build client
-    #  shell: bash
-    #  run: |
-    #    cmake -Bbuild_client -GNinja -DCA_MUX_TARGETS_TO_ENABLE="riscv" -DCA_RISCV_ENABLED=ON -DCA_LLVM_INSTALL_DIR=$GITHUB_WORKSPACE/llvm_install -DCA_CL_ENABLE_ICD_LOADER=ON -DCA_HAL_NAME=cpu_client
-    #    ninja -Cbuild_client UnitCL
+    #  uses: ./.github/actions/do_build_ock
+    #  with:
+    #    build_dir: build_client
+    #    mux_targets_enable: riscv
+    #    riscv_enabled: ON
+    #    llvm_install_dir: $GITHUB_WORKSPACE/llvm_install
+    #    command_buffer: OFF
+    #    extra_flags: -DCA_HAL_NAME=cpu_client
+    #    build_targets: 'UnitCL'
+    - name : build client
+      shell: bash
+      run: |
+        cmake -Bbuild_client -GNinja -DCA_MUX_TARGETS_TO_ENABLE="riscv" -DCA_RISCV_ENABLED=ON -DCA_LLVM_INSTALL_DIR=$GITHUB_WORKSPACE/llvm_install -DCA_CL_ENABLE_ICD_LOADER=ON -DCA_HAL_NAME=cpu_client
+        ninja -Cbuild_client UnitCL
     - name : run remote_hal
       shell: bash
       run: |
@@ -35,8 +35,8 @@ runs:
         export CA_CPU_HAL_NUM_THREADS=1
         export START_STRING="Listening on port $HAL_REMOTE_PORT"
         export TRIES=10
-        # Allow time for the server to start. Check that its running.
         ( /usr/bin/qemu-riscv64 -L /usr/riscv64-linux-gnu ./hal_cpu_server_bin $HAL_REMOTE_PORT > /tmp/halop 2>&1 ) &
+        # Allow time for the server to start. Check that its running.
         while [ "$TRIES" -gt 0 ] && ! grep "$START_STRING" /tmp/halop ; do
           sleep 1
           TRIES=$(( TRIES - 1 ))

--- a/.github/actions/do_build_run_remote_hal/action.yml
+++ b/.github/actions/do_build_run_remote_hal/action.yml
@@ -23,11 +23,10 @@ runs:
         export HAL_REMOTE_PORT=9999
         # Limit number of threads to 1 due to hal cpu use of temporary threads causing excessive qemu memory usage.
         export CA_CPU_HAL_NUM_THREADS=1
-        # This gives enough time for the server to start. We should consider whether a better
-        # design could avoid this - see OR-380
+        # Allow time for the server to start. Check that its running.
         ( /usr/bin/qemu-riscv64 -L /usr/riscv64-linux-gnu ./hal_cpu_server_bin $HAL_REMOTE_PORT > /tmp/hal 2>&1 ) &
         tries=10
-        while [ "$tries" -gt 0 ] && ! grep "Listening on port $HAL_REMOTE_PORT" /tmp/hal ; do
+        while [ "$tries" -gt 0 ] && ! grep "Xistening on port $HAL_REMOTE_PORT" /tmp/hal ; do
           sleep 1
           tries=$(( tries - 1 ))
         done

--- a/.github/actions/do_build_run_remote_hal/action.yml
+++ b/.github/actions/do_build_run_remote_hal/action.yml
@@ -18,6 +18,7 @@ runs:
         mux_targets_enable: riscv
         riscv_enabled: ON
         llvm_install_dir: $GITHUB_WORKSPACE/llvm_install
+        command_buffer: OFF
         extra_flags: -DCA_HAL_NAME=cpu_client
         build_targets: 'UnitCL'
     #- name : build client

--- a/.github/actions/do_build_run_remote_hal/action.yml
+++ b/.github/actions/do_build_run_remote_hal/action.yml
@@ -12,10 +12,19 @@ runs:
         cmake -GNinja $GITHUB_WORKSPACE/examples/hal_cpu_remote_server -Bbuild_server -DCMAKE_TOOLCHAIN_FILE=$GITHUB_WORKSPACE/platform/riscv64-linux/riscv64-gcc-toolchain.cmake
         ninja -Cbuild_server
     - name : build client
-      shell: bash
-      run: |
-        cmake -Bbuild_client -GNinja -DCA_MUX_TARGETS_TO_ENABLE="riscv" -DCA_RISCV_ENABLED=ON -DCA_LLVM_INSTALL_DIR=$GITHUB_WORKSPACE/llvm_install -DCA_CL_ENABLE_ICD_LOADER=ON -DCA_HAL_NAME=cpu_client
-        ninja -Cbuild_client UnitCL
+      uses: ./.github/actions/do_build_ock
+      with:
+        build_dir: build_client
+        mux_targets_enable: riscv
+        riscv_enabled: ON
+        llvm_install_dir: $GITHUB_WORKSPACE/llvm_install
+        extra_flags: -DCA_HAL_NAME=cpu_client
+        build_targets: 'UnitCL'
+    #- name : build client
+    #  shell: bash
+    #  run: |
+    #    cmake -Bbuild_client -GNinja -DCA_MUX_TARGETS_TO_ENABLE="riscv" -DCA_RISCV_ENABLED=ON -DCA_LLVM_INSTALL_DIR=$GITHUB_WORKSPACE/llvm_install -DCA_CL_ENABLE_ICD_LOADER=ON -DCA_HAL_NAME=cpu_client
+    #    ninja -Cbuild_client UnitCL
     - name : run remote_hal
       shell: bash
       run: |
@@ -23,15 +32,16 @@ runs:
         export HAL_REMOTE_PORT=9999
         # Limit number of threads to 1 due to hal cpu use of temporary threads causing excessive qemu memory usage.
         export CA_CPU_HAL_NUM_THREADS=1
+        export START_STRING="Listening on port $HAL_REMOTE_PORT"
+        export TRIES=10
         # Allow time for the server to start. Check that its running.
-        ( /usr/bin/qemu-riscv64 -L /usr/riscv64-linux-gnu ./hal_cpu_server_bin $HAL_REMOTE_PORT > /tmp/hal 2>&1 ) &
-        tries=10
-        while [ "$tries" -gt 0 ] && ! grep "Xistening on port $HAL_REMOTE_PORT" /tmp/hal ; do
+        ( /usr/bin/qemu-riscv64 -L /usr/riscv64-linux-gnu ./hal_cpu_server_bin $HAL_REMOTE_PORT > /tmp/halop 2>&1 ) &
+        while [ "$TRIES" -gt 0 ] && ! grep "$START_STRING" /tmp/halop ; do
           sleep 1
-          tries=$(( tries - 1 ))
+          TRIES=$(( TRIES - 1 ))
         done
-        rm /tmp/hal
-        if [ "$tries" -ne 0 ]; then
+        rm /tmp/halop
+        if [ "$TRIES" -ne 0 ]; then
           jobs
           cd $GITHUB_WORKSPACE/build_client
           exitcode=0
@@ -39,6 +49,6 @@ runs:
           kill %1
           exit $exitcode
         else
-          echo "Server has failed to start"
+          echo "Fail: no server start string: $START_STRING"
           exit 1
         fi

--- a/.github/actions/do_build_run_remote_hal/action.yml
+++ b/.github/actions/do_build_run_remote_hal/action.yml
@@ -23,7 +23,6 @@ runs:
         export HAL_REMOTE_PORT=9999
         # Limit number of threads to 1 due to hal cpu use of temporary threads causing excessive qemu memory usage.
         export CA_CPU_HAL_NUM_THREADS=1
-        /usr/bin/qemu-riscv64 -L /usr/riscv64-linux-gnu ./hal_cpu_server_bin $HAL_REMOTE_PORT &
         # This gives enough time for the server to start. We should consider whether a better
         # design could avoid this - see OR-380
         ( /usr/bin/qemu-riscv64 -L /usr/riscv64-linux-gnu ./hal_cpu_server_bin $HAL_REMOTE_PORT > /tmp/hal 2>&1 ) &

--- a/.github/actions/do_build_run_remote_hal/action.yml
+++ b/.github/actions/do_build_run_remote_hal/action.yml
@@ -6,17 +6,20 @@ runs:
   using: "composite"
   steps:
     - name : build server
+      shell: bash
       run: |
         echo build_server
         mkdir build_server
         cmake -GNinja $GITHUB_WORKSPACE/examples/hal_cpu_remote_server -Bbuild_server -DCMAKE_TOOLCHAIN_FILE=$GITHUB_WORKSPACE/platform/riscv64-linux/riscv64-gcc-toolchain.cmake
         ninja -Cbuild_server
     - name : build client
+      shell: bash
       run: |
         ls -l
         echo build_client
         cmake -Bbuild_client -GNinja -DCA_MUX_TARGETS_TO_ENABLE="riscv" -DCA_RISCV_ENABLED=ON -DCA_LLVM_INSTALL_DIR=$GITHUB_WORKSPACE/llvm_install -DCA_CL_ENABLE_ICD_LOADER=ON -DCA_HAL_NAME=cpu_client
         ninja -Cbuild_client UnitCL
     - name : run remote_hal
+      shell: bash
       run: |
         echo run remote_hal

--- a/.github/actions/do_build_run_remote_hal/action.yml
+++ b/.github/actions/do_build_run_remote_hal/action.yml
@@ -11,16 +11,6 @@ runs:
         mkdir build_server
         cmake -GNinja $GITHUB_WORKSPACE/examples/hal_cpu_remote_server -Bbuild_server -DCMAKE_TOOLCHAIN_FILE=$GITHUB_WORKSPACE/platform/riscv64-linux/riscv64-gcc-toolchain.cmake
         ninja -Cbuild_server
-    #- name : build client
-    #  uses: ./.github/actions/do_build_ock
-    #  with:
-    #    build_dir: build_client
-    #    mux_targets_enable: riscv
-    #    riscv_enabled: ON
-    #    llvm_install_dir: $GITHUB_WORKSPACE/llvm_install
-    #    command_buffer: OFF
-    #    extra_flags: -DCA_HAL_NAME=cpu_client
-    #    build_targets: 'UnitCL'
     - name : build client
       shell: bash
       run: |
@@ -29,27 +19,29 @@ runs:
     - name : run remote_hal
       shell: bash
       run: |
-        cd build_server
         export HAL_REMOTE_PORT=9999
         # Limit number of threads to 1 due to hal cpu use of temporary threads causing excessive qemu memory usage.
         export CA_CPU_HAL_NUM_THREADS=1
         export START_STRING="Listening on port $HAL_REMOTE_PORT"
         export TRIES=10
-        ( /usr/bin/qemu-riscv64 -L /usr/riscv64-linux-gnu ./hal_cpu_server_bin $HAL_REMOTE_PORT > /tmp/halop 2>&1 ) &
-        # Allow time for the server to start. Check that its running.
-        while [ "$TRIES" -gt 0 ] && ! grep "$START_STRING" /tmp/halop ; do
+        # Start server
+        cd build_server
+        ( /usr/bin/qemu-riscv64 -L /usr/riscv64-linux-gnu ./hal_cpu_server_bin $HAL_REMOTE_PORT > /tmp/hal.op 2>&1 ) &
+        # Check that server is running.
+        while [ "$TRIES" -gt 0 ] && ! grep "$START_STRING" /tmp/hal.op ; do
           sleep 1
           TRIES=$(( TRIES - 1 ))
         done
-        rm /tmp/halop
+        rm /tmp/hal.op
         if [ "$TRIES" -ne 0 ]; then
           jobs
+          # Run client
           cd $GITHUB_WORKSPACE/build_client
           exitcode=0
           OCL_ICD_FILENAMES=$PWD/lib/libCL.so.4.0 ./bin/UnitCL || exitcode=$?
           kill %1
           exit $exitcode
         else
-          echo "Fail: no server start string: $START_STRING"
+          echo "FAIL: server start check - no listener start string found"
           exit 1
         fi

--- a/.github/actions/do_build_run_remote_hal/action.yml
+++ b/.github/actions/do_build_run_remote_hal/action.yml
@@ -8,21 +8,17 @@ runs:
     - name : build server
       shell: bash
       run: |
-        echo build_server
         mkdir build_server
         cmake -GNinja $GITHUB_WORKSPACE/examples/hal_cpu_remote_server -Bbuild_server -DCMAKE_TOOLCHAIN_FILE=$GITHUB_WORKSPACE/platform/riscv64-linux/riscv64-gcc-toolchain.cmake
         ninja -Cbuild_server
     - name : build client
       shell: bash
       run: |
-        echo build_client
         cmake -Bbuild_client -GNinja -DCA_MUX_TARGETS_TO_ENABLE="riscv" -DCA_RISCV_ENABLED=ON -DCA_LLVM_INSTALL_DIR=$GITHUB_WORKSPACE/llvm_install -DCA_CL_ENABLE_ICD_LOADER=ON -DCA_HAL_NAME=cpu_client
         ninja -Cbuild_client UnitCL
     - name : run remote_hal
       shell: bash
       run: |
-        ls -l
-        echo run remote_hal
         cd build_server
         export HAL_REMOTE_PORT=9999
         # Limit number of threads to 1 due to hal cpu use of temporary threads causing excessive qemu memory usage.
@@ -30,9 +26,21 @@ runs:
         /usr/bin/qemu-riscv64 -L /usr/riscv64-linux-gnu ./hal_cpu_server_bin $HAL_REMOTE_PORT &
         # This gives enough time for the server to start. We should consider whether a better
         # design could avoid this - see OR-380
-        sleep 1
-        cd $GITHUB_WORKSPACE/build_client
-        exitcode=0
-        OCL_ICD_FILENAMES=$PWD/lib/libCL.so.4.0 ./bin/UnitCL || exitcode=$?
-        kill %1
-        exit $exitcode
+        ( /usr/bin/qemu-riscv64 -L /usr/riscv64-linux-gnu ./hal_cpu_server_bin $HAL_REMOTE_PORT > /tmp/hal 2>&1 ) &
+        tries=10
+        while [ "$tries" -gt 0 ] && ! grep "Listening on port $HAL_REMOTE_PORT" /tmp/hal ; do
+          sleep 1
+          tries=$(( tries - 1 ))
+        done
+        rm /tmp/hal
+        if [ "$tries" -ne 0 ]; then
+          jobs
+          cd $GITHUB_WORKSPACE/build_client
+          exitcode=0
+          OCL_ICD_FILENAMES=$PWD/lib/libCL.so.4.0 ./bin/UnitCL || exitcode=$?
+          kill %1
+          exit $exitcode
+        else
+          echo "Server has failed to start"
+          exit 1
+        fi

--- a/.github/workflows/planned_testing_caller.yml
+++ b/.github/workflows/planned_testing_caller.yml
@@ -17,6 +17,10 @@ on:
         type: boolean
         description: 'Enable testing tornado'
         default: true
+      test_remote_hal:
+        type: boolean
+        description: 'Enable testing remote_hal'
+        default: true
       test_sycl_cts:
         type: boolean
         description: 'Enable testing sycl-cts'
@@ -91,6 +95,7 @@ jobs:
       target_list: ${{ inputs.target_list }}
       ock: ${{ inputs.ock }}
       test_tornado: ${{ inputs.test_tornado }}
+      test_remote_hal: ${{ inputs.test_remote_hal }}
       test_sycl_cts: ${{ inputs.test_sycl_cts }}
       test_sycl_e2e: ${{ inputs.test_sycl_e2e }}
       test_opencl_cts: ${{ inputs.test_opencl_cts }}

--- a/.github/workflows/planned_testing_caller_19.yml
+++ b/.github/workflows/planned_testing_caller_19.yml
@@ -24,16 +24,17 @@ jobs:
       use_llvm_github_cache: true
       # We can set ock, test_sycl_cts etc here optionally if this is used as a pull request.
       # Any with parameters below this is intended for local testing and should not be merged.
-      # target_list: '[ "host_x86_64_linux" ]'
+      target_list: '[ "host_x86_64_linux" ]'
       # ock: true
-      # native_cpu: true
-      # test_tornado: true
-      # test_sycl_cts: true
-      # test_sycl_e2e: true
-      # test_opencl_cts: true
-      # run_internal: true
+      native_cpu: false
+      test_tornado: false
+      test_remote_hal: true
+      test_sycl_cts: false
+      test_sycl_e2e: false
+      test_opencl_cts: false
+      run_internal: false
       # run_external: true
-      # build_llvm: true
+      build_llvm: false
 
       # # These can be set to a workflow run-id to download from a previous workflow. This can be seen from
       # # the action run of a job or workflow

--- a/.github/workflows/planned_testing_caller_19.yml
+++ b/.github/workflows/planned_testing_caller_19.yml
@@ -25,7 +25,7 @@ jobs:
       # We can set ock, test_sycl_cts etc here optionally if this is used as a pull request.
       # Any with parameters below this is intended for local testing and should not be merged.
       target_list: '[ "host_x86_64_linux" ]'
-      ock: false
+      # ock: true
       native_cpu: false
       test_tornado: false
       test_remote_hal: true
@@ -34,7 +34,7 @@ jobs:
       test_opencl_cts: false
       run_internal: false
       # run_external: true
-      build_llvm: false
+      # build_llvm: true
 
       # # These can be set to a workflow run-id to download from a previous workflow. This can be seen from
       # # the action run of a job or workflow

--- a/.github/workflows/planned_testing_caller_19.yml
+++ b/.github/workflows/planned_testing_caller_19.yml
@@ -24,15 +24,15 @@ jobs:
       use_llvm_github_cache: true
       # We can set ock, test_sycl_cts etc here optionally if this is used as a pull request.
       # Any with parameters below this is intended for local testing and should not be merged.
-      target_list: '[ "host_x86_64_linux" ]'
+      # target_list: '[ "host_x86_64_linux" ]'
       # ock: true
-      native_cpu: false
-      test_tornado: false
-      test_remote_hal: true
-      test_sycl_cts: false
-      test_sycl_e2e: false
-      test_opencl_cts: false
-      run_internal: false
+      # native_cpu: true
+      # test_tornado: true
+      # test_remote_hal: true
+      # test_sycl_cts: true
+      # test_sycl_e2e: true
+      # test_opencl_cts: true
+      # run_internal: true
       # run_external: true
       # build_llvm: true
 

--- a/.github/workflows/planned_testing_caller_19.yml
+++ b/.github/workflows/planned_testing_caller_19.yml
@@ -25,7 +25,7 @@ jobs:
       # We can set ock, test_sycl_cts etc here optionally if this is used as a pull request.
       # Any with parameters below this is intended for local testing and should not be merged.
       target_list: '[ "host_x86_64_linux" ]'
-      # ock: true
+      ock: false
       native_cpu: false
       test_tornado: false
       test_remote_hal: true

--- a/.github/workflows/planned_testing_caller_19.yml
+++ b/.github/workflows/planned_testing_caller_19.yml
@@ -25,7 +25,7 @@ jobs:
       # We can set ock, test_sycl_cts etc here optionally if this is used as a pull request.
       # Any with parameters below this is intended for local testing and should not be merged.
       target_list: '[ "host_x86_64_linux" ]'
-      ock: false
+      # ock: true
       native_cpu: false
       test_tornado: false
       test_remote_hal: true

--- a/.github/workflows/run_ock_external_tests.yml
+++ b/.github/workflows/run_ock_external_tests.yml
@@ -226,15 +226,15 @@ jobs:
       - name : build server
         run: |
           echo build_server
-          ls -l
-          ls -l examples || echo NO EXAMPLES
-          ls -l llvm_install || echo NO LLVM_INSTALL
           mkdir build_server
           cmake -GNinja $GITHUB_WORKSPACE/examples/hal_cpu_remote_server -Bbuild_server -DCMAKE_TOOLCHAIN_FILE=$GITHUB_WORKSPACE/platform/riscv64-linux/riscv64-gcc-toolchain.cmake
           ninja -Cbuild_server
       - name : build client
         run: |
+          ls -l
           echo build_client
+          cmake -Bbuild_client -GNinja -DCA_MUX_TARGETS_TO_ENABLE="riscv" -DCA_RISCV_ENABLED=ON -DCA_LLVM_INSTALL_DIR=$GITHUB_WORKSPACE/llvm_install -DCA_CL_ENABLE_ICD_LOADER=ON -DCA_HAL_NAME=cpu_client
+          ninja -Cbuild_client UnitCL
       - name : run remote_hal
         run: |
           echo run remote_hal

--- a/.github/workflows/run_ock_external_tests.yml
+++ b/.github/workflows/run_ock_external_tests.yml
@@ -223,21 +223,8 @@ jobs:
           llvm_version: ${{ inputs.llvm_version }}
           llvm_source: ${{ inputs.llvm_source}}
           github_token: ${{ secrets.GITHUB_TOKEN }}
-      - name : build server
-        run: |
-          echo build_server
-          mkdir build_server
-          cmake -GNinja $GITHUB_WORKSPACE/examples/hal_cpu_remote_server -Bbuild_server -DCMAKE_TOOLCHAIN_FILE=$GITHUB_WORKSPACE/platform/riscv64-linux/riscv64-gcc-toolchain.cmake
-          ninja -Cbuild_server
-      - name : build client
-        run: |
-          ls -l
-          echo build_client
-          cmake -Bbuild_client -GNinja -DCA_MUX_TARGETS_TO_ENABLE="riscv" -DCA_RISCV_ENABLED=ON -DCA_LLVM_INSTALL_DIR=$GITHUB_WORKSPACE/llvm_install -DCA_CL_ENABLE_ICD_LOADER=ON -DCA_HAL_NAME=cpu_client
-          ninja -Cbuild_client UnitCL
-      - name : run remote_hal
-        run: |
-          echo run remote_hal
+      - name : build run remote_hal
+        uses: ./.github/actions/do_build_run_remote_hal
 
   # Currently only builds and runs on x86_64 linux
   build_run_tornado:

--- a/.github/workflows/run_ock_external_tests.yml
+++ b/.github/workflows/run_ock_external_tests.yml
@@ -18,6 +18,11 @@ on:
         type: boolean
         description: 'Enable testing tornado'
         default: true
+      test_remote_hal:
+        required: false
+        type: boolean
+        description: 'Enable testing remote_hal'
+        default: true
       test_sycl_cts:
         required: false
         type: boolean
@@ -201,7 +206,21 @@ jobs:
         with:
           target: ${{matrix.target}}
 
-  
+  build_run_remote_hal:
+    if: inputs.test_remote_hal
+    needs: [ workflow_vars ]
+    runs-on: 'ubuntu-24.04'
+    steps:
+      - name : build server
+        run: |
+          echo build_server
+      - name : build client
+        run: |
+          echo build_client
+      - name : run remote_hal
+        run: |
+          echo run remote_hal
+
   # Currently only builds and runs on x86_64 linux
   build_run_tornado:
     if: inputs.test_tornado

--- a/.github/workflows/run_ock_external_tests.yml
+++ b/.github/workflows/run_ock_external_tests.yml
@@ -210,10 +210,24 @@ jobs:
     if: inputs.test_remote_hal
     needs: [ workflow_vars ]
     runs-on: 'ubuntu-24.04'
+    container:
+      image: 'ghcr.io/uxlfoundation/ock_ubuntu_24.04-x86-64:latest'
+      volumes:
+        - ${{github.workspace}}:${{github.workspace}}
     steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+      - name: setup-ubuntu
+        uses: ./.github/actions/setup_build
+        with:
+          llvm_version: ${{ inputs.llvm_version }}
+          llvm_source: ${{ inputs.llvm_source}}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
       - name : build server
         run: |
           echo build_server
+          ls -l examples || echo NO EXAMPLES
+          ls -l llvm_install || echo NO LLVM_INSTALL
       - name : build client
         run: |
           echo build_client

--- a/.github/workflows/run_ock_external_tests.yml
+++ b/.github/workflows/run_ock_external_tests.yml
@@ -226,6 +226,7 @@ jobs:
       - name : build server
         run: |
           echo build_server
+          ls -l
           ls -l examples || echo NO EXAMPLES
           ls -l llvm_install || echo NO LLVM_INSTALL
       - name : build client

--- a/.github/workflows/run_ock_external_tests.yml
+++ b/.github/workflows/run_ock_external_tests.yml
@@ -229,6 +229,9 @@ jobs:
           ls -l
           ls -l examples || echo NO EXAMPLES
           ls -l llvm_install || echo NO LLVM_INSTALL
+          mkdir build_server
+          cmake -GNinja $GITHUB_WORKSPACE/examples/hal_cpu_remote_server -Bbuild_server -DCMAKE_TOOLCHAIN_FILE=$GITHUB_WORKSPACE/platform/riscv64-linux/riscv64-gcc-toolchain.cmake
+          ninja -Cbuild_server
       - name : build client
         run: |
           echo build_client


### PR DESCRIPTION
# Overview

Migrate remote_hal build/run to Github

# Reason for change

On-going CI move to Github

# Description of change

- Add remote_hal test to planned testing.
- Add remote_hal job to external OCK tests.
- Add build/run remote_hal action. Server build/client build/run all live in the same action
- Updated server start-up check. Job fails if no start-up detected.

# Anything else we should know?

Github job replicates the corresponding output on Gitlab.