### PR TITLE
Remove test_atomic XFail.

### DIFF
--- a/scripts/testing/sycl_cts/override_all.csv
+++ b/scripts/testing/sycl_cts/override_all.csv
@@ -1,2 +1,1 @@
 SYCL_CTS,test_event "event::wait does not report asynchronous errors",MayFail
-SYCL_CTS,test_atomic,XFail


### PR DESCRIPTION
# Overview

Remove test_atomic XFail.

# Reason for change

The fix for this has been merged in DPC++.

# Description of change

*Describe the intended behaviour your changes are meant to introduce to the
project and explain how they resolve the problem stated above. Detail any
relevant changes that may affect other users of the project, such as
compilation options, runtime flags, expected inputs and outputs, API entry
points, etc.*

*If you have added new testing, provide details on what tests you have added
and what the purpose of them is.*

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-19](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
