### PR TITLE
[LLVM 22] Another VFS update.

### DIFF
--- a/modules/compiler/source/base/source/context.cpp
+++ b/modules/compiler/source/base/source/context.cpp
@@ -34,7 +34,11 @@ BaseContext::BaseContext() {
     const char *argv[] = {"ComputeAortaCL"};
     const std::lock_guard<std::mutex> lock(
         compiler::utils::getLLVMGlobalMutex());
-    llvm::cl::ParseCommandLineOptions(1, argv, "", nullptr, "CA_LLVM_OPTIONS");
+    llvm::cl::ParseCommandLineOptions(1, argv, "", /*Errs=*/nullptr,
+#if LLVM_VERSION_GREATER_EQUAL(22, 0)
+                                      /*VFS=*/nullptr,
+#endif
+                                      "CA_LLVM_OPTIONS");
 
     llvm_time_passes = llvm::TimePassesIsEnabled;
 


### PR DESCRIPTION
# Overview

[LLVM 22] Another VFS update.

# Reason for change

In LLVM 22, ParseCommandLineOptions has been updated to take VFS as a parameter.

# Description of change

*Describe the intended behaviour your changes are meant to introduce to the
project and explain how they resolve the problem stated above. Detail any
relevant changes that may affect other users of the project, such as
compilation options, runtime flags, expected inputs and outputs, API entry
points, etc.*

*If you have added new testing, provide details on what tests you have added
and what the purpose of them is.*

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/uxlfoundation/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-20](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
