### PR TITLE
[NFC] Remove some old LLVM support from tests.

### DIFF
--- a/modules/compiler/spirv-ll/test/spvasm/codeplay/opencl_group_async_copy_2d2d.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/codeplay/opencl_group_async_copy_2d2d.spvasm
@@ -16,8 +16,7 @@
 
 ; REQUIRES: spirv-as-v2020.0+
 ; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
-; RUN: %pp-llvm-ver -o %t < %s --llvm-ver %LLVMVER
-; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %t
+; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
 
                         OpCapability Addresses
                         OpCapability Linkage
@@ -57,13 +56,11 @@
                %entry = OpLabel
 
 
-; CHECK-GE17: [[inEvent:%.*]] = call spir_func target("spirv.Event") @_Z26async_work_group_copy_2D2DPU3AS3vmPU3AS1Kvmmmmmm9ocl_event(ptr addrspace(3) [[scratch]], i64 0, ptr addrspace(1) [[in]], i64 0, i64 4, i64 16, i64 8, i64 4, i64 4, target("spirv.Event") zeroinitializer)
-; CHECK-LT17: [[inEvent:%.*]] = call spir_func ptr @_Z26async_work_group_copy_2D2DPU3AS3vmPU3AS1Kvmmmmmm9ocl_event(ptr addrspace(3) [[scratch]], i64 0, ptr addrspace(1) [[in]], i64 0, i64 4, i64 16, i64 8, i64 4, i64 4, ptr null)
+; CHECK: [[inEvent:%.*]] = call spir_func target("spirv.Event") @_Z26async_work_group_copy_2D2DPU3AS3vmPU3AS1Kvmmmmmm9ocl_event(ptr addrspace(3) [[scratch]], i64 0, ptr addrspace(1) [[in]], i64 0, i64 4, i64 16, i64 8, i64 4, i64 4, target("spirv.Event") zeroinitializer)
              %inEvent = OpExtInst %eventT %groupAsyncCopies 1 %scratch %int64Zero %in %int64Zero %sizeofInt32T %numBytesPerLine %numLines %lineLength %lineLength %nullEvent
 
 
-; CHECK-GE17: = call spir_func target("spirv.Event") @_Z26async_work_group_copy_2D2DPU3AS1vmPU3AS3Kvmmmmmm9ocl_event(ptr addrspace(1) [[out]], i64 0, ptr addrspace(3) [[scratch]], i64 0, i64 4, i64 16, i64 8, i64 4, i64 4, target("spirv.Event") [[inEvent]])
-; CHECK-LT17: = call spir_func ptr @_Z26async_work_group_copy_2D2DPU3AS1vmPU3AS3Kvmmmmmm9ocl_event(ptr addrspace(1) [[out]], i64 0, ptr addrspace(3) [[scratch]], i64 0, i64 4, i64 16, i64 8, i64 4, i64 4, ptr [[inEvent]])
+; CHECK: = call spir_func target("spirv.Event") @_Z26async_work_group_copy_2D2DPU3AS1vmPU3AS3Kvmmmmmm9ocl_event(ptr addrspace(1) [[out]], i64 0, ptr addrspace(3) [[scratch]], i64 0, i64 4, i64 16, i64 8, i64 4, i64 4, target("spirv.Event") [[inEvent]])
             %outEvent = OpExtInst %eventT %groupAsyncCopies 1 %out %int64Zero %scratch %int64Zero %sizeofInt32T %numBytesPerLine %numLines %lineLength %lineLength %inEvent
 
                         OpReturn

--- a/modules/compiler/spirv-ll/test/spvasm/codeplay/opencl_group_async_copy_3d3d.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/codeplay/opencl_group_async_copy_3d3d.spvasm
@@ -16,8 +16,7 @@
 
 ; REQUIRES: spirv-as-v2020.0+
 ; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
-; RUN: %pp-llvm-ver -o %t < %s --llvm-ver %LLVMVER
-; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %t
+; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
 
                         OpCapability Addresses
                         OpCapability Linkage
@@ -59,13 +58,11 @@
                %entry = OpLabel
 
 
-; CHECK-GE17: [[inEvent:%.*]] = call spir_func target("spirv.Event") @_Z26async_work_group_copy_3D3DPU3AS3vmPU3AS1Kvmmmmmmmmm9ocl_event(ptr addrspace(3) [[scratch]], i64 0, ptr addrspace(1) [[in]], i64 0, i64 4, i64 16, i64 8, i64 2, i64 4, i64 32, i64 4, i64 32, target("spirv.Event") zeroinitializer)
-; CHECK-LT17: [[inEvent:%.*]] = call spir_func ptr @_Z26async_work_group_copy_3D3DPU3AS3vmPU3AS1Kvmmmmmmmmm9ocl_event(ptr addrspace(3) [[scratch]], i64 0, ptr addrspace(1) [[in]], i64 0, i64 4, i64 16, i64 8, i64 2, i64 4, i64 32, i64 4, i64 32, ptr null)
+; CHECK: [[inEvent:%.*]] = call spir_func target("spirv.Event") @_Z26async_work_group_copy_3D3DPU3AS3vmPU3AS1Kvmmmmmmmmm9ocl_event(ptr addrspace(3) [[scratch]], i64 0, ptr addrspace(1) [[in]], i64 0, i64 4, i64 16, i64 8, i64 2, i64 4, i64 32, i64 4, i64 32, target("spirv.Event") zeroinitializer)
              %inEvent = OpExtInst %eventT %groupAsyncCopies 2 %scratch %int64Zero %in %int64Zero %sizeofInt32T %numBytesPerLine %numLines %numPlanes %lineLength %planeArea %lineLength %planeArea %nullEvent
 
 
-; CHECK-GE17: = call spir_func target("spirv.Event") @_Z26async_work_group_copy_3D3DPU3AS1vmPU3AS3Kvmmmmmmmmm9ocl_event(ptr addrspace(1) [[out]], i64 0, ptr addrspace(3) [[scratch]], i64 0, i64 4, i64 16, i64 8, i64 2, i64 4, i64 32, i64 4, i64 32, target("spirv.Event") [[inEvent]])
-; CHECK-LT17: = call spir_func ptr @_Z26async_work_group_copy_3D3DPU3AS1vmPU3AS3Kvmmmmmmmmm9ocl_event(ptr addrspace(1) [[out]], i64 0, ptr addrspace(3) [[scratch]], i64 0, i64 4, i64 16, i64 8, i64 2, i64 4, i64 32, i64 4, i64 32, ptr [[inEvent]])
+; CHECK: = call spir_func target("spirv.Event") @_Z26async_work_group_copy_3D3DPU3AS1vmPU3AS3Kvmmmmmmmmm9ocl_event(ptr addrspace(1) [[out]], i64 0, ptr addrspace(3) [[scratch]], i64 0, i64 4, i64 16, i64 8, i64 2, i64 4, i64 32, i64 4, i64 32, target("spirv.Event") [[inEvent]])
             %outEvent = OpExtInst %eventT %groupAsyncCopies 2 %out %int64Zero %scratch %int64Zero %sizeofInt32T %numBytesPerLine %numLines %numPlanes %lineLength %planeArea %lineLength %planeArea %inEvent
 
                         OpReturn

--- a/modules/compiler/spirv-ll/test/spvasm/op_constant_sampler_1d.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_constant_sampler_1d.spvasm
@@ -16,8 +16,7 @@
 
 ; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: %if online-spirv-as %{ spirv-val %spv_file_s %}
-; RUN: %pp-llvm-ver -o %t < %s --llvm-ver %LLVMVER
-; RUN: spirv-ll-tool -a OpenCL -b 64 -c Sampled1D -c LiteralSampler %spv_file_s | FileCheck %t
+; RUN: spirv-ll-tool -a OpenCL -b 64 -c Sampled1D -c LiteralSampler %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses
                         OpCapability Sampled1D
@@ -40,12 +39,10 @@
        %const_sampler = OpConstantSampler %sampler_t None 0 Nearest
     %constant_sampler = OpFunction %void_t None %sampler_fn_t
             %in_image = OpFunctionParameter %image1d_t
