### PR TITLE
city runner: do not mark skipped tests as failing.

### DIFF
--- a/scripts/testing/city_runner/test_info.py
+++ b/scripts/testing/city_runner/test_info.py
@@ -364,6 +364,7 @@ class TestResults(object):
         self.mayfail_list = []
         self.xfail_list = []
         self.unknown_pass_list = []
+        self.unknown_skip_list = []
         self.unknown_fail_list = []
         self.unknown_timeout_list = []
 
@@ -395,6 +396,8 @@ class TestResults(object):
                 else:
                     if run.status == "PASS":
                         self.unknown_pass_list.append(run)
+                    elif run.status == "SKIP":
+                        self.unknown_skip_list.append(run)
                     elif run.status == "TIMEOUT":
                         self.unknown_timeout_list.append(run)
                     else:

--- a/scripts/testing/city_runner/ui.py
+++ b/scripts/testing/city_runner/ui.py
@@ -123,6 +123,10 @@ class TestUI(object):
             self.out.write(self.fmt.red("Unknown passing tests:\n"))
             self.report_test_list(results.unknown_pass_list)
 
+        if results.unknown_skip_list:
+            self.out.write(self.fmt.red("Unknown skipped tests:\n"))
+            self.report_test_list(results.unknown_skip_list)
+
         if results.unknown_timeout_list:
             self.out.write(self.fmt.red("Unknown timeout tests:\n"))
             self.report_test_list(results.unknown_timeout_list)


### PR DESCRIPTION
# Overview

city runner: do not mark skipped tests as failing.

# Reason for change

If we encounter a new test, we previously only allowed three scenarios: pass, timeout, or fail. If the test did not pass and did not time out, we treated it as a fail. This is incorrect for tests that self-report as skipped, which need to be treated as a separate category.

# Description of change

This change implements that.

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-19](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
