### PR TITLE
[CI][E2E] Add support for e2e aarch64

### DIFF
--- a/.github/workflows/planned_testing_caller.yml
+++ b/.github/workflows/planned_testing_caller.yml
@@ -105,6 +105,7 @@ jobs:
       test_sycl_cts: ${{ inputs.test_sycl_cts }}
       test_sycl_e2e: ${{ inputs.test_sycl_e2e }}
       test_opencl_cts: ${{ inputs.test_opencl_cts }}
+      test_sanitizers: ${{ inputs.test_sanitizers }}   
       native_cpu: ${{ inputs.native_cpu }}
       llvm_branch: ${{ inputs.llvm_branch }}
       save_cache: ${{ inputs.save_cache }}

--- a/.github/workflows/run_ock_external_tests.yml
+++ b/.github/workflows/run_ock_external_tests.yml
@@ -341,6 +341,7 @@ jobs:
           llvm_version: ${{ inputs.llvm_version }}
 
   build_opencl_cts_riscv64:
+    if: inputs.test_opencl_cts && (contains(inputs.target_list, 'host_riscv64_linux'))
     needs: [ workflow_vars, build_icd, create_ock_artefacts_ubuntu ]
     runs-on: 'ubuntu-24.04'
     container:
@@ -366,7 +367,7 @@ jobs:
           target: host_riscv64_linux
 
   run_opencl_cts_riscv64:
-    if: inputs.test_opencl_cts
+    if: inputs.test_opencl_cts && (contains(inputs.target_list, 'host_riscv64_linux'))
     needs: [ workflow_vars, build_icd, create_ock_artefacts_ubuntu, build_opencl_cts_riscv64 ]
     runs-on: 'ubuntu-24.04'
     strategy:
@@ -429,7 +430,7 @@ jobs:
       volumes:
         - ${{github.workspace}}:${{github.workspace}}
 
-    if: inputs.test_sycl_cts && contains(inputs.target_list, 'host_aarch64_linux')
+    if: (inputs.test_sycl_cts || inputs.test_sycl_e2e) && contains(inputs.target_list, 'host_aarch64_linux')
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
@@ -898,4 +899,40 @@ jobs:
         uses: ./.github/actions/do_build_run_sycl_e2e
         with:
           target: host_x86_64_linux
+          sycl_device: opencl
+
+  run_sycl_e2e_aarch64_native_cpu:
+    needs: [workflow_vars, build_dpcpp_native_aarch64]
+    runs-on: 'ubuntu-22.04-arm'
+    container:
+      image: 'ghcr.io/uxlfoundation/ock_ubuntu_22.04-aarch64:latest'
+      volumes:
+        - ${{github.workspace}}:${{github.workspace}}
+
+    if: inputs.test_sycl_e2e && inputs.native_cpu && contains(inputs.target_list, 'host_aarch64_linux')
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+      - name: build e2e
+        uses: ./.github/actions/do_build_run_sycl_e2e
+        with:
+          target: host_aarch64_linux
+          sycl_device: native_cpu
+
+  run_sycl_e2e_aarch64_opencl:
+    needs: [workflow_vars, build_dpcpp_native_aarch64]
+    runs-on: 'ubuntu-22.04-arm'
+    container:
+      image: 'ghcr.io/uxlfoundation/ock_ubuntu_22.04-aarch64:latest'
+      volumes:
+        - ${{github.workspace}}:${{github.workspace}}
+
+    if: inputs.test_sycl_e2e && inputs.ock && contains(inputs.target_list, 'host_aarch64_linux')
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+      - name: build e2e
+        uses: ./.github/actions/do_build_run_sycl_e2e
+        with:
+          target: host_aarch64_linux
           sycl_device: opencl

--- a/scripts/testing/sycl_e2e/override_host_aarch64_linux.csv
+++ b/scripts/testing/sycl_e2e/override_host_aarch64_linux.csv
@@ -1,0 +1,10 @@
+SYCL,Basic/built-ins/const_vec_common.cpp,XFail
+SYCL,Basic/built-ins/const_vec_geometric.cpp,XFail
+SYCL,Basic/built-ins/const_vec_math.cpp,XFail
+SYCL,Basic/built-ins/marray_math.cpp,XFail
+SYCL,Basic/built-ins/vec_common.cpp,XFail
+SYCL,Basic/built-ins/vec_geometric.cpp,XFail
+SYCL,Basic/built-ins/vec_math.cpp,XFail
+SYCL,DeviceLib/built-ins/marray_integer.cpp,XFail
+SYCL,DeviceLib/built-ins/vector_relational.cpp,XFail
+SYCL,DotProduct/dot_product_int_test.cpp,XFail

