### PR TITLE
[LLVM 21] Allow nuw in more tests.

### DIFF
--- a/modules/compiler/test/lit/passes/barriers-live-vars-literal-structs.ll
+++ b/modules/compiler/test/lit/passes/barriers-live-vars-literal-structs.ll
@@ -30,7 +30,7 @@ target datalayout = "e-p:64:64:64-m:e-i64:64-f80:128-n8:16:32:64-S128"
 ; CHECK: @foo.mux-barrier-region(ptr [[D:%.*]], ptr [[A:%.*]], ptr [[MEM:%.*]])
 ; CHECK:  [[FIXED_ADDR:%.*]] = getelementptr inbounds %foo_live_mem_info, ptr [[MEM]], i32 0, i32 2
 ; CHECK:  [[VSCALE:%.*]] = call i64 @llvm.vscale.i64()
-; CHECK:  [[NXV1I16_OFFS:%.*]] = mul i64 [[VSCALE]], 32
+; CHECK:  [[NXV1I16_OFFS:%.*]] = mul {{(nuw )?}}i64 [[VSCALE]], 32
 ; CHECK:  [[NXV1I16_ADDR:%.*]] = getelementptr inbounds %foo_live_mem_info, ptr [[MEM]], i32 0, i32 4, i64 [[NXV1I16_OFFS]]
 ; CHECK:  [[NXV8I32_ADDR:%.*]] = getelementptr inbounds %foo_live_mem_info, ptr [[MEM]], i32 0, i32 4, i32 0
 ; CHECK:  [[I8_ADDR:%.*]] = getelementptr inbounds %foo_live_mem_info, ptr [[MEM]], i32 0, i32 0
@@ -52,7 +52,7 @@ target datalayout = "e-p:64:64:64-m:e-i64:64-f80:128-n8:16:32:64-S128"
 ; CHECK: @foo.mux-barrier-region.1(ptr [[D:%.*]], ptr [[A:%.*]], ptr [[MEM:%.*]])
 ; CHECK:  [[FIXED_ADDR:%.*]] = getelementptr inbounds %foo_live_mem_info, ptr [[MEM]], i32 0, i32 2
 ; CHECK:  [[VSCALE:%.*]] = call i64 @llvm.vscale.i64()
-; CHECK:  [[NXV1I16_OFFS:%.*]] = mul i64 [[VSCALE]], 32
+; CHECK:  [[NXV1I16_OFFS:%.*]] = mul {{(nuw )?}}i64 [[VSCALE]], 32
 ; CHECK:  [[NXV1I16_ADDR:%.*]] = getelementptr inbounds %foo_live_mem_info, ptr [[MEM]], i32 0, i32 4, i64 [[NXV1I16_OFFS]]
 ; CHECK:  [[NXV8I32_ADDR:%.*]] = getelementptr inbounds %foo_live_mem_info, ptr [[MEM]], i32 0, i32 4, i32 0
 ; CHECK:  [[I8_ADDR:%.*]] = getelementptr inbounds %foo_live_mem_info, ptr [[MEM]], i32 0, i32 0
@@ -82,7 +82,7 @@ target datalayout = "e-p:64:64:64-m:e-i64:64-f80:128-n8:16:32:64-S128"
 
 ; CHECK: define void @foo.mux-barrier-wrapper(ptr %d, ptr %a)
 ; CHECK:  [[VSCALE:%.*]] = call i64 @llvm.vscale.i64()
-; CHECK:  [[SCALABLE_SIZE:%.*]] = mul i64 [[VSCALE:%.*]], 64
+; CHECK:  [[SCALABLE_SIZE:%.*]] = mul {{(nuw )?}}i64 [[VSCALE:%.*]], 64
 ; CHECK:  [[PER_WI_SIZE:%.*]] = add i64 [[SCALABLE_SIZE]], 32
 ; CHECK:  [[TOTAL_WG_SIZE:%.*]] = mul i64 [[PER_WI_SIZE]], {{%.*}}
 ; CHECK:  %live_variables = alloca i8, i64 [[TOTAL_WG_SIZE]], align 32

