### PR TITLE
[NFC] Remove unused %pp-llvm-ver.

### DIFF
--- a/modules/compiler/test/lit/passes/replace-local-module-scope-vars-dbg-2.ll
+++ b/modules/compiler/test/lit/passes/replace-local-module-scope-vars-dbg-2.ll
@@ -21,8 +21,7 @@
 ; info entries should reference into that struct but retain the original
 ; function's scope.
 
-; RUN: %pp-llvm-ver -o %t < %s --llvm-ver %LLVMVER
-; RUN: muxc --passes "replace-module-scope-vars,verify" -S %s | FileCheck %t
+; RUN: muxc --passes "replace-module-scope-vars,verify" -S %s | FileCheck %s
 
 ; TODO: It's not clear why @helper_kernel has one dbg.declare but @local_array
 ; has two. See CA-4534.

--- a/modules/compiler/vecz/test/lit/llvm/inlined_function_debug_info.ll
+++ b/modules/compiler/vecz/test/lit/llvm/inlined_function_debug_info.ll
@@ -16,8 +16,7 @@
 
 ; Check VECZ debug info for inlined DILocation metadata nodes
 
-; RUN: %pp-llvm-ver -o %t < %s --llvm-ver %LLVMVER
-; RUN: veczc -k functions_one -vecz-passes=builtin-inlining -vecz-simd-width=4 -S < %s | FileCheck %t
+; RUN: veczc -k functions_one -vecz-passes=builtin-inlining -vecz-simd-width=4 -S < %s | FileCheck %s
 
 ; ModuleID = '/tmp/inlined_function.ll'
 target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"

--- a/modules/compiler/vecz/test/lit/llvm/insert_element_debug_info.ll
+++ b/modules/compiler/vecz/test/lit/llvm/insert_element_debug_info.ll
@@ -18,8 +18,7 @@
 ; intrinsics across all lanes even when scalarization masks disable some
 ; of the lanes. This occurs when we scalarize insertelement instructions.
 
-; RUN: %pp-llvm-ver -o %t < %s --llvm-ver %LLVMVER
-; RUN: veczc -k unaligned_load -vecz-passes="function(instcombine,adce),scalarize,packetizer,instcombine" -vecz-simd-width=4 -vecz-choices=FullScalarization -S < %s | FileCheck %t
+; RUN: veczc -k unaligned_load -vecz-passes="function(instcombine,adce),scalarize,packetizer,instcombine" -vecz-simd-width=4 -vecz-choices=FullScalarization -S < %s | FileCheck %s
 
 ; ModuleID = 'kernel.opencl'
 target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"

--- a/modules/compiler/vecz/test/lit/llvm/packetization_debug_info.ll
+++ b/modules/compiler/vecz/test/lit/llvm/packetization_debug_info.ll
@@ -17,8 +17,7 @@
 ; Check that debug info is preserved in the vectorized kernel.
 ; Specifically that the packetization pass creates vector types
 ; in the DI for the variables.
-; RUN: %pp-llvm-ver -o %t < %s --llvm-ver %LLVMVER
-; RUN: veczc -k add -S < %s | FileCheck %t
+; RUN: veczc -k add -S < %s | FileCheck %s
 
 ; ModuleID = 'kernel.opencl'
 target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"

--- a/modules/compiler/vecz/test/lit/llvm/phi_node_debug_info.ll
+++ b/modules/compiler/vecz/test/lit/llvm/phi_node_debug_info.ll
@@ -17,8 +17,7 @@
 ; Check that debug info intrinsics are correctly placed after
 ; phi nodes.
 
-; RUN: %pp-llvm-ver -o %t < %s --llvm-ver %LLVMVER
-; RUN: veczc -vecz-simd-width=4 -S < %s | FileCheck %t
+; RUN: veczc -vecz-simd-width=4 -S < %s | FileCheck %s
 
 ; ModuleID = 'kernel.opencl'
 target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"

--- a/modules/compiler/vecz/test/lit/llvm/scalarization_debug_info.ll
+++ b/modules/compiler/vecz/test/lit/llvm/scalarization_debug_info.ll
@@ -18,8 +18,7 @@
 ; Specifically that the scalarization pass doesn't destroy DI
 ; intrinsics attached to the vector instructions it scalarizes.
 
-; RUN: %pp-llvm-ver -o %t < %s --llvm-ver %LLVMVER
-; RUN: veczc -k mul2 -vecz-passes="scalarize,function(mem2reg)" -vecz-choices=FullScalarization -S < %s | FileCheck %t
+; RUN: veczc -k mul2 -vecz-passes="scalarize,function(mem2reg)" -vecz-choices=FullScalarization -S < %s | FileCheck %s
 
 ; ModuleID = 'kernel.opencl'
 target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"


### PR DESCRIPTION
# Overview

[NFC] Remove unused %pp-llvm-ver.

# Reason for change

A number of tests were still using %pp-llvm-ver despite not having any LLVM-version-conditional checks.

# Description of change

*Describe the intended behaviour your changes are meant to introduce to the
project and explain how they resolve the problem stated above. Detail any
relevant changes that may affect other users of the project, such as
compilation options, runtime flags, expected inputs and outputs, API entry
points, etc.*

*If you have added new testing, provide details on what tests you have added
and what the purpose of them is.*

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/uxlfoundation/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-20](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