--- a/scripts/testing/sycl_e2e/override_native_cpu.csv
+++ b/scripts/testing/sycl_e2e/override_native_cpu.csv
@@ -9,7 +9,6 @@ SYCL,Basic/kernel_bundle/kernel_bundle_api.cpp,XFail
 SYCL,Basic/large-range.cpp,XFail
 SYCL,Basic/max_linear_work_group_size_props.cpp,XFail
 SYCL,Basic/max_work_group_size_props.cpp,XFail
-SYCL,Complex/sycl_complex_math_test.cpp,XFail
 SYCL,Compression/no_zstd_warning.cpp,XFail
 SYCL,DeviceImageDependencies/dynamic.cpp,XFail
 SYCL,DeviceImageDependencies/free_function_kernels.cpp,XFail

--- a/scripts/testing/sycl_e2e/override_native_cpu_host_aarch64_linux.csv
+++ b/scripts/testing/sycl_e2e/override_native_cpu_host_aarch64_linux.csv
@@ -1,0 +1,9 @@
+SYCL,GroupAlgorithm/SYCL2020/reduce_over_group_size.cpp,XFail
+SYCL,HierPar/hier_par_wgscope_O0.cpp,XFail
+SYCL,OptionalKernelFeatures/is_compatible/is_compatible_with_aspects.cpp,XFail
+SYCL,OptionalKernelFeatures/throw-exception-for-unsupported-aspect.cpp,XFail
+SYCL,Regression/2020-spec-constants-debug-info.cpp,XFail
+SYCL,Regression/default-constructed-local-accessor.cpp,XFail
+SYCL,Regression/optimization_level_debug_info_intopt.cpp,XFail
+SYCL,Regression/unoptimized_stream.cpp,XFail
+SYCL,syclcompat/math/math_emu_simd_from_syclomatic.cpp,XFail

--- a/scripts/testing/sycl_e2e/override_native_cpu_host_x86_64_linux.csv
+++ b/scripts/testing/sycl_e2e/override_native_cpu_host_x86_64_linux.csv
@@ -1,0 +1,1 @@
+SYCL,Complex/sycl_complex_math_test.cpp,XFail

--- a/scripts/testing/sycl_e2e/override_opencl.csv
+++ b/scripts/testing/sycl_e2e/override_opencl.csv
@@ -114,6 +114,7 @@ SYCL,HierPar/hier_par_wgscope_O0.cpp,MayFail
 SYCL,KernelCompiler/sycl_cache.cpp,XFail
 SYCL,KernelCompiler/sycl.cpp,XFail
 SYCL,KernelCompiler/sycl_device_globals.cpp,XFail
+SYCL,NewOffloadDriver/multisource.cpp,XFail
 SYCL,NonUniformGroups/ballot_group_algorithms.cpp,XFail
 SYCL,NonUniformGroups/fixed_size_group_algorithms.cpp,XFail
 SYCL,NonUniformGroups/fixed_size_group.cpp,XFail

--- a/scripts/testing/sycl_e2e/override_opencl_host_aarch64_linux.csv
+++ b/scripts/testing/sycl_e2e/override_opencl_host_aarch64_linux.csv
@@ -1,0 +1,8 @@
+SYCL,AtomicRef/max.cpp,MayFail
+SYCL,AtomicRef/sub_generic.cpp,MayFail
+SYCL,Basic/built-ins/marray_geometric.cpp,XFail
+SYCL,Config/env_vars.cpp,XFail
+SYCL,DeviceLib/math_test_marray_vec_fp16.cpp,XFail
+SYCL,syclcompat/math/math_compare.cpp,XFail
+SYCL,syclcompat/math/math_emu_simd_from_syclomatic.cpp,XFail
+SYCL,syclcompat/math/math_emu_simd_from_syclomatic.cpp,XFail

--- a/scripts/testing/sycl_e2e/override_opencl_host_x86_64_linux.csv
+++ b/scripts/testing/sycl_e2e/override_opencl_host_x86_64_linux.csv
@@ -1,1 +1,0 @@
-SYCL,NewOffloadDriver/multisource.cpp,XFail


### PR DESCRIPTION
# Overview

Add github ci support for e2e aarch64

# Reason for change

It is useful to test the aarch64 architecture along with x86_64.

# Description of change

Add jobs for e2e for opencl and native_cpu for aarch64. This also involves
some overrides to match specific fails for aarch64.

Also fixed some if: conditions on jobs as it was noticed they ran when
top level flags suggested they should not.
