### PR TITLE
[LLVM 22] A few more lifetime fixes

### DIFF
--- a/modules/compiler/compiler_pipeline/source/remove_lifetime_intrinsics_pass.cpp
+++ b/modules/compiler/compiler_pipeline/source/remove_lifetime_intrinsics_pass.cpp
@@ -40,7 +40,8 @@ PreservedAnalyses compiler::utils::RemoveLifetimeIntrinsicsPass::run(
 
           // Second argument to intrinsic is a pointer bitcasted to `i8*`,
           // this can be removed since the lifetime intrinsic is the only use.
-          auto bitcast = dyn_cast<BitCastInst>(intrinsic->getArgOperand(1));
+          auto bitcast = dyn_cast<BitCastInst>(
+              intrinsic->getArgOperand(intrinsic->arg_size() - 1));
           if (bitcast && bitcast->hasOneUse()) {
             toDelete.push_back(bitcast);
           }

--- a/modules/compiler/spirv-ll/test/spvasm/op_lifetime_sized.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_lifetime_sized.spvasm
@@ -43,10 +43,10 @@
             OpFunctionEnd
 ; CHECK: ; ModuleID = '{{.*}}'
 ; CHECK: define spir_kernel void @lifetime(ptr addrspace(3) noundef [[PTR:%.*]])
-; CHECK: call void @llvm.lifetime.start.p3(i64 4, ptr addrspace(3) [[PTR]])
-; CHECK: call void @llvm.lifetime.end.p3(i64 4, ptr addrspace(3) [[PTR]])
+; CHECK: call void @llvm.lifetime.start.p3({{(i64 4, )?}}ptr addrspace(3) [[PTR]])
+; CHECK: call void @llvm.lifetime.end.p3({{(i64 4, )?}}ptr addrspace(3) [[PTR]])
 ; CHECK: ret void
-; CHECK: declare void @llvm.lifetime.start.p3(i64 immarg, ptr addrspace(3) {{nocapture|captures\(none\)}})
-; CHECK: declare void @llvm.lifetime.end.p3(i64 immarg, ptr addrspace(3) {{nocapture|captures\(none\)}})
+; CHECK: declare void @llvm.lifetime.start.p3({{(i64 immarg, )?}}ptr addrspace(3) {{nocapture|captures\(none\)}})
+; CHECK: declare void @llvm.lifetime.end.p3({{(i64 immarg, )?}}ptr addrspace(3) {{nocapture|captures\(none\)}})
 ; make sure the void* type is also functioning correctly
 ; CHECK: !{!"void*"}

--- a/modules/compiler/spirv-ll/test/spvasm/op_lifetime_unsized.spvasm
+++ b/modules/compiler/spirv-ll/test/spvasm/op_lifetime_unsized.spvasm
@@ -47,10 +47,10 @@
 ; CHECK: [[PTR:%.*]] = alloca i32
 ; CHECK: store i32 0, ptr [[PTR]]
 ; LLVM 4.0 doesn't need to add the address space as it assumes 0
-; CHECK: call void @llvm.lifetime.start{{(.p0)?}}(i64 -1, ptr [[PTR]])
+; CHECK: call void @llvm.lifetime.start.p0({{(i64 -1, )?}}ptr [[PTR]])
 ; CHECK: store i32 1, ptr [[PTR]]
-; CHECK: call void @llvm.lifetime.end{{(.p0)?}}(i64 -1, ptr [[PTR]])
+; CHECK: call void @llvm.lifetime.end.p0({{(i64 -1, )?}}ptr [[PTR]])
 ; CHECK: store i32 424, ptr [[PTR]]
 ; CHECK: ret void
-; CHECK: declare void @llvm.lifetime.start{{(.p0)?}}(i64{{.*}}, ptr {{nocapture|captures\(none\)}})
-; CHECK: declare void @llvm.lifetime.end{{(.p0)?}}(i64{{.*}}, ptr {{nocapture|captures\(none\)}})
+; CHECK: declare void @llvm.lifetime.start.p0({{(i64 immarg, )?}}ptr {{nocapture|captures\(none\)}})
+; CHECK: declare void @llvm.lifetime.end.p0({{(i64 immarg, )?}}ptr {{nocapture|captures\(none\)}})

--- a/modules/compiler/vecz/test/lit/llvm/divergent_loop_bug.ll
+++ b/modules/compiler/vecz/test/lit/llvm/divergent_loop_bug.ll
@@ -48,7 +48,7 @@ entry.if.end17_crit_edge:                          ; preds = %entry
 ; %or.cond branch.
 ; CHECK: if.then:
 ; CHECK: call void @__vecz_b_masked_store4_fu3ptrb(float 0.000000e+00, ptr %cosa, i1 [[CMP_NOT_NOT]])
-; CHECK: %1 = call spir_func float @__vecz_b_masked__Z6sincosfPf(float 0.000000e+00, ptr nonnull %cosa, i1 [[CMP_NOT_NOT]]) #9
+; CHECK: %1 = call spir_func float @__vecz_b_masked__Z6sincosfPf(float 0.000000e+00, ptr nonnull %cosa, i1 [[CMP_NOT_NOT]])
 ; CHECK: %2 = call float @__vecz_b_masked_load4_fu3ptrb(ptr %cosa, i1 [[CMP_NOT_NOT]])
 ; CHECK: %mul7 = fmul float %2, -2.950000e+01
 ; CHECK: %cmp11 = fcmp uge float %mul7, 0.000000e+00
@@ -113,7 +113,7 @@ entry.if.end17_crit_edge:                          ; preds = %entry
 ; %or.cond branch.
 ; CHECK: if.then:
 ; CHECK: call void @__vecz_b_masked_store4_fu3ptrb(float 0.000000e+00, ptr %cosa, i1 [[CMP_NOT_NOT]])
-; CHECK: %1 = call spir_func float @__vecz_b_masked__Z6sincosfPf(float 0.000000e+00, ptr nonnull %cosa, i1 [[CMP_NOT_NOT]]) #9
+; CHECK: %1 = call spir_func float @__vecz_b_masked__Z6sincosfPf(float 0.000000e+00, ptr nonnull %cosa, i1 [[CMP_NOT_NOT]])
 ; CHECK: %2 = call float @__vecz_b_masked_load4_fu3ptrb(ptr %cosa, i1 [[CMP_NOT_NOT]])
 ; CHECK: %mul7 = fmul float %2, -2.950000e+01
 ; CHECK: %cmp11 = fcmp uge float %mul7, 0.000000e+00


### PR DESCRIPTION
# Overview

[LLVM 22] A few more lifetime fixes.

# Description of change

* Obtain lifetime_(start|end) pointer argument by getting last argument.
* Do not update size argument when there is no size argument.
* Update tests.