### PR TITLE
Fix abs.

### DIFF
--- a/modules/compiler/builtins/abacus/generate/abacus_detail_integer/abacus_detail_integer.in
+++ b/modules/compiler/builtins/abacus/generate/abacus_detail_integer/abacus_detail_integer.in
@@ -51,9 +51,10 @@ template<typename T, bool SIGNED = TypeTraits<T>::is_signed> struct abs_helper {
 
 template<typename T> struct abs_helper<T, true> {
   static typename TypeTraits<T>::UnsignedType _(const T& x) {
+    typedef typename TypeTraits<T>::UnsignedType UnsignedType;
     const typename TypeTraits<T>::SignedType cond = x < 0;
-    return cast::as<typename TypeTraits<T>::UnsignedType>(
-      relational::select(x, (T)-x, cond));
+    UnsignedType ux = cast::as<UnsignedType>(x);
+    return relational::select(ux, (UnsignedType)-ux, cond);
   }
 };
 


### PR DESCRIPTION
# Overview

Fix abs.

# Reason for change

Unlike C and C++ abs, OpenCL abs is well-defined for all inputs and we have to make sure we handle the largest negative value correctly.

# Description of change

For that, we can convert to unsigned before the negation rather than after.

# Anything else we should know?

Fixes OpenCL CTS test_conversions.

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-19](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