--- a/modules/compiler/vecz/test/lit/llvm/ScalableVectors/define_subgroup_scans.ll
+++ b/modules/compiler/vecz/test/lit/llvm/ScalableVectors/define_subgroup_scans.ll
@@ -44,7 +44,7 @@ declare <vscale x 4 x i32> @__vecz_b_sub_group_scan_inclusive_add_u5nxv4j(<vscal
 ; CHECK:   %[[SHUFFLE_ALLOC:.+]] = alloca <vscale x 4 x i32>
 ; CHECK:   %[[STEP:.+]] = call <vscale x 4 x i32> @llvm.{{(experimental\.)?}}stepvector.nxv4i32()
 ; CHECK:   %[[SCALE:.+]] = call i32 @llvm.vscale.i32()
-; CHECK:   %[[SIZE:.+]] = mul i32 %[[SCALE]], 4
+; CHECK:   %[[SIZE:.+]] = mul {{(nuw )?}}i32 %[[SCALE]], 4
 ; CHECK:   br label %loop
 ; CHECK: loop:
 ; CHECK:   %[[IV:.+]] = phi i32 [ 1, %entry ], [ %[[N2:.+]], %loop ]
@@ -79,7 +79,7 @@ declare <vscale x 4 x i32> @__vecz_b_sub_group_scan_exclusive_add_u5nxv4j(<vscal
 ; CHECK:   %[[SHUFFLE_ALLOC:.+]] = alloca <vscale x 4 x i32>
 ; CHECK:   %[[STEP:.+]] = call <vscale x 4 x i32> @llvm.{{(experimental\.)?}}stepvector.nxv4i32()
 ; CHECK:   %[[SCALE:.+]] = call i32 @llvm.vscale.i32()
-; CHECK:   %[[SIZE:.+]] = mul i32 %[[SCALE]], 4
+; CHECK:   %[[SIZE:.+]] = mul {{(nuw )?}}i32 %[[SCALE]], 4
 ; CHECK:   br label %loop
 ; CHECK: loop:
 ; CHECK:   %[[IV:.+]] = phi i32 [ 1, %entry ], [ %[[N2:.+]], %loop ]

--- a/modules/compiler/vecz/test/lit/llvm/ScalableVectors/subgroup_builtins.ll
+++ b/modules/compiler/vecz/test/lit/llvm/ScalableVectors/subgroup_builtins.ll
@@ -34,7 +34,7 @@ define spir_kernel void @get_sub_group_size(i32 addrspace(1)* %in, i32 addrspace
   ret void
 ; CHECK-LABEL: define spir_kernel void @__vecz_nxv4_get_sub_group_size(
 ; CHECK: [[VSCALE:%.*]] = call i32 @llvm.vscale.i32()
-; CHECK: [[W:%.*]] = shl i32 [[VSCALE]], 2
+; CHECK: [[W:%.*]] = shl {{(nuw )?}}i32 [[VSCALE]], 2
 ; CHECK: [[RED:%.*]] = call i32 @__mux_sub_group_reduce_add_i32(i32 [[W]])
 ; CHECK: store i32 [[RED]], ptr addrspace(1) {{.*}}
 }
@@ -47,7 +47,7 @@ define spir_kernel void @get_sub_group_local_id(i32 addrspace(1)* %in, i32 addrs
 ; CHECK-LABEL: define spir_kernel void @__vecz_nxv4_get_sub_group_local_id(
 ; CHECK: %call = tail call spir_func i32 @__mux_get_sub_group_local_id()
 ; CHECK: [[VSCALE:%.*]] = call i32 @llvm.vscale.i32()
-; CHECK: [[SHL:%.*]] = shl i32 %1, 2
+; CHECK: [[SHL:%.*]] = shl {{(nuw )?}}i32 [[VSCALE]], 2
 ; CHECK: [[MUL:%.*]] = mul i32 %call, [[SHL]]
 ; CHECK: [[SPLATINSERT:%.*]] = insertelement <vscale x 4 x i32> poison, i32 [[MUL]], i64 0
 ; CHECK: [[SPLAT:%.*]] = shufflevector <vscale x 4 x i32> [[SPLATINSERT]], <vscale x 4 x i32> poison, <vscale x 4 x i32> zeroinitializer

--- a/modules/compiler/vecz/test/lit/llvm/VectorPredication/compute_vector_length.ll
+++ b/modules/compiler/vecz/test/lit/llvm/VectorPredication/compute_vector_length.ll
@@ -49,7 +49,7 @@ define spir_kernel void @get_sub_group_size(i32 addrspace(1)* %in, i32 addrspace
 ; CHECK-S4: [[SZ:%.*]] = call i64 @__mux_get_local_size(i32 0)
 ; CHECK-S4: [[WL:%.*]] = sub {{.*}} i64 [[SZ]], [[ID]]
 ; CHECK-S4: [[VF0:%.*]] = call i64 @llvm.vscale.i64()
-; CHECK-S4: [[VF1:%.*]] = shl i64 [[VF0]], 2
+; CHECK-S4: [[VF1:%.*]] = shl {{(nuw )?}}i64 [[VF0]], 2
 ; CHECK-S4: [[VL0:%.*]] = call i64 @llvm.umin.i64(i64 [[WL]], i64 [[VF1]])
 ; CHECK-S4: [[VL1:%.*]] = trunc {{(nuw )?(nsw )?}}i64 [[VL0]] to i32
 ; CHECK-S4: [[RED:%.*]] = call i32 @__mux_sub_group_reduce_add_i32(i32 [[VL1]])

--- a/modules/compiler/vecz/test/lit/llvm/VectorPredication/load_add_store.ll
+++ b/modules/compiler/vecz/test/lit/llvm/VectorPredication/load_add_store.ll
@@ -55,7 +55,7 @@ entry:
 ; CHECK_1S: [[LSIZE:%.*]] = call i64 @__mux_get_local_size(i32 0)
 ; CHECK_1S: [[WREM:%.*]] = sub nuw nsw i64 [[LSIZE]], [[LID]]
 ; CHECK_1S: [[T0:%.*]] = call i64 @llvm.vscale.i64()
-; CHECK_1S: [[T1:%.*]] = shl i64 [[T0]], 2
+; CHECK_1S: [[T1:%.*]] = shl {{(nuw )?}}i64 [[T0]], 2
 ; CHECK_1S: [[T2:%.*]] = call i64 @llvm.umin.i64(i64 [[WREM]], i64 [[T1]])
 ; CHECK_1S: [[VL:%.*]] = trunc {{(nuw )?(nsw )?}}i64 [[T2]] to i32
 ; CHECK_1S: [[LHS:%.*]] = call <vscale x 4 x i32> @llvm.vp.load.nxv4i32.p0(ptr {{%.*}}, [[TRUEMASK:<vscale x 4 x i1> (shufflevector \(<vscale x 4 x i1> insertelement \(<vscale x 4 x i1> (undef|poison), i1 true, (i32|i64) 0\), <vscale x 4 x i1> (undef|poison), <vscale x 4 x i32> zeroinitializer\)|splat \(i1 true\))]], i32 [[VL]])
@@ -94,7 +94,7 @@ entry:
 ; CHECK_V4_1S: [[LSIZE:%.*]] = call i64 @__mux_get_local_size(i32 0)
 ; CHECK_V4_1S: [[WREM:%.*]] = sub nuw nsw i64 [[LSIZE]], [[LID]]
 ; CHECK_V4_1S: [[T0:%.*]] = call i64 @llvm.vscale.i64()
-; CHECK_V4_1S: [[T1:%.*]] = shl i64 [[T0]], 2
+; CHECK_V4_1S: [[T1:%.*]] = shl {{(nuw )?}}i64 [[T0]], 2
 ; CHECK_V4_1S: [[T2:%.*]] = call i64 @llvm.umin.i64(i64 [[WREM]], i64 [[T1]])
 ; CHECK_V4_1S: [[VL:%.*]] = trunc {{(nuw )?(nsw )?}}i64 [[T2]] to i32
 ; Each WI performs 4 elements, so multiply the VL by 4

--- a/modules/compiler/vecz/test/lit/llvm/VectorPredication/udiv.ll
+++ b/modules/compiler/vecz/test/lit/llvm/VectorPredication/udiv.ll
@@ -41,7 +41,7 @@ entry:
 ; CHECK: [[LSIZE:%.*]] = call i64 @__mux_get_local_size(i32 0)
 ; CHECK: [[WREM:%.*]] = sub nuw nsw i64 [[LSIZE]], [[LID]]
 ; CHECK: [[T0:%.*]] = call i64 @llvm.vscale.i64()
-; CHECK: [[T1:%.*]] = shl i64 [[T0]], 1
+; CHECK: [[T1:%.*]] = shl {{(nuw )?}}i64 [[T0]], 1
 ; CHECK: [[T2:%.*]] = call i64 @llvm.umin.i64(i64 [[WREM]], i64 [[T1]])
 ; CHECK: [[VL:%.*]] = trunc i64 [[T2]] to i32
 ; CHECK: [[LHS:%.*]] = call <vscale x 2 x i32> @llvm.vp.load.nxv2i32.p0(ptr {{%.*}}, [[TRUEMASK:<vscale x 2 x i1> (shufflevector \(<vscale x 2 x i1> insertelement \(<vscale x 2 x i1> (undef|poison), i1 true, (i32|i64) 0\), <vscale x 2 x i1> (undef|poison), <vscale x 2 x i32> zeroinitializer\)|splat \(i1 true\))]], i32 [[VL]])


### PR DESCRIPTION
# Overview

[LLVM 21] Allow nuw in more tests.

# Reason for change

LLVM 21 adds nuw flags for vscale multiplications.

# Description of change

Allow these in tests.

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-19](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
