### PR TITLE
[clik] Add missing includes.

### DIFF
--- a/clik/examples/clik_async/barrier_print/barrier_print.cpp
+++ b/clik/examples/clik_async/barrier_print/barrier_print.cpp
@@ -15,6 +15,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include <stdio.h>
+#include <stdlib.h>
 
 #include "clik_async_api.h"
 #include "option_parser.h"

--- a/clik/examples/clik_async/barrier_sum/barrier_sum.cpp
+++ b/clik/examples/clik_async/barrier_sum/barrier_sum.cpp
@@ -15,6 +15,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include <stdio.h>
+#include <stdlib.h>
 
 #include "clik_async_api.h"
 #include "option_parser.h"

--- a/clik/examples/clik_async/concatenate_dma/concatenate_dma.cpp
+++ b/clik/examples/clik_async/concatenate_dma/concatenate_dma.cpp
@@ -20,6 +20,7 @@
 // destination buffer using concurrent DMA operations.
 
 #include <stdio.h>
+#include <stdlib.h>
 
 #include <vector>
 

--- a/clik/examples/clik_async/copy_buffer/copy_buffer.cpp
+++ b/clik/examples/clik_async/copy_buffer/copy_buffer.cpp
@@ -15,6 +15,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include <stdio.h>
+#include <stdlib.h>
 
 #include "clik_async_api.h"
 #include "option_parser.h"

--- a/clik/examples/clik_async/hello/hello.cpp
+++ b/clik/examples/clik_async/hello/hello.cpp
@@ -15,6 +15,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include <stdio.h>
+#include <stdlib.h>
 
 #include "clik_async_api.h"
 #include "option_parser.h"

--- a/clik/examples/clik_async/ternary/ternary.cpp
+++ b/clik/examples/clik_async/ternary/ternary.cpp
@@ -15,6 +15,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include <stdio.h>
+#include <stdlib.h>
 
 #include <vector>
 

--- a/clik/examples/clik_async/vector_add/vector_add.cpp
+++ b/clik/examples/clik_async/vector_add/vector_add.cpp
@@ -15,6 +15,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include <stdio.h>
+#include <stdlib.h>
 
 #include <vector>
 

--- a/clik/examples/clik_async/vector_add_wfv/vector_add_wfv.cpp
+++ b/clik/examples/clik_async/vector_add_wfv/vector_add_wfv.cpp
@@ -15,6 +15,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include <stdio.h>
+#include <stdlib.h>
 
 #include <vector>
 

--- a/clik/examples/clik_sync/copy_buffer/copy_buffer.cpp
+++ b/clik/examples/clik_sync/copy_buffer/copy_buffer.cpp
@@ -15,6 +15,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include <stdio.h>
+#include <stdlib.h>
 
 #include "clik_sync_api.h"
 #include "option_parser.h"

--- a/clik/examples/clik_sync/hello/hello.cpp
+++ b/clik/examples/clik_sync/hello/hello.cpp
@@ -15,6 +15,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include <stdio.h>
+#include <stdlib.h>
 
 #include "clik_sync_api.h"
 #include "option_parser.h"

--- a/clik/examples/clik_sync/vector_add/vector_add.cpp
+++ b/clik/examples/clik_sync/vector_add/vector_add.cpp
@@ -15,6 +15,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include <stdio.h>
+#include <stdlib.h>
 
 #include "clik_sync_api.h"
 #include "option_parser.h"


### PR DESCRIPTION
# Overview

[clik] Add missing includes.

# Reason for change

We were using strtoull without including <stdlib.h>, which may or may not work depending on exactly which headers get included implicitly by other headers. With newer libstdc++, it no longer works.

# Description of change

Include the header directly.

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-19](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
