### PR TITLE
Fix ccache deletion for dpcpp

### DIFF
--- a/.github/workflows/planned_testing_caller_19.yml
+++ b/.github/workflows/planned_testing_caller_19.yml
@@ -60,4 +60,4 @@ jobs:
         uses: ./.github/actions/clean_cache
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          cache_prefixes: "ccache-dpcpp-build-host_x86_64_linux ccache-dpcpp-build-host_aarch64_linux ccache-dpcpp-build-host_riscv64_linux"
+          cache_prefixes: "ccache-ccache-dpcpp-build-host_x86_64_linux ccache-ccache-dpcpp-build-host_aarch64_linux ccache-ccache-dpcpp-build-host_riscv64_linux"

--- a/.github/workflows/planned_testing_caller_20.yml
+++ b/.github/workflows/planned_testing_caller_20.yml
@@ -50,4 +50,4 @@ jobs:
         uses: ./.github/actions/clean_cache
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          cache_prefixes: "ccache-dpcpp-build-host_x86_64_linux ccache-dpcpp-build-host_aarch64_linux ccache-dpcpp-build-host_riscv64_linux"
+          cache_prefixes: "ccache-ccache-dpcpp-build-host_x86_64_linux ccache-ccache-dpcpp-build-host_aarch64_linux ccache-ccache-dpcpp-build-host_riscv64_linux"


### PR DESCRIPTION
# Overview

The ccache delete did not have the full prefix and therefore no ccaches were being deleted.
