### PR TITLE
[CI] Tweak test_vector_swizzles invocation.

### DIFF
--- a/scripts/testing/sycl_cts/tests.csv
+++ b/scripts/testing/sycl_cts/tests.csv
@@ -559,13 +559,13 @@ SYCL_CTS,test_vector_swizzle_assignment vector_SWIZZLE_ASSIGNMENT_byte
 SYCL_CTS,test_vector_swizzle_assignment vector_SWIZZLE_ASSIGNMENT_std_byte
 SYCL_CTS,test_vector_swizzle_assignment vector_SWIZZLE_ASSIGNMENT_int8_t
 SYCL_CTS,test_vector_swizzle_assignment vector_SWIZZLE_ASSIGNMENT_int32_t
-SYCL_CTS,test_vector_swizzles vector_swizzles_bool
-SYCL_CTS,test_vector_swizzles vector_swizzles_char
-SYCL_CTS,test_vector_swizzles vector_swizzles_int
-SYCL_CTS,test_vector_swizzles vector_swizzles_float
-SYCL_CTS,test_vector_swizzles vector_swizzles_double
-SYCL_CTS,test_vector_swizzles vector_swizzles_half --allow-running-no-tests
-SYCL_CTS,test_vector_swizzles vector_swizzles_byte
-SYCL_CTS,test_vector_swizzles vector_swizzles_std_byte
-SYCL_CTS,test_vector_swizzles vector_swizzles_int8_t
-SYCL_CTS,test_vector_swizzles vector_swizzles_int32_t
+SYCL_CTS,test_vector_swizzles "vector_swizzles_bool*"
+SYCL_CTS,test_vector_swizzles "vector_swizzles_char*"
+SYCL_CTS,test_vector_swizzles "vector_swizzles_int*"
+SYCL_CTS,test_vector_swizzles "vector_swizzles_float*"
+SYCL_CTS,test_vector_swizzles "vector_swizzles_double*"
+SYCL_CTS,test_vector_swizzles "vector_swizzles_half*" --allow-running-no-tests
+SYCL_CTS,test_vector_swizzles "vector_swizzles_byte*"
+SYCL_CTS,test_vector_swizzles "vector_swizzles_std_byte*"
+SYCL_CTS,test_vector_swizzles "vector_swizzles_int8_t*"
+SYCL_CTS,test_vector_swizzles "vector_swizzles_int32_t*"


### PR DESCRIPTION
# Overview

[CI] Tweak test_vector_swizzles invocation.

# Reason for change

The tests have been broken up so that we now have not vector_swizzles_bool, but vector_swizzles_bool_0,
vector_swizzles_bool_1, etc.

# Description of change

This commit updates our tests.csv accordingly.

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/uxlfoundation/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-20](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
