### PR TITLE
[NFC] Avoid deprecation warning.

### DIFF
--- a/modules/compiler/compiler_pipeline/source/add_kernel_wrapper_pass.cpp
+++ b/modules/compiler/compiler_pipeline/source/add_kernel_wrapper_pass.cpp
@@ -250,13 +250,13 @@ PreservedAnalyses compiler::utils::AddKernelWrapperPass::run(
         // If the old argument was marked 'noundef', the result of the load
         // from it will also be noundef. Use metadata to convey that.
         if (F.getArg(argMapping.OldArgIdx)->hasAttribute(Attribute::NoUndef)) {
-          MDNode *md = MDNode::get(newFunction->getContext(), std::nullopt);
+          MDNode *md = MDNode::get(newFunction->getContext(), {});
           arg_load->setMetadata(LLVMContext::MD_noundef, md);
         }
         // If the old argument was marked 'nonnull', the result of the load
         // from it will also be nonnull. Use metadata to convey that.
         if (F.getArg(argMapping.OldArgIdx)->hasAttribute(Attribute::NonNull)) {
-          MDNode *md = MDNode::get(newFunction->getContext(), std::nullopt);
+          MDNode *md = MDNode::get(newFunction->getContext(), {});
           arg_load->setMetadata(LLVMContext::MD_nonnull, md);
         }
         params.push_back(arg_load);


### PR DESCRIPTION
# Overview

[NFC] Avoid deprecation warning.

# Reason for change

ArrayRef(std::nullopt_t) is deprecated in favor of {}.

# Description of change

We use MDNode::get(..., {}) in other places already, do the same here.

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-19](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
