### PR TITLE
Disable 32 bit x86 tests when only building 64 bit x86_64 llvm

### DIFF
--- a/.github/workflows/run_ock_internal_tests.yml
+++ b/.github/workflows/run_ock_internal_tests.yml
@@ -484,7 +484,7 @@ jobs:
 
  # Based on: mr-ubuntu-clang-x86-llvm-latest-cl3.0
   run-ubuntu-clang-x86-llvm-latest-cl3-0:
-    if: ${{ !inputs.is_pull_request && contains(inputs.target_list, 'host_x86_64_linux') }}
+    if: ${{ !inputs.is_pull_request && contains(inputs.target_list, 'host_i686_linux') }}
     runs-on: ubuntu-22.04
     container:
       image: ghcr.io/uxlfoundation/ock_ubuntu_22.04-x86-64:latest
@@ -507,7 +507,7 @@ jobs:
 
  # Based on: mr-ubuntu-gcc-x86-llvm-previous-cl3.0-release
   run-ubuntu-gcc-x86-llvm-previous-cl3-0-release:
-    if: ${{ !inputs.is_pull_request && contains(inputs.target_list, 'host_x86_64_linux') }}
+    if: ${{ !inputs.is_pull_request && contains(inputs.target_list, 'host_i686_linux') }}
     runs-on: ubuntu-22.04
     container:
       image: ghcr.io/uxlfoundation/ock_ubuntu_22.04-x86-64:latest


### PR DESCRIPTION
# Overview

When we test daily llvm tip, we only build x86_64 llvm. Some of the internal tests require 32 bit llvm and had been wrongly tagged to try running. This updates the tags on jobs to host_i686_linux where necessary.
