### PR TITLE
Add ninja to aarch64 docker builds for consistency.

### DIFF
--- a/.github/dockerfiles/Dockerfile_22.04-aarch64
+++ b/.github/dockerfiles/Dockerfile_22.04-aarch64
@@ -5,7 +5,7 @@ RUN apt-get -y install sudo
 RUN apt-get install -y git
 RUN apt-get install --yes cmake
 RUN apt-get install --yes gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
-RUN apt-get install --yes python3 python3-pip
+RUN apt-get install --yes python3 python3-pip ninja-build
 RUN pip install cmakelint colorama lit
 RUN apt-get install --yes spirv-tools
 RUN apt-get install --yes wget gpg


### PR DESCRIPTION
# Overview

Add ninja to aarch64 docker builds for consistency.
