### PR TITLE
Avoid linking in LLVMSPIRVLib.

### DIFF
--- a/modules/compiler/utils/CMakeLists.txt
+++ b/modules/compiler/utils/CMakeLists.txt
@@ -58,7 +58,12 @@ if(LLD_FOUND)
   set(LLVM_LIBS)
   foreach(target IN LISTS LLVM_TARGETS_TO_BUILD)
     foreach(lib IN LISTS LLVM_AVAILABLE_LIBS)
-      if(lib MATCHES "^LLVM${target}")
+      # If LLVM is built with SPIRV-LLVM-Translator as an external project, in
+      # addition to LLVM's own LLVMSPIRVCodeGen, LLVMSPIRVDesc, etc. libraries,
+      # we will also have SPIRV-LLVM-Translator's LLVMSPIRVLib. This is not
+      # required by LLD and may result in linker errors depending on the exact
+      # configuration, so take care to leave it out.
+      if(lib MATCHES "^LLVM${target}" AND NOT lib STREQUAL "LLVMSPIRVLib")
         list(APPEND LLVM_LIBS "${lib}")
       endif()
     endforeach()


### PR DESCRIPTION
# Overview

Avoid linking in LLVMSPIRVLib.

# Reason for change

If LLVM is built together with SPIRV-LLVM-Translator, we may inadvertently link in its library. This can result in errors.

# Description of change

Make sure we skip that.

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-19](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
