### PR TITLE
[clik] Remove unused import.

### DIFF
--- a/clik/test/profile.py
+++ b/clik/test/profile.py
@@ -14,7 +14,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-import imp
 import os
 import re
 import argparse


### PR DESCRIPTION
# Overview

[clik] Remove unused import.

# Reason for change

We were importing imp, but not using it. As imp has been removed in Python 3.12, this now results in an error.

# Description of change

Since we were already not using it, just stop importing it.

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/codeplaysoftware/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-19](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