-; CHECK-GE17: define spir_kernel void @constant_sampler([[IMG_TY:target\("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0\)]] noundef %in_image)
-; CHECK-LT17: define spir_kernel void @constant_sampler([[IMG_TY:ptr addrspace\(1\)]] noundef %in_image)
+; CHECK: define spir_kernel void @constant_sampler([[IMG_TY:target\("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0\)]] noundef %in_image)
                    %1 = OpLabel
        %sampled_image = OpSampledImage %sampled_image_t %in_image %const_sampler
-; CHECK-GE17: [[SAMPLER:%.*]] = call [[SAMPLER_TY:target\("spirv.Sampler"\)]] @__translate_sampler_initializer(i32 16)
-; CHECK-LT17: [[SAMPLER:%.*]] = call [[SAMPLER_TY:ptr]] @__translate_sampler_initializer(i32 16)
+; CHECK: [[SAMPLER:%.*]] = call [[SAMPLER_TY:target\("spirv.Sampler"\)]] @__translate_sampler_initializer(i32 16)
                    %2 = OpImageSampleExplicitLod %v4float_t %sampled_image %float_1 None
 ; CHECK: = call spir_func <4 x float> @_Z11read_imagef11ocl_image1d11ocl_samplerf([[IMG_TY]] %in_image, [[SAMPLER_TY]] [[SAMPLER]], float 1.000000e+00)
                    %3 = OpImageSampleExplicitLod %v4float_t %sampled_image %uint_1 None

--- a/modules/compiler/spirv-ll/test/spvasm/op_constant_sampler_1d_array.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_constant_sampler_1d_array.spvasm
@@ -16,8 +16,7 @@
 
 ; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: %if online-spirv-as %{ spirv-val %spv_file_s %}
-; RUN: %pp-llvm-ver -o %t < %s --llvm-ver %LLVMVER
-; RUN: spirv-ll-tool -a OpenCL -b 64 -c Sampled1D -c LiteralSampler %spv_file_s | FileCheck %t
+; RUN: spirv-ll-tool -a OpenCL -b 64 -c Sampled1D -c LiteralSampler %spv_file_s | FileCheck %s
                       OpCapability Kernel
                       OpCapability Addresses
                       OpCapability Sampled1D
@@ -46,12 +45,10 @@
 
   %constant_sampler = OpFunction %void_t None %sampler_fn_t
           %in_image = OpFunctionParameter %image1d_array_ro_t
-; CHECK-GE17: define spir_kernel void @constant_sampler([[IMG_TY:target\("spirv.Image", void, 0, 0, 1, 0, 0, 0, 0\)]] noundef %in_image)
-; CHECK-LT17: define spir_kernel void @constant_sampler([[IMG_TY:ptr addrspace\(1\)]] noundef %in_image)
+; CHECK: define spir_kernel void @constant_sampler([[IMG_TY:target\("spirv.Image", void, 0, 0, 1, 0, 0, 0, 0\)]] noundef %in_image)
                  %1 = OpLabel
      %sampled_image = OpSampledImage %sampled_image_t %in_image %const_sampler
-; CHECK-GE17: [[SAMPLER:%.*]] = call [[SAMPLER_TY:target\("spirv.Sampler"\)]] @__translate_sampler_initializer(i32 16)
-; CHECK-LT17: [[SAMPLER:%.*]] = call [[SAMPLER_TY:ptr]] @__translate_sampler_initializer(i32 16)
+; CHECK: [[SAMPLER:%.*]] = call [[SAMPLER_TY:target\("spirv.Sampler"\)]] @__translate_sampler_initializer(i32 16)
                  %2 = OpImageSampleExplicitLod %v4float_t %sampled_image %v2float_1 None
 ; CHECK: = call spir_func <4 x float> @_Z11read_imagef16ocl_image1darray11ocl_samplerDv2_f([[IMG_TY]] %in_image, [[SAMPLER_TY]] [[SAMPLER]], <2 x float> {{<(float 1.000000e\+00(, )?)+>|splat \(float 1.000000e\+00\)}})
                  %3 = OpImageSampleExplicitLod %v4float_t %sampled_image %v2uint_1 None

--- a/modules/compiler/spirv-ll/test/spvasm/op_constant_sampler_2d.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_constant_sampler_2d.spvasm
@@ -16,8 +16,7 @@
 
 ; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: %if online-spirv-as %{ spirv-val %spv_file_s %}
-; RUN: %pp-llvm-ver -o %t < %s --llvm-ver %LLVMVER
-; RUN: spirv-ll-tool -a OpenCL -b 64 -c Sampled1D -c LiteralSampler %spv_file_s | FileCheck %t
+; RUN: spirv-ll-tool -a OpenCL -b 64 -c Sampled1D -c LiteralSampler %spv_file_s | FileCheck %s
                       OpCapability Kernel
                       OpCapability Addresses
                       OpCapability Sampled1D
@@ -46,12 +45,10 @@
 
   %constant_sampler = OpFunction %void_t None %sampler_fn_t
           %in_image = OpFunctionParameter %image2d_ro_t
-; CHECK-GE17: define spir_kernel void @constant_sampler([[IMG_TY:target\("spirv.Image", void, 1, 0, 0, 0, 0, 0, 0\)]] noundef %in_image)
-; CHECK-LT17: define spir_kernel void @constant_sampler([[IMG_TY:ptr addrspace\(1\)]] noundef %in_image)
+; CHECK: define spir_kernel void @constant_sampler([[IMG_TY:target\("spirv.Image", void, 1, 0, 0, 0, 0, 0, 0\)]] noundef %in_image)
                  %1 = OpLabel
      %sampled_image = OpSampledImage %sampled_image_t %in_image %const_sampler
-; CHECK-GE17: [[SAMPLER:%.*]] = call [[SAMPLER_TY:target\("spirv.Sampler"\)]] @__translate_sampler_initializer(i32 16)
-; CHECK-LT17: [[SAMPLER:%.*]] = call [[SAMPLER_TY:ptr]] @__translate_sampler_initializer(i32 16)
+; CHECK: [[SAMPLER:%.*]] = call [[SAMPLER_TY:target\("spirv.Sampler"\)]] @__translate_sampler_initializer(i32 16)
                  %2 = OpImageSampleExplicitLod %v4float_t %sampled_image %v2float_1 None
 ; CHECK: = call spir_func <4 x float> @_Z11read_imagef11ocl_image2d11ocl_samplerDv2_f([[IMG_TY]] %in_image, [[SAMPLER_TY]] [[SAMPLER]], <2 x float> {{<(float 1.000000e\+00(, )?)+>|splat \(float 1.000000e\+00\)}})
                  %3 = OpImageSampleExplicitLod %v4float_t %sampled_image %v2int_1 None

--- a/modules/compiler/spirv-ll/test/spvasm/op_constant_sampler_2d_array.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_constant_sampler_2d_array.spvasm
@@ -16,8 +16,7 @@
 
 ; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: %if online-spirv-as %{ spirv-val %spv_file_s %}
-; RUN: %pp-llvm-ver -o %t < %s --llvm-ver %LLVMVER
-; RUN: spirv-ll-tool -a OpenCL -b 64 -c Sampled1D -c LiteralSampler %spv_file_s | FileCheck %t
+; RUN: spirv-ll-tool -a OpenCL -b 64 -c Sampled1D -c LiteralSampler %spv_file_s | FileCheck %s
                       OpCapability Kernel
                       OpCapability Addresses
                       OpCapability Sampled1D
@@ -44,12 +43,10 @@
 
   %constant_sampler = OpFunction %void_t None %sampler_fn_t
           %in_image = OpFunctionParameter %image2d_array_ro_t
-; CHECK-GE17: define spir_kernel void @constant_sampler([[IMG_TY:target\("spirv.Image", void, 1, 0, 1, 0, 0, 0, 0\)]] noundef %in_image)
-; CHECK-LT17: define spir_kernel void @constant_sampler([[IMG_TY:ptr addrspace\(1\)]] noundef %in_image)
+; CHECK: define spir_kernel void @constant_sampler([[IMG_TY:target\("spirv.Image", void, 1, 0, 1, 0, 0, 0, 0\)]] noundef %in_image)
                  %1 = OpLabel
      %sampled_image = OpSampledImage %sampled_image_t %in_image %const_sampler
-; CHECK-GE17: [[SAMPLER:%.*]] = call [[SAMPLER_TY:target\("spirv.Sampler"\)]] @__translate_sampler_initializer(i32 16)
-; CHECK-LT17: [[SAMPLER:%.*]] = call [[SAMPLER_TY:ptr]] @__translate_sampler_initializer(i32 16)
+; CHECK: [[SAMPLER:%.*]] = call [[SAMPLER_TY:target\("spirv.Sampler"\)]] @__translate_sampler_initializer(i32 16)
                  %2 = OpImageSampleExplicitLod %v4float_t %sampled_image %v4float_1 None
 ; CHECK: = call spir_func <4 x float> @_Z11read_imagef16ocl_image2darray11ocl_samplerDv4_f([[IMG_TY]] %in_image, [[SAMPLER_TY]] [[SAMPLER]], <4 x float> {{<(float 1.000000e\+00(, )?)+>|splat \(float 1.000000e\+00\)}})
                  %3 = OpImageSampleExplicitLod %v4float_t %sampled_image %v4int_1 None

--- a/modules/compiler/spirv-ll/test/spvasm/op_constant_sampler_3d.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_constant_sampler_3d.spvasm
@@ -16,8 +16,7 @@
 
 ; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: %if online-spirv-as %{ spirv-val %spv_file_s %}
-; RUN: %pp-llvm-ver -o %t < %s --llvm-ver %LLVMVER
-; RUN: spirv-ll-tool -a OpenCL -b 64 -c Sampled1D -c LiteralSampler %spv_file_s | FileCheck %t
+; RUN: spirv-ll-tool -a OpenCL -b 64 -c Sampled1D -c LiteralSampler %spv_file_s | FileCheck %s
                       OpCapability Kernel
                       OpCapability Addresses
                       OpCapability Sampled1D
@@ -44,12 +43,10 @@
 
   %constant_sampler = OpFunction %void_t None %sampler_fn_t
           %in_image = OpFunctionParameter %image3d_ro_t
-; CHECK-GE17: define spir_kernel void @constant_sampler([[IMG_TY:target\("spirv.Image", void, 2, 0, 0, 0, 0, 0, 0\)]] noundef %in_image)
-; CHECK-LT17: define spir_kernel void @constant_sampler([[IMG_TY:ptr addrspace\(1\)]] noundef %in_image)
+; CHECK: define spir_kernel void @constant_sampler([[IMG_TY:target\("spirv.Image", void, 2, 0, 0, 0, 0, 0, 0\)]] noundef %in_image)
                  %1 = OpLabel
      %sampled_image = OpSampledImage %sampled_image_t %in_image %const_sampler
-; CHECK-GE17: [[SAMPLER:%.*]] = call [[SAMPLER_TY:target\("spirv.Sampler"\)]] @__translate_sampler_initializer(i32 16)
-; CHECK-LT17: [[SAMPLER:%.*]] = call [[SAMPLER_TY:ptr]] @__translate_sampler_initializer(i32 16)
+; CHECK: [[SAMPLER:%.*]] = call [[SAMPLER_TY:target\("spirv.Sampler"\)]] @__translate_sampler_initializer(i32 16)
                  %2 = OpImageSampleExplicitLod %v4float_t %sampled_image %v4float_1 None
 ; CHECK: = call spir_func <4 x float> @_Z11read_imagef11ocl_image3d11ocl_samplerDv4_f([[IMG_TY]] %in_image, [[SAMPLER_TY]] [[SAMPLER]], <4 x float> {{<(float 1.000000e\+00(, )?)+>|splat \(float 1.000000e\+00\)}})
                  %3 = OpImageSampleExplicitLod %v4float_t %sampled_image %v4int_1 None

--- a/modules/compiler/spirv-ll/test/spvasm/op_global_invocation_id.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_global_invocation_id.spvasm
@@ -16,8 +16,7 @@
 
 ; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: %if online-spirv-as %{ spirv-val %spv_file_s %}
-; RUN: %pp-llvm-ver -o %t < %s --llvm-ver %LLVMVER
-; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %t
+; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
                OpCapability Kernel
                OpCapability Addresses
                OpCapability Int64
@@ -49,5 +48,4 @@
 
 ; CHECK: declare spir_func i64 @_Z13get_global_idj(i32) [[ATTRS:#[0-9]+]]
 
-; CHECK-GE16: attributes [[ATTRS]] = { nounwind memory(read) }
-; CHECK-LT16: attributes [[ATTRS]] = { nounwind readonly }
+; CHECK: attributes [[ATTRS]] = { nounwind memory(read) }

--- a/modules/compiler/spirv-ll/test/spvasm/op_group_async_copy_double.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_group_async_copy_double.spvasm
@@ -16,8 +16,7 @@
 
 ; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: %if online-spirv-as %{ spirv-val %spv_file_s %}
-; RUN: %pp-llvm-ver -o %t < %s --llvm-ver %LLVMVER
-; RUN: spirv-ll-tool -a OpenCL -b 64 -c Addresses -c Float64 %spv_file_s | FileCheck %t
+; RUN: spirv-ll-tool -a OpenCL -b 64 -c Addresses -c Float64 %spv_file_s | FileCheck %s
                OpCapability Addresses
                OpCapability Kernel
                OpCapability Int64
@@ -56,10 +55,8 @@
                OpFunctionEnd
 ; CHECK: ; ModuleID = '{{.*}}'
 ; CHECK: define spir_kernel void @async_copy(ptr addrspace(1) noundef %in, ptr addrspace(3) noundef %out, i64 noundef %size)
-; CHECK-GE17: [[EVENT_VAR:%.*]] = alloca [[EVENT_TY:target\("spirv.Event"\)]]
-; CHECK-LT17: [[EVENT_VAR:%.*]] = alloca [[EVENT_TY:ptr]]
-; CHECK-GE17: [[EVENT:%.*]] = call spir_func [[EVENT_TY]] @_Z29async_work_group_strided_copyPU3AS1dPU3AS3Kdmm9ocl_event(ptr addrspace(1) %in, ptr addrspace(3) %out, i64 %size, i64 1, [[EVENT_TY]] zeroinitializer)
-; CHECK-LT17: [[EVENT:%.*]] = call spir_func [[EVENT_TY]] @_Z29async_work_group_strided_copyPU3AS1dPU3AS3Kdmm9ocl_event(ptr addrspace(1) %in, ptr addrspace(3) %out, i64 %size, i64 1, [[EVENT_TY]] null)
+; CHECK: [[EVENT_VAR:%.*]] = alloca [[EVENT_TY:target\("spirv.Event"\)]]
+; CHECK: [[EVENT:%.*]] = call spir_func [[EVENT_TY]] @_Z29async_work_group_strided_copyPU3AS1dPU3AS3Kdmm9ocl_event(ptr addrspace(1) %in, ptr addrspace(3) %out, i64 %size, i64 1, [[EVENT_TY]] zeroinitializer)
 ; CHECK: store [[EVENT_TY]] [[EVENT]], ptr [[EVENT_VAR]] 
 ; CHECK: call spir_func void @_Z17wait_group_eventsiP9ocl_event(i32 1, ptr [[EVENT_VAR]])
 ; CHECK: ret void

--- a/modules/compiler/spirv-ll/test/spvasm/op_group_async_copy_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_group_async_copy_float.spvasm
@@ -16,8 +16,7 @@
 
 ; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: %if online-spirv-as %{ spirv-val %spv_file_s %}
-; RUN: %pp-llvm-ver -o %t < %s --llvm-ver %LLVMVER
-; RUN: spirv-ll-tool -a OpenCL -b 64 -c Addresses %spv_file_s | FileCheck %t
+; RUN: spirv-ll-tool -a OpenCL -b 64 -c Addresses %spv_file_s | FileCheck %s
                OpCapability Addresses
                OpCapability Kernel
                OpCapability Int64
@@ -55,10 +54,8 @@
                OpFunctionEnd
 ; CHECK: ; ModuleID = '{{.*}}'
 ; CHECK: define spir_kernel void @async_copy(ptr addrspace(1) noundef %in, ptr addrspace(3) noundef %out, i64 noundef %size)
-; CHECK-GE17: [[EVENT_VAR:%.*]] = alloca [[EVENT_TY:target\("spirv.Event"\)]]
-; CHECK-LT17: [[EVENT_VAR:%.*]] = alloca [[EVENT_TY:ptr]]
-; CHECK-GE17: [[EVENT:%.*]] = call spir_func [[EVENT_TY]] @_Z29async_work_group_strided_copyPU3AS1fPU3AS3Kfmm9ocl_event(ptr addrspace(1) %in, ptr addrspace(3) %out, i64 %size, i64 1, [[EVENT_TY]] zeroinitializer)
-; CHECK-LT17: [[EVENT:%.*]] = call spir_func [[EVENT_TY]] @_Z29async_work_group_strided_copyPU3AS1fPU3AS3Kfmm9ocl_event(ptr addrspace(1) %in, ptr addrspace(3) %out, i64 %size, i64 1, [[EVENT_TY]] null)
+; CHECK: [[EVENT_VAR:%.*]] = alloca [[EVENT_TY:target\("spirv.Event"\)]]
+; CHECK: [[EVENT:%.*]] = call spir_func [[EVENT_TY]] @_Z29async_work_group_strided_copyPU3AS1fPU3AS3Kfmm9ocl_event(ptr addrspace(1) %in, ptr addrspace(3) %out, i64 %size, i64 1, [[EVENT_TY]] zeroinitializer)
 ; CHECK: store [[EVENT_TY]] [[EVENT]], ptr [[EVENT_VAR]]
 ; CHECK: call spir_func void @_Z17wait_group_eventsiP9ocl_event(i32 1, ptr [[EVENT_VAR]])
 ; CHECK: ret void

--- a/modules/compiler/spirv-ll/test/spvasm/op_group_async_copy_int.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_group_async_copy_int.spvasm
@@ -16,8 +16,7 @@
 
 ; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: %if online-spirv-as %{ spirv-val %spv_file_s %}
-; RUN: %pp-llvm-ver -o %t < %s --llvm-ver %LLVMVER
-; RUN: spirv-ll-tool -a OpenCL -b 64 -c Addresses %spv_file_s | FileCheck %t
+; RUN: spirv-ll-tool -a OpenCL -b 64 -c Addresses %spv_file_s | FileCheck %s
                OpCapability Addresses
                OpCapability Kernel
                OpCapability Int64
@@ -54,10 +53,8 @@
                OpFunctionEnd
 ; CHECK: ; ModuleID = '{{.*}}'
 ; CHECK: define spir_kernel void @async_copy(ptr addrspace(1) noundef %in, ptr addrspace(3) noundef %out, i64 noundef %size)
-; CHECK-GE17: [[EVENT_VAR:%.*]] = alloca [[EVENT_TY:target\("spirv.Event"\)]]
-; CHECK-LT17: [[EVENT_VAR:%.*]] = alloca [[EVENT_TY:ptr]]
-; CHECK-GE17: [[EVENT:%.*]] = call spir_func [[EVENT_TY]] @_Z29async_work_group_strided_copyPU3AS1jPU3AS3Kjmm9ocl_event(ptr addrspace(1) %in, ptr addrspace(3) %out, i64 %size, i64 1, [[EVENT_TY]] zeroinitializer)
-; CHECK-LT17: [[EVENT:%.*]] = call spir_func [[EVENT_TY]] @_Z29async_work_group_strided_copyPU3AS1jPU3AS3Kjmm9ocl_event(ptr addrspace(1) %in, ptr addrspace(3) %out, i64 %size, i64 1, [[EVENT_TY]] null)
+; CHECK: [[EVENT_VAR:%.*]] = alloca [[EVENT_TY:target\("spirv.Event"\)]]
+; CHECK: [[EVENT:%.*]] = call spir_func [[EVENT_TY]] @_Z29async_work_group_strided_copyPU3AS1jPU3AS3Kjmm9ocl_event(ptr addrspace(1) %in, ptr addrspace(3) %out, i64 %size, i64 1, [[EVENT_TY]] zeroinitializer)
 ; CHECK: store [[EVENT_TY]] [[EVENT]], ptr [[EVENT_VAR]]
 ; CHECK: call spir_func void @_Z17wait_group_eventsiP9ocl_event(i32 1, ptr [[EVENT_VAR]])
 ; CHECK: ret void

--- a/modules/compiler/spirv-ll/test/spvasm/op_group_async_copy_long.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_group_async_copy_long.spvasm
@@ -16,8 +16,7 @@
 
 ; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: %if online-spirv-as %{ spirv-val %spv_file_s %}
-; RUN: %pp-llvm-ver -o %t < %s --llvm-ver %LLVMVER
-; RUN: spirv-ll-tool -a OpenCL -b 64 -c Addresses %spv_file_s | FileCheck %t
+; RUN: spirv-ll-tool -a OpenCL -b 64 -c Addresses %spv_file_s | FileCheck %s
                OpCapability Addresses
                OpCapability Kernel
                OpCapability Int64
@@ -54,10 +53,8 @@
                OpFunctionEnd
 ; CHECK: ; ModuleID = '{{.*}}'
 ; CHECK: define spir_kernel void @async_copy(ptr addrspace(1) noundef %in, ptr addrspace(3) noundef %out, i64 noundef %size)
-; CHECK-GE17: [[EVENT_VAR:%.*]] = alloca [[EVENT_TY:target\("spirv.Event"\)]]
-; CHECK-LT17: [[EVENT_VAR:%.*]] = alloca [[EVENT_TY:ptr]]
-; CHECK-GE17: [[EVENT:%.*]] = call spir_func [[EVENT_TY]] @_Z29async_work_group_strided_copyPU3AS1mPU3AS3Kmmm9ocl_event(ptr addrspace(1) %in, ptr addrspace(3) %out, i64 %size, i64 1, [[EVENT_TY]] zeroinitializer)
-; CHECK-LT17: [[EVENT:%.*]] = call spir_func [[EVENT_TY]] @_Z29async_work_group_strided_copyPU3AS1mPU3AS3Kmmm9ocl_event(ptr addrspace(1) %in, ptr addrspace(3) %out, i64 %size, i64 1, [[EVENT_TY]] null)
+; CHECK: [[EVENT_VAR:%.*]] = alloca [[EVENT_TY:target\("spirv.Event"\)]]
+; CHECK: [[EVENT:%.*]] = call spir_func [[EVENT_TY]] @_Z29async_work_group_strided_copyPU3AS1mPU3AS3Kmmm9ocl_event(ptr addrspace(1) %in, ptr addrspace(3) %out, i64 %size, i64 1, [[EVENT_TY]] zeroinitializer)
 ; CHECK: store [[EVENT_TY]] [[EVENT]], ptr [[EVENT_VAR]]
 ; CHECK: call spir_func void @_Z17wait_group_eventsiP9ocl_event(i32 1, ptr [[EVENT_VAR]])
 ; CHECK: ret void

--- a/modules/compiler/spirv-ll/test/spvasm/op_group_async_copy_vec_float.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_group_async_copy_vec_float.spvasm
@@ -16,8 +16,7 @@
 
 ; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: %if online-spirv-as %{ spirv-val %spv_file_s %}
-; RUN: %pp-llvm-ver -o %t < %s --llvm-ver %LLVMVER
-; RUN: spirv-ll-tool -a OpenCL -b 64 -c Addresses %spv_file_s | FileCheck %t
+; RUN: spirv-ll-tool -a OpenCL -b 64 -c Addresses %spv_file_s | FileCheck %s
                OpCapability Addresses
                OpCapability Kernel
                OpCapability Int64
@@ -56,10 +55,8 @@
                OpFunctionEnd
 ; CHECK: ; ModuleID = '{{.*}}'
 ; CHECK: define spir_kernel void @async_copy(ptr addrspace(1) noundef %in, ptr addrspace(3) noundef %out, i64 noundef %size)
-; CHECK-GE17: [[EVENT_VAR:%.*]] = alloca [[EVENT_TY:target\("spirv.Event"\)]]
-; CHECK-LT17: [[EVENT_VAR:%.*]] = alloca [[EVENT_TY:ptr]]
-; CHECK-GE17: [[EVENT:%.*]] = call spir_func [[EVENT_TY]] @_Z29async_work_group_strided_copyPU3AS1Dv3_fPU3AS3KS_mm9ocl_event(ptr addrspace(1) %in, ptr addrspace(3) %out, i64 %size, i64 1, [[EVENT_TY]] zeroinitializer)
-; CHECK-LT17: [[EVENT:%.*]] = call spir_func [[EVENT_TY]] @_Z29async_work_group_strided_copyPU3AS1Dv3_fPU3AS3KS_mm9ocl_event(ptr addrspace(1) %in, ptr addrspace(3) %out, i64 %size, i64 1, [[EVENT_TY]] null)
+; CHECK: [[EVENT_VAR:%.*]] = alloca [[EVENT_TY:target\("spirv.Event"\)]]
+; CHECK: [[EVENT:%.*]] = call spir_func [[EVENT_TY]] @_Z29async_work_group_strided_copyPU3AS1Dv3_fPU3AS3KS_mm9ocl_event(ptr addrspace(1) %in, ptr addrspace(3) %out, i64 %size, i64 1, [[EVENT_TY]] zeroinitializer)
 ; CHECK: store [[EVENT_TY]] [[EVENT]], ptr [[EVENT_VAR]]
 ; CHECK: call spir_func void @_Z17wait_group_eventsiP9ocl_event(i32 1, ptr [[EVENT_VAR]])
 ; CHECK: ret void

--- a/modules/compiler/spirv-ll/test/spvasm/op_group_async_copy_vec_int.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_group_async_copy_vec_int.spvasm
@@ -16,8 +16,7 @@
 
 ; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: %if online-spirv-as %{ spirv-val %spv_file_s %}
-; RUN: %pp-llvm-ver -o %t < %s --llvm-ver %LLVMVER
-; RUN: spirv-ll-tool -a OpenCL -b 64 -c Addresses %spv_file_s | FileCheck %t
+; RUN: spirv-ll-tool -a OpenCL -b 64 -c Addresses %spv_file_s | FileCheck %s
                OpCapability Addresses
                OpCapability Kernel
                OpCapability Int64
@@ -55,10 +54,8 @@
                OpFunctionEnd
 ; CHECK: ; ModuleID = '{{.*}}'
 ; CHECK: define spir_kernel void @async_copy(ptr addrspace(1) noundef %in, ptr addrspace(3) noundef %out, i64 noundef %size)
-; CHECK-GE17: [[EVENT_VAR:%.*]] = alloca [[EVENT_TY:target\("spirv.Event"\)]]
-; CHECK-LT17: [[EVENT_VAR:%.*]] = alloca [[EVENT_TY:ptr]]
-; CHECK-GE17: [[EVENT:%.*]] = call spir_func [[EVENT_TY]] @_Z29async_work_group_strided_copyPU3AS1Dv3_jPU3AS3KS_mm9ocl_event(ptr addrspace(1) %in, ptr addrspace(3) %out, i64 %size, i64 1, [[EVENT_TY]] zeroinitializer)
-; CHECK-LT17: [[EVENT:%.*]] = call spir_func [[EVENT_TY]] @_Z29async_work_group_strided_copyPU3AS1Dv3_jPU3AS3KS_mm9ocl_event(ptr addrspace(1) %in, ptr addrspace(3) %out, i64 %size, i64 1, [[EVENT_TY]] null)
+; CHECK: [[EVENT_VAR:%.*]] = alloca [[EVENT_TY:target\("spirv.Event"\)]]
+; CHECK: [[EVENT:%.*]] = call spir_func [[EVENT_TY]] @_Z29async_work_group_strided_copyPU3AS1Dv3_jPU3AS3KS_mm9ocl_event(ptr addrspace(1) %in, ptr addrspace(3) %out, i64 %size, i64 1, [[EVENT_TY]] zeroinitializer)
 ; CHECK: store [[EVENT_TY]] [[EVENT]], ptr [[EVENT_VAR]]
 ; CHECK: call spir_func void @_Z17wait_group_eventsiP9ocl_event(i32 1, ptr [[EVENT_VAR]])
 ; CHECK: ret void

--- a/modules/compiler/spirv-ll/test/spvasm/op_image.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image.spvasm
@@ -16,8 +16,7 @@
 
 ; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: %if online-spirv-as %{ spirv-val %spv_file_s %}
-; RUN: %pp-llvm-ver -o %t < %s --llvm-ver %LLVMVER
-; RUN: spirv-ll-tool -a OpenCL -b 64 -c ImageBasic -c Sampled1D %spv_file_s | FileCheck %t
+; RUN: spirv-ll-tool -a OpenCL -b 64 -c ImageBasic -c Sampled1D %spv_file_s | FileCheck %s
                 OpCapability Kernel
                 OpCapability Addresses
                 OpCapability ImageBasic
@@ -46,8 +45,7 @@
            %4 = OpImageRead %float4_t %get_image %int_0
                 OpReturn
                 OpFunctionEnd
-; CHECK-GE17: define spir_kernel void @image1d([[IMG_TY:target\("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0\)]] noundef %image, target("spirv.Sampler") noundef{{( %0)?}})
-; CHECK-LT17: define spir_kernel void @image1d([[IMG_TY:ptr addrspace\(1\)]] noundef %image, ptr noundef{{( %0)?}})
+; CHECK: define spir_kernel void @image1d([[IMG_TY:target\("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0\)]] noundef %image, target("spirv.Sampler") noundef{{( %0)?}})
 ; CHECK: = call spir_func <4 x i32> @_Z12read_imageui11ocl_image1di([[IMG_TY]] %image, i32 0)
 ; CHECK: = call spir_func <4 x float> @_Z11read_imagef11ocl_image1di([[IMG_TY]] %image, i32 0)
 ; CHECK: ret void

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_query_format_1d.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_query_format_1d.spvasm
@@ -16,8 +16,7 @@
 
 ; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: %if online-spirv-as %{ spirv-val %spv_file_s %}
-; RUN: %pp-llvm-ver -o %t < %s --llvm-ver %LLVMVER
-; RUN: spirv-ll-tool -a OpenCL -b 64 -c Sampled1D %spv_file_s | FileCheck %t
+; RUN: spirv-ll-tool -a OpenCL -b 64 -c Sampled1D %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses
                         OpCapability Sampled1D
@@ -35,8 +34,7 @@
 ; All functions
              %image1d = OpFunction %void_t None %query_format_fn_t
             %in_image = OpFunctionParameter %image1d_t
-; CHECK-GE17: define spir_kernel void @image1d([[TY:target\("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0\)]] noundef %in_image)
-; CHECK-LT17: define spir_kernel void @image1d([[TY:ptr addrspace\(1\)]] noundef %in_image)
+; CHECK: define spir_kernel void @image1d([[TY:target\("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0\)]] noundef %in_image)
                    %1 = OpLabel
                    %2 = OpImageQueryFormat %int_t %in_image
 ; CHECK: = call spir_func i32 @_Z27get_image_channel_data_type11ocl_image1d([[TY]] %in_image)

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_query_format_1d_array.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_query_format_1d_array.spvasm
@@ -16,8 +16,7 @@
 
 ; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: %if online-spirv-as %{ spirv-val %spv_file_s %}
-; RUN: %pp-llvm-ver -o %t < %s --llvm-ver %LLVMVER
-; RUN: spirv-ll-tool -a OpenCL -b 64 -c Sampled1D %spv_file_s | FileCheck %t
+; RUN: spirv-ll-tool -a OpenCL -b 64 -c Sampled1D %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses
                         OpCapability Sampled1D
@@ -35,8 +34,7 @@
 ; All functions
        %image1d_array = OpFunction %void_t None %query_format_fn_t
             %in_image = OpFunctionParameter %image1d_array_t
-; CHECK-GE17: define spir_kernel void @image1d_array([[TY:target\("spirv.Image", void, 0, 0, 1, 0, 0, 0, 0\)]] noundef %in_image)
-; CHECK-LT17: define spir_kernel void @image1d_array([[TY:ptr addrspace\(1\)]] noundef %in_image)
+; CHECK: define spir_kernel void @image1d_array([[TY:target\("spirv.Image", void, 0, 0, 1, 0, 0, 0, 0\)]] noundef %in_image)
                    %1 = OpLabel
                    %2 = OpImageQueryFormat %int_t %in_image
 ; CHECK: = call spir_func i32 @_Z27get_image_channel_data_type16ocl_image1darray([[TY]] %in_image)

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_query_format_1d_buffer.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_query_format_1d_buffer.spvasm
@@ -16,8 +16,7 @@
 
 ; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: %if online-spirv-as %{ spirv-val %spv_file_s %}
-; RUN: %pp-llvm-ver -o %t < %s --llvm-ver %LLVMVER
-; RUN: spirv-ll-tool -a OpenCL -b 64 -c SampledBuffer %spv_file_s | FileCheck %t
+; RUN: spirv-ll-tool -a OpenCL -b 64 -c SampledBuffer %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses
                         OpCapability SampledBuffer
@@ -35,8 +34,7 @@
 ; All functions
       %image1d_buffer = OpFunction %void_t None %query_format_fn_t
             %in_image = OpFunctionParameter %image1d_buffer_t
-; CHECK-GE17: define spir_kernel void @image1d_buffer([[TY:target\("spirv.Image", void, 5, 0, 0, 0, 0, 0, 0\)]] noundef %in_image)
-; CHECK-LT17: define spir_kernel void @image1d_buffer([[TY:ptr addrspace\(1\)]] noundef %in_image)
+; CHECK: define spir_kernel void @image1d_buffer([[TY:target\("spirv.Image", void, 5, 0, 0, 0, 0, 0, 0\)]] noundef %in_image)
                    %1 = OpLabel
                    %2 = OpImageQueryFormat %int_t %in_image
 ; CHECK: = call spir_func i32 @_Z27get_image_channel_data_type17ocl_image1dbuffer([[TY]] %in_image)

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_query_format_2d.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_query_format_2d.spvasm
@@ -16,8 +16,7 @@
 
 ; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: %if online-spirv-as %{ spirv-val %spv_file_s %}
-; RUN: %pp-llvm-ver -o %t < %s --llvm-ver %LLVMVER
-; RUN: spirv-ll-tool -a OpenCL -b 64 -c Sampled1D %spv_file_s | FileCheck %t
+; RUN: spirv-ll-tool -a OpenCL -b 64 -c Sampled1D %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses
                         OpCapability Sampled1D
@@ -35,8 +34,7 @@
 ; All functions
              %image2d = OpFunction %void_t None %query_format_fn_t
             %in_image = OpFunctionParameter %image2d_t
-; CHECK-GE17: define spir_kernel void @image2d([[TY:target\("spirv.Image", void, 1, 0, 0, 0, 0, 0, 0\)]] noundef %in_image)
-; CHECK-LT17: define spir_kernel void @image2d([[TY:ptr addrspace\(1\)]] noundef %in_image)
+; CHECK: define spir_kernel void @image2d([[TY:target\("spirv.Image", void, 1, 0, 0, 0, 0, 0, 0\)]] noundef %in_image)
                    %1 = OpLabel
                    %2 = OpImageQueryFormat %int_t %in_image
 ; CHECK: = call spir_func i32 @_Z27get_image_channel_data_type11ocl_image2d([[TY]] %in_image)

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_query_format_2d_array.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_query_format_2d_array.spvasm
@@ -16,8 +16,7 @@
 
 ; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: %if online-spirv-as %{ spirv-val %spv_file_s %}
-; RUN: %pp-llvm-ver -o %t < %s --llvm-ver %LLVMVER
-; RUN: spirv-ll-tool -a OpenCL -b 64 -c Sampled1D %spv_file_s | FileCheck %t
+; RUN: spirv-ll-tool -a OpenCL -b 64 -c Sampled1D %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses
                         OpCapability Sampled1D
@@ -35,8 +34,7 @@
 ; All functions
        %image2d_array = OpFunction %void_t None %query_format_fn_t
             %in_image = OpFunctionParameter %image2d_array_t
-; CHECK-GE17: define spir_kernel void @image2d_array([[TY:target\("spirv.Image", void, 1, 0, 1, 0, 0, 0, 0\)]] noundef %in_image)
-; CHECK-LT17: define spir_kernel void @image2d_array([[TY:ptr addrspace\(1\)]] noundef %in_image)
+; CHECK: define spir_kernel void @image2d_array([[TY:target\("spirv.Image", void, 1, 0, 1, 0, 0, 0, 0\)]] noundef %in_image)
                    %1 = OpLabel
                    %2 = OpImageQueryFormat %int_t %in_image
 ; CHECK: = call spir_func i32 @_Z27get_image_channel_data_type16ocl_image2darray([[TY]] %in_image)

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_query_format_3d.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_query_format_3d.spvasm
@@ -16,8 +16,7 @@
 
 ; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: %if online-spirv-as %{ spirv-val %spv_file_s %}
-; RUN: %pp-llvm-ver -o %t < %s --llvm-ver %LLVMVER
-; RUN: spirv-ll-tool -a OpenCL -b 64 -c Sampled1D %spv_file_s | FileCheck %t
+; RUN: spirv-ll-tool -a OpenCL -b 64 -c Sampled1D %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses
                         OpCapability Sampled1D
@@ -35,8 +34,7 @@
 ; All functions
              %image3d = OpFunction %void_t None %query_format_fn_t
             %in_image = OpFunctionParameter %image3d_t
-; CHECK-GE17: define spir_kernel void @image3d([[TY:target\("spirv.Image", void, 2, 0, 0, 0, 0, 0, 0\)]] noundef %in_image)
-; CHECK-LT17: define spir_kernel void @image3d([[TY:ptr addrspace\(1\)]] noundef %in_image)
+; CHECK: define spir_kernel void @image3d([[TY:target\("spirv.Image", void, 2, 0, 0, 0, 0, 0, 0\)]] noundef %in_image)
                    %1 = OpLabel
                    %2 = OpImageQueryFormat %int_t %in_image
 ; CHECK: = call spir_func i32 @_Z27get_image_channel_data_type11ocl_image3d([[TY]] %in_image)

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_query_order_1d.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_query_order_1d.spvasm
@@ -16,8 +16,7 @@
 
 ; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: %if online-spirv-as %{ spirv-val %spv_file_s %}
-; RUN: %pp-llvm-ver -o %t < %s --llvm-ver %LLVMVER
-; RUN: spirv-ll-tool -a OpenCL -b 64 -c Sampled1D %spv_file_s | FileCheck %t
+; RUN: spirv-ll-tool -a OpenCL -b 64 -c Sampled1D %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses
                         OpCapability Sampled1D
@@ -35,8 +34,7 @@
 ; All functions
              %image1d = OpFunction %void_t None %query_format_fn_t
             %in_image = OpFunctionParameter %image1d_t
-; CHECK-GE17: define spir_kernel void @image1d([[TY:target\("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0\)]] noundef %in_image)
-; CHECK-LT17: define spir_kernel void @image1d([[TY:ptr addrspace\(1\)]] noundef %in_image)
+; CHECK: define spir_kernel void @image1d([[TY:target\("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0\)]] noundef %in_image)
                    %1 = OpLabel
                    %2 = OpImageQueryOrder %int_t %in_image
 ; CHECK: = call spir_func i32 @_Z23get_image_channel_order11ocl_image1d([[TY]] %in_image)

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_query_order_1d_array.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_query_order_1d_array.spvasm
@@ -16,8 +16,7 @@
 
 ; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: %if online-spirv-as %{ spirv-val %spv_file_s %}
-; RUN: %pp-llvm-ver -o %t < %s --llvm-ver %LLVMVER
-; RUN: spirv-ll-tool -a OpenCL -b 64 -c Sampled1D %spv_file_s | FileCheck %t
+; RUN: spirv-ll-tool -a OpenCL -b 64 -c Sampled1D %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses
                         OpCapability Sampled1D
@@ -35,8 +34,7 @@
 ; All functions
        %image1d_array = OpFunction %void_t None %query_format_fn_t
             %in_image = OpFunctionParameter %image1d_array_t
-; CHECK-GE17: define spir_kernel void @image1d_array([[TY:target\("spirv.Image", void, 0, 0, 1, 0, 0, 0, 0\)]] noundef %in_image)
-; CHECK-LT17: define spir_kernel void @image1d_array([[TY:ptr addrspace\(1\)]] noundef %in_image)
+; CHECK: define spir_kernel void @image1d_array([[TY:target\("spirv.Image", void, 0, 0, 1, 0, 0, 0, 0\)]] noundef %in_image)
                    %1 = OpLabel
                    %2 = OpImageQueryOrder %int_t %in_image
 ; CHECK: = call spir_func i32 @_Z23get_image_channel_order16ocl_image1darray([[TY]] %in_image)

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_query_order_1d_buffer.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_query_order_1d_buffer.spvasm
@@ -16,8 +16,7 @@
 
 ; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: %if online-spirv-as %{ spirv-val %spv_file_s %}
-; RUN: %pp-llvm-ver -o %t < %s --llvm-ver %LLVMVER
-; RUN: spirv-ll-tool -a OpenCL -b 64 -c SampledBuffer %spv_file_s | FileCheck %t
+; RUN: spirv-ll-tool -a OpenCL -b 64 -c SampledBuffer %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses
                         OpCapability SampledBuffer
@@ -35,8 +34,7 @@
 ; All functions
       %image1d_buffer = OpFunction %void_t None %query_format_fn_t
             %in_image = OpFunctionParameter %image1d_buffer_t
-; CHECK-GE17: define spir_kernel void @image1d_buffer([[TY:target\("spirv.Image", void, 5, 0, 0, 0, 0, 0, 0\)]] noundef %in_image)
-; CHECK-LT17: define spir_kernel void @image1d_buffer([[TY:ptr addrspace\(1\)]] noundef %in_image)
+; CHECK: define spir_kernel void @image1d_buffer([[TY:target\("spirv.Image", void, 5, 0, 0, 0, 0, 0, 0\)]] noundef %in_image)
                    %1 = OpLabel
                    %2 = OpImageQueryOrder %int_t %in_image
 ; CHECK: = call spir_func i32 @_Z23get_image_channel_order17ocl_image1dbuffer([[TY]] %in_image)

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_query_order_2d.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_query_order_2d.spvasm
@@ -16,8 +16,7 @@
 
 ; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: %if online-spirv-as %{ spirv-val %spv_file_s %}
-; RUN: %pp-llvm-ver -o %t < %s --llvm-ver %LLVMVER
-; RUN: spirv-ll-tool -a OpenCL -b 64 -c Sampled1D %spv_file_s | FileCheck %t
+; RUN: spirv-ll-tool -a OpenCL -b 64 -c Sampled1D %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses
                         OpCapability Sampled1D
@@ -35,8 +34,7 @@
 ; All functions
              %image2d = OpFunction %void_t None %query_format_fn_t
             %in_image = OpFunctionParameter %image2d_t
-; CHECK-GE17: define spir_kernel void @image2d([[TY:target\("spirv.Image", void, 1, 0, 0, 0, 0, 0, 0\)]] noundef %in_image)
-; CHECK-LT17: define spir_kernel void @image2d([[TY:ptr addrspace\(1\)]] noundef %in_image)
+; CHECK: define spir_kernel void @image2d([[TY:target\("spirv.Image", void, 1, 0, 0, 0, 0, 0, 0\)]] noundef %in_image)
                    %1 = OpLabel
                    %2 = OpImageQueryOrder %int_t %in_image
 ; CHECK: = call spir_func i32 @_Z23get_image_channel_order11ocl_image2d([[TY]] %in_image)

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_query_order_2d_array.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_query_order_2d_array.spvasm
@@ -16,8 +16,7 @@
 
 ; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: %if online-spirv-as %{ spirv-val %spv_file_s %}
-; RUN: %pp-llvm-ver -o %t < %s --llvm-ver %LLVMVER
-; RUN: spirv-ll-tool -a OpenCL -b 64 -c Sampled1D %spv_file_s | FileCheck %t
+; RUN: spirv-ll-tool -a OpenCL -b 64 -c Sampled1D %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses
                         OpCapability Sampled1D
@@ -35,8 +34,7 @@
 ; All functions
        %image2d_array = OpFunction %void_t None %query_format_fn_t
             %in_image = OpFunctionParameter %image2d_array_t
-; CHECK-GE17: define spir_kernel void @image2d_array([[TY:target\("spirv.Image", void, 1, 0, 1, 0, 0, 0, 0\)]] noundef %in_image)
-; CHECK-LT17: define spir_kernel void @image2d_array([[TY:ptr addrspace\(1\)]] noundef %in_image)
+; CHECK: define spir_kernel void @image2d_array([[TY:target\("spirv.Image", void, 1, 0, 1, 0, 0, 0, 0\)]] noundef %in_image)
                    %1 = OpLabel
                    %2 = OpImageQueryOrder %int_t %in_image
 ; CHECK: = call spir_func i32 @_Z23get_image_channel_order16ocl_image2darray([[TY]] %in_image)

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_query_order_3d.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_query_order_3d.spvasm
@@ -16,8 +16,7 @@
 
 ; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: %if online-spirv-as %{ spirv-val %spv_file_s %}
-; RUN: %pp-llvm-ver -o %t < %s --llvm-ver %LLVMVER
-; RUN: spirv-ll-tool -a OpenCL -b 64 -c Sampled1D %spv_file_s | FileCheck %t
+; RUN: spirv-ll-tool -a OpenCL -b 64 -c Sampled1D %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses
                         OpCapability Sampled1D
@@ -35,8 +34,7 @@
 ; All functions
              %image3d = OpFunction %void_t None %query_format_fn_t
             %in_image = OpFunctionParameter %image3d_t
-; CHECK-GE17: define spir_kernel void @image3d([[TY:target\("spirv.Image", void, 2, 0, 0, 0, 0, 0, 0\)]] noundef %in_image)
-; CHECK-LT17: define spir_kernel void @image3d([[TY:ptr addrspace\(1\)]] noundef %in_image)
+; CHECK: define spir_kernel void @image3d([[TY:target\("spirv.Image", void, 2, 0, 0, 0, 0, 0, 0\)]] noundef %in_image)
                    %1 = OpLabel
                    %2 = OpImageQueryOrder %int_t %in_image
 ; CHECK: = call spir_func i32 @_Z23get_image_channel_order11ocl_image3d([[TY]] %in_image)

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_query_size_lod_1d.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_query_size_lod_1d.spvasm
@@ -16,8 +16,7 @@
 
 ; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: %if online-spirv-as %{ spirv-val %spv_file_s %}
-; RUN: %pp-llvm-ver -o %t < %s --llvm-ver %LLVMVER
-; RUN: spirv-ll-tool -a OpenCL -b 64 -c Sampled1D %spv_file_s | FileCheck %t
+; RUN: spirv-ll-tool -a OpenCL -b 64 -c Sampled1D %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses
                         OpCapability Sampled1D
@@ -36,8 +35,7 @@
 ; All functions
              %image1d = OpFunction %void_t None %query_size_fn_t
                %image = OpFunctionParameter %image1d_t
-; CHECK-GE17: define spir_kernel void @image1d([[IMG_TY:target\("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0\)]] noundef %image)
-; CHECK-LT17: define spir_kernel void @image1d([[IMG_TY:ptr addrspace\(1\)]] noundef %image)
+; CHECK: define spir_kernel void @image1d([[IMG_TY:target\("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0\)]] noundef %image)
                    %1 = OpLabel
                    %2 = OpImageQuerySizeLod %int_t %image %int_1
 ; CHECK: = call spir_func i32 @_Z15get_image_width11ocl_image1d([[IMG_TY]] %image)

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_query_size_lod_1d_array.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_query_size_lod_1d_array.spvasm
@@ -16,8 +16,7 @@
 
 ; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: %if online-spirv-as %{ spirv-val %spv_file_s %}
-; RUN: %pp-llvm-ver -o %t < %s --llvm-ver %LLVMVER
-; RUN: spirv-ll-tool -a OpenCL -b 64 -c Sampled1D %spv_file_s | FileCheck %t
+; RUN: spirv-ll-tool -a OpenCL -b 64 -c Sampled1D %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses
                         OpCapability Sampled1D
@@ -37,8 +36,7 @@
 ; All functions
        %image1d_array = OpFunction %void_t None %query_size_fn_t
                %image = OpFunctionParameter %image1d_array_t
-; CHECK-GE17: define spir_kernel void @image1d_array([[IMG_TY:target\("spirv.Image", void, 0, 0, 1, 0, 0, 0, 0\)]] noundef %image)
-; CHECK-LT17: define spir_kernel void @image1d_array([[IMG_TY:ptr addrspace\(1\)]] noundef %image)
+; CHECK: define spir_kernel void @image1d_array([[IMG_TY:target\("spirv.Image", void, 0, 0, 1, 0, 0, 0, 0\)]] noundef %image)
                    %1 = OpLabel
                    %2 = OpImageQuerySizeLod %v2int_t %image %int_1
 ; CHECK: [[size_result:%.*]] = call spir_func [[bitness:.*]] @_Z20get_image_array_size16ocl_image1darray([[IMG_TY]] %image)

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_query_size_lod_1d_array_32bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_query_size_lod_1d_array_32bit.spvasm
@@ -16,8 +16,7 @@
 
 ; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: %if online-spirv-as %{ spirv-val %spv_file_s %}
-; RUN: %pp-llvm-ver -o %t < %s --llvm-ver %LLVMVER
-; RUN: spirv-ll-tool -a OpenCL -b 32 -c Sampled1D %spv_file_s | FileCheck %t
+; RUN: spirv-ll-tool -a OpenCL -b 32 -c Sampled1D %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses
                         OpCapability Sampled1D
@@ -37,8 +36,7 @@
 ; All functions
        %image1d_array = OpFunction %void_t None %query_size_fn_t
                %image = OpFunctionParameter %image1d_array_t
-; CHECK-GE17: define spir_kernel void @image1d_array([[IMG_TY:target\("spirv.Image", void, 0, 0, 1, 0, 0, 0, 0\)]] noundef %image)
-; CHECK-LT17: define spir_kernel void @image1d_array([[IMG_TY:ptr addrspace\(1\)]] noundef %image)
+; CHECK: define spir_kernel void @image1d_array([[IMG_TY:target\("spirv.Image", void, 0, 0, 1, 0, 0, 0, 0\)]] noundef %image)
                    %1 = OpLabel
                    %2 = OpImageQuerySizeLod %v2int_t %image %int_1
 ; CHECK: [[size_result:%.*]] = call spir_func i32 @_Z20get_image_array_size16ocl_image1darray([[IMG_TY]] %image)

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_query_size_lod_2d.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_query_size_lod_2d.spvasm
@@ -16,8 +16,7 @@
 
 ; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: %if online-spirv-as %{ spirv-val %spv_file_s %}
-; RUN: %pp-llvm-ver -o %t < %s --llvm-ver %LLVMVER
-; RUN: spirv-ll-tool -a OpenCL -b 64 -c SampledBuffer %spv_file_s | FileCheck %t
+; RUN: spirv-ll-tool -a OpenCL -b 64 -c SampledBuffer %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses
                         OpCapability SampledBuffer
@@ -37,8 +36,7 @@
 ; All functions
              %image2d = OpFunction %void_t None %query_size_fn_t
                %image = OpFunctionParameter %image2d_t
-; CHECK-GE17: define spir_kernel void @image2d([[IMG_TY:target\("spirv.Image", void, 1, 0, 0, 0, 0, 0, 0\)]] noundef %image)
-; CHECK-LT17: define spir_kernel void @image2d([[IMG_TY:ptr addrspace\(1\)]] noundef %image)
+; CHECK: define spir_kernel void @image2d([[IMG_TY:target\("spirv.Image", void, 1, 0, 0, 0, 0, 0, 0\)]] noundef %image)
                    %1 = OpLabel
                    %2 = OpImageQuerySizeLod %v2int_t %image %int_1
 ; CHECK: [[width_result:%.*]] = call spir_func i32 @_Z15get_image_width11ocl_image2d([[IMG_TY]] %image)

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_query_size_lod_2d_array.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_query_size_lod_2d_array.spvasm
@@ -16,8 +16,7 @@
 
 ; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: %if online-spirv-as %{ spirv-val %spv_file_s %}
-; RUN: %pp-llvm-ver -o %t < %s --llvm-ver %LLVMVER
-; RUN: spirv-ll-tool -a OpenCL -b 64 -c SampledBuffer %spv_file_s | FileCheck %t
+; RUN: spirv-ll-tool -a OpenCL -b 64 -c SampledBuffer %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses
                         OpCapability SampledBuffer
@@ -37,8 +36,7 @@
 ; All functions
        %image2d_array = OpFunction %void_t None %query_size_fn_t
                %image = OpFunctionParameter %image2d_array_t
-; CHECK-GE17: define spir_kernel void @image2d_array([[IMG_TY:target\("spirv.Image", void, 1, 0, 1, 0, 0, 0, 0\)]] noundef %image)
-; CHECK-LT17: define spir_kernel void @image2d_array([[IMG_TY:ptr addrspace\(1\)]] noundef %image)
+; CHECK: define spir_kernel void @image2d_array([[IMG_TY:target\("spirv.Image", void, 1, 0, 1, 0, 0, 0, 0\)]] noundef %image)
                    %1 = OpLabel
                    %2 = OpImageQuerySizeLod %v3int_t %image %int_1
 ; CHECK: [[size_result:%.*]] = call spir_func [[bitness:.*]] @_Z20get_image_array_size16ocl_image2darray([[IMG_TY]] %image)

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_query_size_lod_2d_array_32bit.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_query_size_lod_2d_array_32bit.spvasm
@@ -16,8 +16,7 @@
 
 ; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: %if online-spirv-as %{ spirv-val %spv_file_s %}
-; RUN: %pp-llvm-ver -o %t < %s --llvm-ver %LLVMVER
-; RUN: spirv-ll-tool -a OpenCL -b 32 -c SampledBuffer %spv_file_s | FileCheck %t
+; RUN: spirv-ll-tool -a OpenCL -b 32 -c SampledBuffer %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses
                         OpCapability SampledBuffer
@@ -37,8 +36,7 @@
 ; All functions
        %image2d_array = OpFunction %void_t None %query_size_fn_t
                %image = OpFunctionParameter %image2d_array_t
-; CHECK-GE17: define spir_kernel void @image2d_array([[IMG_TY:target\("spirv.Image", void, 1, 0, 1, 0, 0, 0, 0\)]] noundef %image)
-; CHECK-LT17: define spir_kernel void @image2d_array([[IMG_TY:ptr addrspace\(1\)]] noundef %image)
+; CHECK: define spir_kernel void @image2d_array([[IMG_TY:target\("spirv.Image", void, 1, 0, 1, 0, 0, 0, 0\)]] noundef %image)
                    %1 = OpLabel
                    %2 = OpImageQuerySizeLod %v3int_t %image %int_1
 ; CHECK: [[size_result:%.*]] = call spir_func i32 @_Z20get_image_array_size16ocl_image2darray([[IMG_TY]] %image)

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_query_size_lod_3d.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_query_size_lod_3d.spvasm
@@ -16,8 +16,7 @@
 
 ; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: %if online-spirv-as %{ spirv-val %spv_file_s %}
-; RUN: %pp-llvm-ver -o %t < %s --llvm-ver %LLVMVER
-; RUN: spirv-ll-tool -a OpenCL -b 64 -c Sampled1D %spv_file_s | FileCheck %t
+; RUN: spirv-ll-tool -a OpenCL -b 64 -c Sampled1D %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses
                         OpCapability Sampled1D
@@ -37,8 +36,7 @@
 ; All functions
              %image3d = OpFunction %void_t None %query_size_fn_t
                %image = OpFunctionParameter %image3d_t
-; CHECK-GE17: define spir_kernel void @image3d([[IMG_TY:target\("spirv.Image", void, 2, 0, 0, 0, 0, 0, 0\)]] noundef %image)
-; CHECK-LT17: define spir_kernel void @image3d([[IMG_TY:ptr addrspace\(1\)]] noundef %image)
+; CHECK: define spir_kernel void @image3d([[IMG_TY:target\("spirv.Image", void, 2, 0, 0, 0, 0, 0, 0\)]] noundef %image)
                    %1 = OpLabel
                    %2 = OpImageQuerySizeLod %v3int_t %image %int_1
 ; CHECK: [[width_result:%.*]] = call spir_func i32 @_Z15get_image_width11ocl_image3d([[IMG_TY]] %image)

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_read_1d.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_read_1d.spvasm
@@ -16,8 +16,7 @@
 
 ; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: %if online-spirv-as %{ spirv-val %spv_file_s %}
-; RUN: %pp-llvm-ver -o %t < %s --llvm-ver %LLVMVER
-; RUN: spirv-ll-tool -a OpenCL -b 64 -c ImageBasic -c Sampled1D %spv_file_s | FileCheck %t
+; RUN: spirv-ll-tool -a OpenCL -b 64 -c ImageBasic -c Sampled1D %spv_file_s | FileCheck %s
                 OpCapability Kernel
                 OpCapability Addresses
                 OpCapability ImageBasic
@@ -36,8 +35,7 @@
       %uint_0 = OpConstant %uint_t 0
      %image1d = OpFunction %void_t None %foo_t
        %image = OpFunctionParameter %image1d_t
-; CHECK-GE17: define spir_kernel void @image1d([[TY:target\("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0\)]] noundef %image)
-; CHECK-LT17: define spir_kernel void @image1d([[TY:ptr addrspace\(1\)]] noundef %image)
+; CHECK: define spir_kernel void @image1d([[TY:target\("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0\)]] noundef %image)
            %1 = OpLabel
            %3 = OpImageRead %uint4_t %image %uint_0
 ; CHECK: = call spir_func <4 x i32> @_Z12read_imageui11ocl_image1di([[TY]] %image, i32 0)

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_read_1d_array.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_read_1d_array.spvasm
@@ -16,8 +16,7 @@
 
 ; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: %if online-spirv-as %{ spirv-val %spv_file_s %}
-; RUN: %pp-llvm-ver -o %t < %s --llvm-ver %LLVMVER
-; RUN: spirv-ll-tool -a OpenCL -b 64 -c Sampled1D -c StorageImageReadWithoutFormat %spv_file_s | FileCheck %t
+; RUN: spirv-ll-tool -a OpenCL -b 64 -c Sampled1D -c StorageImageReadWithoutFormat %spv_file_s | FileCheck %s
                       OpCapability Kernel
                       OpCapability Addresses
                       OpCapability Sampled1D
@@ -38,8 +37,7 @@
             %int2_1 = OpConstantComposite %int2_t %int_1 %int_1
    %image1d_array = OpFunction %void_t None %foo_t
            %image = OpFunctionParameter %image1d_array_t
-; CHECK-GE17: define spir_kernel void @image1d_array([[TY:target\("spirv.Image", void, 0, 0, 1, 0, 0, 0, 0\)]] noundef %image)
-; CHECK-LT17: define spir_kernel void @image1d_array([[TY:ptr addrspace\(1\)]] noundef %image)
+; CHECK: define spir_kernel void @image1d_array([[TY:target\("spirv.Image", void, 0, 0, 1, 0, 0, 0, 0\)]] noundef %image)
                %1 = OpLabel
                %3 = OpImageRead %uint4_t %image %int2_1
 ; CHECK: = call spir_func <4 x i32> @_Z12read_imageui16ocl_image1darrayDv2_i([[TY]] %image, <2 x i32> {{<(i32 1(, )?)+>|splat \(i32 1\)}})

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_read_1d_buffer.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_read_1d_buffer.spvasm
@@ -16,8 +16,7 @@
 
 ; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: %if online-spirv-as %{ spirv-val %spv_file_s %}
-; RUN: %pp-llvm-ver -o %t < %s --llvm-ver %LLVMVER
-; RUN: spirv-ll-tool -a OpenCL -b 64 -c ImageBasic -c SampledBuffer %spv_file_s | FileCheck %t
+; RUN: spirv-ll-tool -a OpenCL -b 64 -c ImageBasic -c SampledBuffer %spv_file_s | FileCheck %s
                         OpCapability Kernel
                         OpCapability Addresses
                         OpCapability ImageBasic
@@ -36,8 +35,7 @@
                %int_0 = OpConstant %uint_t 0
       %image1d_buffer = OpFunction %void_t None %foo_t
                %image = OpFunctionParameter %image1d_buffer_t
-; CHECK-GE17: define spir_kernel void @image1d_buffer([[TY:target\("spirv.Image", void, 5, 0, 0, 0, 0, 0, 0\)]] noundef %image)
-; CHECK-LT17: define spir_kernel void @image1d_buffer([[TY:ptr addrspace\(1\)]] noundef %image)
+; CHECK: define spir_kernel void @image1d_buffer([[TY:target\("spirv.Image", void, 5, 0, 0, 0, 0, 0, 0\)]] noundef %image)
                    %1 = OpLabel
                    %3 = OpImageRead %uint4_t %image %int_0
 ; CHECK: = call spir_func <4 x i32> @_Z12read_imageui17ocl_image1dbufferi([[TY]] %image, i32 0)

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_read_2d.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_read_2d.spvasm
@@ -16,8 +16,7 @@
 
 ; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: %if online-spirv-as %{ spirv-val %spv_file_s %}
-; RUN: %pp-llvm-ver -o %t < %s --llvm-ver %LLVMVER
-; RUN: spirv-ll-tool -a OpenCL -b 64 -c Sampled1D -c StorageImageReadWithoutFormat %spv_file_s | FileCheck %t
+; RUN: spirv-ll-tool -a OpenCL -b 64 -c Sampled1D -c StorageImageReadWithoutFormat %spv_file_s | FileCheck %s
                 OpCapability Kernel
                 OpCapability Addresses
                 OpCapability Sampled1D
@@ -38,8 +37,7 @@
       %int2_1 = OpConstantComposite %int2_t %int_1 %int_1
      %image2d = OpFunction %void_t None %foo_t
        %image = OpFunctionParameter %image2d_t
-; CHECK-GE17: define spir_kernel void @image2d([[TY:target\("spirv.Image", void, 1, 0, 0, 0, 0, 0, 0\)]] noundef %image)
-; CHECK-LT17: define spir_kernel void @image2d([[TY:ptr addrspace\(1\)]] noundef %image)
+; CHECK: define spir_kernel void @image2d([[TY:target\("spirv.Image", void, 1, 0, 0, 0, 0, 0, 0\)]] noundef %image)
            %1 = OpLabel
            %3 = OpImageRead %uint4_t %image %int2_1
 ; CHECK: = call spir_func <4 x i32> @_Z12read_imageui11ocl_image2dDv2_i([[TY]] %image, <2 x i32> {{<(i32 1(, )?)+>|splat \(i32 1\)}})

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_read_2d_array.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_read_2d_array.spvasm
@@ -16,8 +16,7 @@
 
 ; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: %if online-spirv-as %{ spirv-val %spv_file_s %}
-; RUN: %pp-llvm-ver -o %t < %s --llvm-ver %LLVMVER
-; RUN: spirv-ll-tool -a OpenCL -b 64 -c ImageBasic -c Sampled1D %spv_file_s | FileCheck %t
+; RUN: spirv-ll-tool -a OpenCL -b 64 -c ImageBasic -c Sampled1D %spv_file_s | FileCheck %s
                       OpCapability Kernel
                       OpCapability Addresses
                       OpCapability ImageBasic
@@ -37,8 +36,7 @@
             %int4_1 = OpConstantComposite %uint4_t %int_1 %int_1 %int_1 %int_1
      %image2d_array = OpFunction %void_t None %foo_t
              %image = OpFunctionParameter %image2d_array_t
-; CHECK-GE17: define spir_kernel void @image2d_array([[TY:target\("spirv.Image", void, 1, 0, 1, 0, 0, 0, 0\)]] noundef %image)
-; CHECK-LT17: define spir_kernel void @image2d_array([[TY:ptr addrspace\(1\)]] noundef %image)
+; CHECK: define spir_kernel void @image2d_array([[TY:target\("spirv.Image", void, 1, 0, 1, 0, 0, 0, 0\)]] noundef %image)
                  %1 = OpLabel
                  %3 = OpImageRead %uint4_t %image %int4_1
 ; CHECK: = call spir_func <4 x i32> @_Z12read_imageui16ocl_image2darrayDv4_i([[TY]] %image, <4 x i32> {{<(i32 1(, )?)+>|splat \(i32 1\)}})

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_read_3d.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_read_3d.spvasm
@@ -16,8 +16,7 @@
 
 ; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: %if online-spirv-as %{ spirv-val %spv_file_s %}
-; RUN: %pp-llvm-ver -o %t < %s --llvm-ver %LLVMVER
-; RUN: spirv-ll-tool -a OpenCL -b 64 -c ImageBasic -c Sampled1D %spv_file_s | FileCheck %t
+; RUN: spirv-ll-tool -a OpenCL -b 64 -c ImageBasic -c Sampled1D %spv_file_s | FileCheck %s
                 OpCapability Kernel
                 OpCapability Addresses
                 OpCapability ImageBasic
@@ -37,8 +36,7 @@
       %int4_1 = OpConstantComposite %uint4_t %int_1 %int_1 %int_1 %int_1
      %image3d = OpFunction %void_t None %foo_t
        %image = OpFunctionParameter %image3d_t
-; CHECK-GE17: define spir_kernel void @image3d([[TY:target\("spirv.Image", void, 2, 0, 0, 0, 0, 0, 0\)]] noundef %image)
-; CHECK-LT17: define spir_kernel void @image3d([[TY:ptr addrspace\(1\)]] noundef %image)
+; CHECK: define spir_kernel void @image3d([[TY:target\("spirv.Image", void, 2, 0, 0, 0, 0, 0, 0\)]] noundef %image)
            %1 = OpLabel
            %3 = OpImageRead %uint4_t %image %int4_1
 ; CHECK: = call spir_func <4 x i32> @_Z12read_imageui11ocl_image3dDv4_i([[TY]] %image, <4 x i32> {{<(i32 1(, )?)+>|splat \(i32 1\)}})

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_sample_explicit_lod_1d.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_sample_explicit_lod_1d.spvasm
@@ -16,8 +16,7 @@
 
 ; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: %if online-spirv-as %{ spirv-val %spv_file_s %}
-; RUN: %pp-llvm-ver -o %t < %s --llvm-ver %LLVMVER
-; RUN: spirv-ll-tool -a OpenCL -b 64 -c Sampled1D %spv_file_s | FileCheck %t
+; RUN: spirv-ll-tool -a OpenCL -b 64 -c Sampled1D %spv_file_s | FileCheck %s
                       OpCapability Kernel
                       OpCapability Addresses
                       OpCapability Sampled1D
@@ -44,10 +43,8 @@
            %image1d = OpFunction %void_t None %sampler_fn_t
         %in_sampler = OpFunctionParameter %sampler_t
           %in_image = OpFunctionParameter %image1d_t
-; CHECK-GE17: define spir_kernel void @image1d([[SAMPLER_TY:target\("spirv.Sampler"\)]] noundef %in_sampler,
-; CHECK-GE17-SAME: [[IMG_TY:target\("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0\)]] noundef %in_image)
-; CHECK-LT17: define spir_kernel void @image1d([[SAMPLER_TY:ptr]] noundef %in_sampler,
-; CHECK-LT17-SAME: [[IMG_TY:ptr addrspace\(1\)]] noundef %in_image)
+; CHECK: define spir_kernel void @image1d([[SAMPLER_TY:target\("spirv.Sampler"\)]] noundef %in_sampler,
+; CHECK-SAME: [[IMG_TY:target\("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0\)]] noundef %in_image)
                 %10 = OpLabel
      %sampled_image = OpSampledImage %sampled_image_t %in_image %in_sampler
                 %11 = OpImageSampleExplicitLod %v4float_t %sampled_image %float_1 None

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_sample_explicit_lod_1d_array.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_sample_explicit_lod_1d_array.spvasm
@@ -16,8 +16,7 @@
 
 ; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: %if online-spirv-as %{ spirv-val %spv_file_s %}
-; RUN: %pp-llvm-ver -o %t < %s --llvm-ver %LLVMVER
-; RUN: spirv-ll-tool -a OpenCL -b 64 -c Sampled1D %spv_file_s | FileCheck %t
+; RUN: spirv-ll-tool -a OpenCL -b 64 -c Sampled1D %spv_file_s | FileCheck %s
                       OpCapability Kernel
                       OpCapability Addresses
                       OpCapability Sampled1D
@@ -48,10 +47,8 @@
      %image1d_array = OpFunction %void_t None %sampler_fn_t
         %in_sampler = OpFunctionParameter %sampler_t
           %in_image = OpFunctionParameter %image1d_array_t
-; CHECK-GE17: define spir_kernel void @image1d_array([[SAMPLER_TY:target\("spirv.Sampler"\)]] noundef %in_sampler,
-; CHECK-GE17-SAME: [[IMG_TY:target\("spirv.Image", void, 0, 0, 1, 0, 0, 0, 0\)]] noundef %in_image)
-; CHECK-LT17: define spir_kernel void @image1d_array([[SAMPLER_TY:ptr]] noundef %in_sampler,
-; CHECK-LT17-SAME: [[IMG_TY:ptr addrspace\(1\)]] noundef %in_image)
+; CHECK: define spir_kernel void @image1d_array([[SAMPLER_TY:target\("spirv.Sampler"\)]] noundef %in_sampler,
+; CHECK-SAME: [[IMG_TY:target\("spirv.Image", void, 0, 0, 1, 0, 0, 0, 0\)]] noundef %in_image)
                  %1 = OpLabel
      %sampled_image = OpSampledImage %sampled_image_t %in_image %in_sampler
                  %2 = OpImageSampleExplicitLod %v4float_t %sampled_image %v2float_1 None

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_sample_explicit_lod_2d.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_sample_explicit_lod_2d.spvasm
@@ -16,8 +16,7 @@
 
 ; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: %if online-spirv-as %{ spirv-val %spv_file_s %}
-; RUN: %pp-llvm-ver -o %t < %s --llvm-ver %LLVMVER
-; RUN: spirv-ll-tool -a OpenCL -b 64 -c Sampled1D %spv_file_s | FileCheck %t
+; RUN: spirv-ll-tool -a OpenCL -b 64 -c Sampled1D %spv_file_s | FileCheck %s
                       OpCapability Kernel
                       OpCapability Addresses
                       OpCapability Sampled1D
@@ -48,10 +47,8 @@
            %image2d = OpFunction %void_t None %sampler_fn_t
         %in_sampler = OpFunctionParameter %sampler_t
           %in_image = OpFunctionParameter %image2d_t
-; CHECK-GE17: define spir_kernel void @image2d([[SAMPLER_TY:target\("spirv.Sampler"\)]] noundef %in_sampler,
-; CHECK-GE17-SAME: [[IMG_TY:target\("spirv.Image", void, 1, 0, 0, 0, 0, 0, 0\)]] noundef %in_image)
-; CHECK-LT17: define spir_kernel void @image2d([[SAMPLER_TY:ptr]] noundef %in_sampler,
-; CHECK-LT17-SAME: [[IMG_TY:ptr addrspace\(1\)]] noundef %in_image)
+; CHECK: define spir_kernel void @image2d([[SAMPLER_TY:target\("spirv.Sampler"\)]] noundef %in_sampler,
+; CHECK-SAME: [[IMG_TY:target\("spirv.Image", void, 1, 0, 0, 0, 0, 0, 0\)]] noundef %in_image)
                  %1 = OpLabel
      %sampled_image = OpSampledImage %sampled_image_t %in_image %in_sampler
                  %2 = OpImageSampleExplicitLod %v4float_t %sampled_image %v2float_1 None

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_sample_explicit_lod_2d_array.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_sample_explicit_lod_2d_array.spvasm
@@ -16,8 +16,7 @@
 
 ; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: %if online-spirv-as %{ spirv-val %spv_file_s %}
-; RUN: %pp-llvm-ver -o %t < %s --llvm-ver %LLVMVER
-; RUN: spirv-ll-tool -a OpenCL -b 64 -c Sampled1D %spv_file_s | FileCheck %t
+; RUN: spirv-ll-tool -a OpenCL -b 64 -c Sampled1D %spv_file_s | FileCheck %s
                       OpCapability Kernel
                       OpCapability Addresses
                       OpCapability Sampled1D
@@ -45,10 +44,8 @@
      %image2d_array = OpFunction %void_t None %sampler_fn_t
         %in_sampler = OpFunctionParameter %sampler_t
           %in_image = OpFunctionParameter %image2d_array_t
-; CHECK-GE17: define spir_kernel void @image2d_array([[SAMPLER_TY:target\("spirv.Sampler"\)]] noundef %in_sampler,
-; CHECK-GE17-SAME: [[IMG_TY:target\("spirv.Image", void, 1, 0, 1, 0, 0, 0, 0\)]] noundef %in_image)
-; CHECK-LT17: define spir_kernel void @image2d_array([[SAMPLER_TY:ptr]] noundef %in_sampler,
-; CHECK-LT17-SAME: [[IMG_TY:ptr addrspace\(1\)]] noundef %in_image)
+; CHECK: define spir_kernel void @image2d_array([[SAMPLER_TY:target\("spirv.Sampler"\)]] noundef %in_sampler,
+; CHECK-SAME: [[IMG_TY:target\("spirv.Image", void, 1, 0, 1, 0, 0, 0, 0\)]] noundef %in_image)
                  %1 = OpLabel
         %sampled_image = OpSampledImage %sampled_image_t %in_image %in_sampler
                  %2 = OpImageSampleExplicitLod %v4float_t %sampled_image %v4float_1 None

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_sample_explicit_lod_3d.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_sample_explicit_lod_3d.spvasm
@@ -16,8 +16,7 @@
 
 ; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: %if online-spirv-as %{ spirv-val %spv_file_s %}
-; RUN: %pp-llvm-ver -o %t < %s --llvm-ver %LLVMVER
-; RUN: spirv-ll-tool -a OpenCL -b 64 -c Sampled1D %spv_file_s | FileCheck %t
+; RUN: spirv-ll-tool -a OpenCL -b 64 -c Sampled1D %spv_file_s | FileCheck %s
                       OpCapability Kernel
                       OpCapability Addresses
                       OpCapability Sampled1D
@@ -46,10 +45,8 @@
            %image3d = OpFunction %void_t None %sampler_fn_t
         %in_sampler = OpFunctionParameter %sampler_t
           %in_image = OpFunctionParameter %image3d_t
-; CHECK-GE17: define spir_kernel void @image3d([[SAMPLER_TY:target\("spirv.Sampler"\)]] noundef %in_sampler,
-; CHECK-GE17-SAME: [[IMG_TY:target\("spirv.Image", void, 2, 0, 0, 0, 0, 0, 0\)]] noundef %in_image)
-; CHECK-LT17: define spir_kernel void @image3d([[SAMPLER_TY:ptr]] noundef %in_sampler,
-; CHECK-LT17-SAME: [[IMG_TY:ptr addrspace\(1\)]] noundef %in_image)
+; CHECK: define spir_kernel void @image3d([[SAMPLER_TY:target\("spirv.Sampler"\)]] noundef %in_sampler,
+; CHECK-SAME: [[IMG_TY:target\("spirv.Image", void, 2, 0, 0, 0, 0, 0, 0\)]] noundef %in_image)
                  %1 = OpLabel
      %sampled_image = OpSampledImage %sampled_image_t %in_image %in_sampler
                  %2 = OpImageSampleExplicitLod %v4float_t %sampled_image %v4float_1 None

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_write_1d.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_write_1d.spvasm
@@ -16,8 +16,7 @@
 
 ; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: %if online-spirv-as %{ spirv-val %spv_file_s %}
-; RUN: %pp-llvm-ver -o %t < %s --llvm-ver %LLVMVER
-; RUN: spirv-ll-tool -a OpenCL -b 64 -c ImageBasic -c Sampled1D -c StorageImageWriteWithoutFormat %spv_file_s | FileCheck %t
+; RUN: spirv-ll-tool -a OpenCL -b 64 -c ImageBasic -c Sampled1D -c StorageImageWriteWithoutFormat %spv_file_s | FileCheck %s
                             OpCapability Kernel
                             OpCapability Addresses
                             OpCapability ImageBasic
@@ -45,8 +44,7 @@
 ; All functions              
                     %test = OpFunction %void_t None %testfnty
                    %image = OpFunctionParameter %image1d_t
-; CHECK-GE17: define spir_kernel void @test([[TY:target\("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0\)]] noundef %image)
-; CHECK-LT17: define spir_kernel void @test([[TY:ptr addrspace\(1\)]] noundef %image)
+; CHECK: define spir_kernel void @test([[TY:target\("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0\)]] noundef %image)
                        %1 = OpLabel
                             OpImageWrite %image %int_0 %float4_color
 ; CHECK: call spir_func void @_Z12write_imagef11ocl_image1diDv4_f([[TY]] %image, i32 0, <4 x float> {{<(float 1.000000e\+00(, )?)+>|splat \(float 1.000000e\+00\)}})

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_write_1d_array.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_write_1d_array.spvasm
@@ -16,8 +16,7 @@
 
 ; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: %if online-spirv-as %{ spirv-val %spv_file_s %}
-; RUN: %pp-llvm-ver -o %t < %s --llvm-ver %LLVMVER
-; RUN: spirv-ll-tool -a OpenCL -b 64 -c ImageBasic -c Sampled1D -c StorageImageWriteWithoutFormat %spv_file_s | FileCheck %t
+; RUN: spirv-ll-tool -a OpenCL -b 64 -c ImageBasic -c Sampled1D -c StorageImageWriteWithoutFormat %spv_file_s | FileCheck %s
                             OpCapability Kernel
                             OpCapability Addresses
                             OpCapability Sampled1D
@@ -45,8 +44,7 @@
 ; All functions
            %image1d_array = OpFunction %void_t None %image_write_fn_t
                    %image = OpFunctionParameter %image1d_array_t
-; CHECK-GE17: define spir_kernel void @image1d_array([[TY:target\("spirv.Image", void, 0, 0, 1, 0, 0, 0, 0\)]] noundef %image)
-; CHECK-LT17: define spir_kernel void @image1d_array([[TY:ptr addrspace\(1\)]] noundef %image)
+; CHECK: define spir_kernel void @image1d_array([[TY:target\("spirv.Image", void, 0, 0, 1, 0, 0, 0, 0\)]] noundef %image)
                        %1 = OpLabel
                             OpImageWrite %image %v2int_1 %v4float_1
 ; CHECK: call spir_func void @_Z12write_imagef16ocl_image1darrayDv2_iDv4_f([[TY]] %image, <2 x i32> {{<(i32 1(, )?)+>|splat \(i32 1\)}}, <4 x float> {{<(float 1.000000e\+00(, )?)+>|splat \(float 1.000000e\+00\)}})

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_write_1d_buffer.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_write_1d_buffer.spvasm
@@ -16,8 +16,7 @@
 
 ; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: %if online-spirv-as %{ spirv-val %spv_file_s %}
-; RUN: %pp-llvm-ver -o %t < %s --llvm-ver %LLVMVER
-; RUN: spirv-ll-tool -a OpenCL -b 64 -c ImageBasic -c SampledBuffer -c StorageImageWriteWithoutFormat %spv_file_s | FileCheck %t
+; RUN: spirv-ll-tool -a OpenCL -b 64 -c ImageBasic -c SampledBuffer -c StorageImageWriteWithoutFormat %spv_file_s | FileCheck %s
                             OpCapability Kernel
                             OpCapability Addresses
                             OpCapability ImageBasic
@@ -43,8 +42,7 @@
 ; All functions
           %image1d_buffer = OpFunction %void_t None %image_write_fn_t
                    %image = OpFunctionParameter %image1d_buffer_t
-; CHECK-GE17: define spir_kernel void @image1d_buffer([[TY:target\("spirv.Image", void, 5, 0, 0, 0, 0, 0, 0\)]] noundef %image)
-; CHECK-LT17: define spir_kernel void @image1d_buffer([[TY:ptr addrspace\(1\)]] noundef %image)
+; CHECK: define spir_kernel void @image1d_buffer([[TY:target\("spirv.Image", void, 5, 0, 0, 0, 0, 0, 0\)]] noundef %image)
                        %1 = OpLabel
                             OpImageWrite %image %uint_1 %v4float_1
 ; CHECK: call spir_func void @_Z12write_imagef17ocl_image1dbufferiDv4_f([[TY]] %image, i32 1, <4 x float> {{<(float 1.000000e\+00(, )?)+>|splat \(float 1.000000e\+00\)}})

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_write_2d.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_write_2d.spvasm
@@ -16,8 +16,7 @@
 
 ; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: %if online-spirv-as %{ spirv-val %spv_file_s %}
-; RUN: %pp-llvm-ver -o %t < %s --llvm-ver %LLVMVER
-; RUN: spirv-ll-tool -a OpenCL -b 64 -c ImageBasic -c StorageImageWriteWithoutFormat %spv_file_s | FileCheck %t
+; RUN: spirv-ll-tool -a OpenCL -b 64 -c ImageBasic -c StorageImageWriteWithoutFormat %spv_file_s | FileCheck %s
                             OpCapability Kernel
                             OpCapability Addresses
                             OpCapability ImageBasic
@@ -44,8 +43,7 @@
 ; All functions
                  %image2d = OpFunction %void_t None %image_write_fn_t                            
                    %image = OpFunctionParameter %image2d_t
-; CHECK-GE17: define spir_kernel void @image2d([[TY:target\("spirv.Image", void, 1, 0, 0, 0, 0, 0, 0\)]] noundef %image)
-; CHECK-LT17: define spir_kernel void @image2d([[TY:ptr addrspace\(1\)]] noundef %image)
+; CHECK: define spir_kernel void @image2d([[TY:target\("spirv.Image", void, 1, 0, 0, 0, 0, 0, 0\)]] noundef %image)
                        %1 = OpLabel
                             OpImageWrite %image %v2int_1 %v4float_1
 ; CHECK: call spir_func void @_Z12write_imagef11ocl_image2dDv2_iDv4_f([[TY]] %image, <2 x i32> {{<(i32 1(, )?)+>|splat \(i32 1\)}}, <4 x float> {{<(float 1.000000e\+00(, )?)+>|splat \(float 1.000000e\+00\)}})

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_write_2d_array.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_write_2d_array.spvasm
@@ -16,8 +16,7 @@
 
 ; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: %if online-spirv-as %{ spirv-val %spv_file_s %}
-; RUN: %pp-llvm-ver -o %t < %s --llvm-ver %LLVMVER
-; RUN: spirv-ll-tool -a OpenCL -b 64 -c StorageImageWriteWithoutFormat %spv_file_s | FileCheck %t
+; RUN: spirv-ll-tool -a OpenCL -b 64 -c StorageImageWriteWithoutFormat %spv_file_s | FileCheck %s
                             OpCapability Kernel
                             OpCapability Addresses
                             OpCapability StorageImageWriteWithoutFormat
@@ -41,8 +40,7 @@
 ; All functions
            %image2d_array = OpFunction %void_t None %image_write_fn_t
                    %image = OpFunctionParameter %image2d_array_t
-; CHECK-GE17: define spir_kernel void @image2d_array([[TY:target\("spirv.Image", void, 1, 0, 1, 0, 0, 0, 0\)]] noundef %image)
-; CHECK-LT17: define spir_kernel void @image2d_array([[TY:ptr addrspace\(1\)]] noundef %image)
+; CHECK: define spir_kernel void @image2d_array([[TY:target\("spirv.Image", void, 1, 0, 1, 0, 0, 0, 0\)]] noundef %image)
                        %1 = OpLabel
                             OpImageWrite %image %v4int_1 %v4float_1
 ; CHECK: call spir_func void @_Z12write_imagef16ocl_image2darrayDv4_iDv4_f([[TY]] %image, <4 x i32> {{<(i32 1(, )?)+>|splat \(i32 1\)}}, <4 x float> {{<(float 1.000000e\+00(, )?)+>|splat \(float 1.000000e\+00\)}})

--- a/modules/compiler/spirv-ll/test/spvasm/op_image_write_3d.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_image_write_3d.spvasm
@@ -16,8 +16,7 @@
 
 ; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: %if online-spirv-as %{ spirv-val %spv_file_s %}
-; RUN: %pp-llvm-ver -o %t < %s --llvm-ver %LLVMVER
-; RUN: spirv-ll-tool -a OpenCL -b 64 -c ImageBasic -c StorageImageWriteWithoutFormat %spv_file_s | FileCheck %t
+; RUN: spirv-ll-tool -a OpenCL -b 64 -c ImageBasic -c StorageImageWriteWithoutFormat %spv_file_s | FileCheck %s
                             OpCapability Kernel
                             OpCapability Addresses
                             OpCapability ImageBasic
@@ -42,8 +41,7 @@
 ; All functions
                  %image3d = OpFunction %void_t None %image_write_fn_t
                    %image = OpFunctionParameter %image3d_t
-; CHECK-GE17: define spir_kernel void @image3d([[TY:target\("spirv.Image", void, 2, 0, 0, 0, 0, 0, 0\)]] noundef %image)
-; CHECK-LT17: define spir_kernel void @image3d([[TY:ptr addrspace\(1\)]] noundef %image)
+; CHECK: define spir_kernel void @image3d([[TY:target\("spirv.Image", void, 2, 0, 0, 0, 0, 0, 0\)]] noundef %image)
                        %1 = OpLabel
                             OpImageWrite %image %v4uint_1 %v4float_1
 ; CHECK: call spir_func void @_Z12write_imagef11ocl_image3dDv4_iDv4_f([[TY]] %image, <4 x i32> {{<(i32 1(, )?)+>|splat \(i32 1\)}}, <4 x float> {{<(float 1.000000e\+00(, )?)+>|splat \(float 1.000000e\+00\)}})

--- a/modules/compiler/spirv-ll/test/spvasm/op_opencl_arg_md.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_opencl_arg_md.spvasm
@@ -16,8 +16,7 @@
 
 ; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: %if online-spirv-as %{ spirv-val %spv_file_s %}
-; RUN: %pp-llvm-ver -o %t < %s --llvm-ver %LLVMVER
-; RUN: spirv-ll-tool -a OpenCL -b 64 -c Int64 %spv_file_s | FileCheck %t
+; RUN: spirv-ll-tool -a OpenCL -b 64 -c Int64 %spv_file_s | FileCheck %s
 
                         OpCapability Kernel
                         OpCapability Addresses
@@ -60,14 +59,12 @@
 
 ; CHECK: define spir_kernel void @my_kernel(ptr addrspace(1) noundef %a,
 ; CHECK-SAME:                              [3 x ptr addrspace(1)] noundef %b, ptr addrspace(3) noundef %c,
-; CHECK-GE17-SAME:                         target("spirv.Image", void, 1, 0, 0, 0, 0, 0, 0) noundef %d
-; CHECK-LT17-SAME:                         ptr addrspace(1) noundef %d
+; CHECK-SAME:                         target("spirv.Image", void, 1, 0, 0, 0, 0, 0, 0) noundef %d
 ; CHECK-SAME:                              ptr addrspace(1) noundef %e)
 
 ; CHECK-SAME: !kernel_arg_addr_space !0 !kernel_arg_access_qual !1 !kernel_arg_type !2 !kernel_arg_base_type !2 !kernel_arg_type_qual !3 !kernel_arg_name !4 {
 
-; CHECK-GE17: !0 = !{i32 1, i32 0, i32 3, i32 0, i32 1}
-; CHECK-LT17: !0 = !{i32 1, i32 0, i32 3, i32 1, i32 1}
+; CHECK: !0 = !{i32 1, i32 0, i32 3, i32 0, i32 1}
 ; CHECK: !1 = !{!"none", !"none", !"none", !"read_only", !"none"}
 ; CHECK: !2 = !{!"array*", !"array", !"sampler_t*", !"image2d_t", !"image2d_t*"}
 ; CHECK: !3 = !{!"", !"", !"", !"", !""}

--- a/modules/compiler/spirv-ll/test/spvasm/op_type_sampler.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_type_sampler.spvasm
@@ -16,8 +16,7 @@
 
 ; RUN: %if online-spirv-as %{ spirv-as --target-env %spv_tgt_env -o %spv_file_s %s %}
 ; RUN: %if online-spirv-as %{ spirv-val %spv_file_s %}
-; RUN: %pp-llvm-ver -o %t < %s --llvm-ver %LLVMVER
-; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %t
+; RUN: spirv-ll-tool -a OpenCL -b 64 %spv_file_s | FileCheck %s
 ; CHECK: ; ModuleID = '{{.*}}'
                         OpCapability Kernel
                         OpCapability Addresses
@@ -28,8 +27,7 @@
           %sampler_t = OpTypeSampler
         %sampler_fn_t = OpTypeFunction %void %sampler_t %sampler_t
         %sampler_type = OpFunction %void None %sampler_fn_t
-; CHECK-GE17: define spir_kernel void @sampler_type(target("spirv.Sampler") noundef %0, target("spirv.Sampler") noundef %1){{.*}}!kernel_arg_type [[MD:\![0-9]+]]
-; CHECK-LT17: define spir_kernel void @sampler_type(ptr noundef %0, ptr noundef %1){{.*}}!kernel_arg_type [[MD:\![0-9]+]]
+; CHECK: define spir_kernel void @sampler_type(target("spirv.Sampler") noundef %0, target("spirv.Sampler") noundef %1){{.*}}!kernel_arg_type [[MD:\![0-9]+]]
   %sampler_type_enter = OpLabel
                         OpReturn
 ; CHECK: ret void

--- a/modules/compiler/vecz/test/lit/llvm/undef_ub.ll
+++ b/modules/compiler/vecz/test/lit/llvm/undef_ub.ll
@@ -14,8 +14,7 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-; RUN: %pp-llvm-ver -o %t < %s --llvm-ver %LLVMVER
-; RUN: veczc -k test -w 4 -S < %s | FileCheck %t
+; RUN: veczc -k test -w 4 -S < %s | FileCheck %s
 
 ; ModuleID = 'Unknown buffer'
 source_filename = "Unknown buffer"
@@ -41,6 +40,4 @@ entry:
 ; The "undefs" in the above IR should "optimize" to a trap call and an unreachable
 ; terminator instruction.
 ; CHECK: define spir_kernel void @__vecz_v4_test
-; Before LLVM 17 there's no such trap: the UB is just that the function returns early.
-; CHECK-LT17: ret void
-; CHECK-GE17: unreachable
+; CHECK: unreachable


### PR DESCRIPTION
# Overview

[NFC] Remove some old LLVM support from tests.

# Reason for change

Our minimum supported LLVM version at the moment is LLVM 19, but we still had some tests that handled LLVM 15 and LLVM 16.

# Description of change

This PR removes that handling.

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-19](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
