### PR TITLE
Avoid +v warnings running OpenCL CTS.

### DIFF
--- a/.github/actions/run_opencl_cts/action.yml
+++ b/.github/actions/run_opencl_cts/action.yml
@@ -15,6 +15,9 @@ inputs:
   split_index:
     description: "optional split index so this run can be done with different splits, current only 0 or 1"
     default: ''
+  cityrunner_args:
+    description: "optional extra arguments to pass to cityrunner"
+    default: ''
 
 runs:
   using: "composite"
@@ -77,4 +80,4 @@ runs:
           -s $CTS_CSV_FILE_PATH \
           -i $GITHUB_WORKSPACE/source/cl/scripts/$CTS_FILTER \
           -o override_combined.csv \
-          -e CA_HOST_TARGET_FEATURES=+v
+          ${{ inputs.cityrunner_args }}

--- a/.github/workflows/run_ock_external_tests.yml
+++ b/.github/workflows/run_ock_external_tests.yml
@@ -402,6 +402,7 @@ jobs:
           target: host_riscv64_linux
           llvm_version: ${{ inputs.llvm_version }}
           split_index: ${{ matrix.split_index }}
+          cityrunner_args: "-e CA_HOST_TARGET_FEATURES=+v"
 
   build_dpcpp_native_x86_64:
     needs: [workflow_vars]


### PR DESCRIPTION
# Overview

Avoid +v warnings running OpenCL CTS.

# Reason for change

We were setting CA_HOST_TARGET_FEATURES=+v to enable RVV, but for non-RISC-V it makes no sense and results in warnings.

# Description of change

This commit changes that so that we set it only for RISC-V.

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/uxlfoundation/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-20](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
