### PR TITLE
[LLVM 22] Handle VFS change.

### DIFF
--- a/modules/compiler/source/base/source/module.cpp
+++ b/modules/compiler/source/base/source/module.cpp
@@ -1473,9 +1473,15 @@ std::unique_ptr<llvm::Module> BaseModule::compileOpenCLCToIR(
   const std::string dbg_filename;
 #endif  // CA_ENABLE_DEBUG_SUPPORT
 
+#if LLVM_VERSION_GREATER_EQUAL(22, 0)
+  instance.createVirtualFileSystem();
+  instance.createDiagnostics(
+      new FrontendDiagnosticPrinter(*this, instance.getDiagnosticOpts()));
+#else
   instance.createDiagnostics(
       *llvm::vfs::getRealFileSystem(),
       new FrontendDiagnosticPrinter(*this, instance.getDiagnosticOpts()));
+#endif
 
   // Write a copy of the kernel source out to disk and update the debug info
   // to point to the location as the kernel source file.


### PR DESCRIPTION
# Overview

[LLVM 22] Handle VFS change.

# Reason for change

LLVM 22 no longer takes a VFS in createDiagnostics(), instead taking it from the instance, where it must have previously been initialized by a call to createVirtualFileSystem().

# Description of change

Do so.

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/uxlfoundation/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-20](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
