### PR TITLE
[CI] Fix branch for build-ock-in-tree-llvm.

### DIFF
--- a/.github/workflows/planned_testing_caller.yml
+++ b/.github/workflows/planned_testing_caller.yml
@@ -135,5 +135,7 @@ jobs:
       # although generally simpler to use caches (inputs.use_llvm_github_cache)
       llvm_source: ${{ github.run_id }}
       llvm_current: ${{ inputs.llvm_version }}
+      llvm_current_branch: ${{ inputs.llvm_branch }}
       llvm_previous: ${{ inputs.llvm_version }}
+      llvm_previous_branch: ${{ inputs.llvm_branch }}
       target_list: ${{ inputs.target_list }}

--- a/.github/workflows/run_ock_internal_tests.yml
+++ b/.github/workflows/run_ock_internal_tests.yml
@@ -15,11 +15,19 @@ on:
       llvm_previous:
         required: true
         type: string
-        description: 'previous llvm version to for those jobs tied to previous.'
+        description: 'previous llvm version to use for those jobs tied to previous.'
+      llvm_previous_branch:
+        required: true
+        type: string
+        description: 'previous llvm branch to use for those jobs tied to previous.'
       llvm_current:
         required: true
         type: string
-        description: 'previous llvm version to for those jobs tied to current.'
+        description: 'current llvm version to use for those jobs tied to current.'
+      llvm_current_branch:
+        required: true
+        type: string
+        description: 'current llvm branch to use for those jobs tied to current.'
       github_token:
         type: string
         description: 'gh token for downloading artifacts - only needed if we want llvm from a previous workflow'
@@ -523,7 +531,7 @@ jobs:
       with:
         repository: llvm/llvm-project
         path: llvm-project
-        ref: release/${{ inputs.llvm_current }}.x  # NOTE: using llvm_current instead of hard-wired ref here
+        ref: ${{ inputs.llvm_current_branch }}
         fetch-depth: 1
     - name: build and run
       run: |

--- a/.github/workflows/run_pr_tests_caller.yml
+++ b/.github/workflows/run_pr_tests_caller.yml
@@ -31,4 +31,6 @@ jobs:
       is_pull_request: true
       llvm_source: install
       llvm_previous: 20
+      llvm_previous_branch: release/20.x
       llvm_current: 21
+      llvm_current_branch: release/21.x


### PR DESCRIPTION
# Overview

[CI] Fix branch for build-ock-in-tree-llvm.

# Reason for change

We were using release/$version.x as the branch name, which is fine for versions 20 and 21, but which does not work for version main.

# Description of change

We already have the branch name as an input in planned_testing_caller.yml, so pass this along instead.

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/uxlfoundation/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-20](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
