### PR TITLE
Fix workflows running in forks

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -9,6 +9,7 @@ permissions: {}
 jobs:
   analyze-host-x86_64-release:
     name: Analyze host x86_64 release
+    if: github.repository == 'uxlfoundation/oneapi-construction-kit'
     permissions:
       # required for all workflows
       security-events: write
@@ -60,6 +61,7 @@ jobs:
 
   analyze-riscv-m1:
     name: Analyze riscv m1
+    if: github.repository == 'uxlfoundation/oneapi-construction-kit'
     permissions:
       # required for all workflows
       security-events: write

--- a/.github/workflows/pr_tests_cache.yml
+++ b/.github/workflows/pr_tests_cache.yml
@@ -136,7 +136,7 @@ jobs:
           cache_seed: true
 
   windows_llvm_prev_jobs:
-    if: github.repository == 'uxlfoundation/oneapi-construction-kit' || github.event_name != 'schedule'
+    if: github.repository == 'uxlfoundation/oneapi-construction-kit' || github.event_name == 'workflow_dispatch'
     runs-on: windows-2025
     steps:
       - name: Setup Windows llvm base
@@ -163,7 +163,7 @@ jobs:
           cache_seed: true
 
   windows_llvm_current_jobs:
-    if: github.repository == 'uxlfoundation/oneapi-construction-kit' || github.event_name != 'schedule'
+    if: github.repository == 'uxlfoundation/oneapi-construction-kit' || github.event_name == 'workflow_dispatch'
     needs: [windows_llvm_prev_jobs]
     runs-on: windows-2025
     steps:
@@ -194,7 +194,7 @@ jobs:
   # Look to uncomment in the future.
 
   clean_cache:
-    if: github.repository == 'uxlfoundation/oneapi-construction-kit' || github.event_name != 'schedule'
+    if: github.repository == 'uxlfoundation/oneapi-construction-kit' || github.event_name == 'workflow_dispatch'
     needs: [ubuntu_22_llvm_current_aarch64_jobs, windows_llvm_current_jobs]
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -16,6 +16,7 @@ permissions: read-all
 jobs:
   analysis:
     name: Scorecard analysis
+    if: github.repository == 'uxlfoundation/oneapi-construction-kit'
     runs-on: ubuntu-latest
     permissions:
       # Needed to upload the results to code-scanning dashboard.


### PR DESCRIPTION
# Overview

Some workflows don't check which repository they are and run in forks which is quite wasteful. Most of these have been disabled but some were still running.
