### PR TITLE
[NFC] Remove leftover RISC-V SYCL bits.

### DIFF
--- a/.github/actions/do_build_dpcpp/action.yml
+++ b/.github/actions/do_build_dpcpp/action.yml
@@ -54,15 +54,6 @@ runs:
 
     # Note: checkout action (above) cleans "path:". Do native artifact download/unpackage after that.
 
-    - name: download pre-built native dpc++ artifact for cross builds
-      if: contains(inputs.download_dpcpp_artefact, inputs.target) != true && contains(inputs.target, 'host_riscv')
-      uses: ./.github/actions/download_artifact
-      with:
-        name: 'dpcpp_host_x86_64_linux'
-        path: llvm/build/x86_64-linux/install
-        needs_tar: 'true'
-        run_id: ${{ github.run_id }}
-
     - name: apply patches
       if: contains(inputs.download_dpcpp_artefact, inputs.target) != true    
       shell: bash
@@ -81,18 +72,11 @@ runs:
       if: contains(inputs.download_dpcpp_artefact, inputs.target) != true
       shell: bash
       run: |
-        CROSS_OPTS=""
-        if [[ "${{inputs.target}}" =~ .*riscv64.* ]] ; then
-          CROSS_OPTS="--cmake-opt=-DCMAKE_TOOLCHAIN_FILE=${{steps.calc_vars.outputs.toolchain}} \
-                      --cmake-opt=-DLLVM_HOST_TRIPLE=${{steps.calc_vars.outputs.arch}}-unknown-linux-gnu \
-                      --cmake-opt=-DLLVM_NATIVE_TOOL_DIR=$GITHUB_WORKSPACE/llvm/build/x86_64-linux/install/bin"
-        fi
         cd llvm
         set -x
         python3 buildbot/configure.py -o build/${{steps.calc_vars.outputs.arch}}-linux \
                 --host-target="X86;AArch64;RISCV" \
                 --llvm-external-projects=lld \
-                $CROSS_OPTS \
                 --cmake-opt=-DLLVM_ENABLE_ZLIB=OFF --cmake-opt=-DLLVM_ENABLE_ZSTD=OFF \
                 --cmake-opt=-DLLVM_CCACHE_BUILD=ON
 
@@ -140,7 +124,7 @@ runs:
         echo Installing configuration files
         cd llvm/build/${{steps.calc_vars.outputs.arch}}-linux/bin
         # Install configuration files to pick up libraries for cross compilation.
-        for arch in x86_64 aarch64 riscv64; do
+        for arch in x86_64 aarch64; do
           echo "
           -L<CFGDIR>/../../../${arch}-linux/install/lib
           " >../install/bin/${arch}-unknown-linux-gnu.cfg;

--- a/.github/actions/do_build_sycl_cts/action.yml
+++ b/.github/actions/do_build_sycl_cts/action.yml
@@ -34,9 +34,8 @@ runs:
         name: opencl_headers_${{inputs.target}}
         path: install_opencl_headers
 
-    - name: download native x86_64 dpc++ artifact (for x86_64 & riscv64 qemu)
-      if: contains(inputs.download_sycl_cts_artefact, inputs.target) != true &&
-          ( contains(inputs.target, 'host_x86_64') || contains(inputs.target, 'host_riscv') )
+    - name: download native x86_64 dpc++ artifact
+      if: contains(inputs.download_sycl_cts_artefact, inputs.target) != true && contains(inputs.target, 'host_x86_64')
       uses: ./.github/actions/download_artifact
       with:
         name: dpcpp_host_x86_64_linux
@@ -50,15 +49,6 @@ runs:
       with:
         name: dpcpp_host_aarch64_linux
         path: dpcpp/aarch64-linux/install
-        needs_tar: 'true'
-        run_id: ${{ github.run_id }}
-
-    - name: download cross riscv64 dpc++ artifact
-      if: contains(inputs.download_sycl_cts_artefact, inputs.target) != true && contains(inputs.target, 'host_riscv')
-      uses: ./.github/actions/download_artifact
-      with:
-        name: dpcpp_host_riscv64_linux
-        path: dpcpp/riscv64-linux/install
         needs_tar: 'true'
         run_id: ${{ github.run_id }}
 

--- a/.github/actions/run_sycl_cts/action.yml
+++ b/.github/actions/run_sycl_cts/action.yml
@@ -54,10 +54,6 @@ runs:
         export ONEAPI_DEVICE_SELECTOR=opencl:0
         export OCL_ICD_FILENAMES=$GITHUB_WORKSPACE/install_ock/lib/libCL.so
         export CTS_CSV_FILE=$GITHUB_WORKSPACE/scripts/testing/sycl_cts/tests.csv
-        PREPEND_PATH=()
-        if [[ "${{inputs.target}}" =~ .*riscv64.* ]] ; then
-          PREPEND_PATH=(--prepend-path '/usr/bin/qemu-riscv64 -L /usr/riscv64-linux-gnu')
-        fi
 
         # Build override file, all is done first, then the target specific. The last file can overwrite previous overrides.
         python3 scripts/testing/create_override_csv.py -d scripts/testing/sycl_cts \
@@ -74,7 +70,6 @@ runs:
         python3 $GITHUB_WORKSPACE/scripts/testing/run_cities.py \
           --color=always \
           --timeout $SYCL_CTS_TIMEOUT \
-          "${PREPEND_PATH[@]}" \
           -p sycl_cts \
           -b SYCL-CTS/bin \
           -L SYCL-CTS/lib \

--- a/.github/workflows/planned_testing_caller_20.yml
+++ b/.github/workflows/planned_testing_caller_20.yml
@@ -58,4 +58,4 @@ jobs:
         uses: ./.github/actions/clean_cache
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          cache_prefixes: "ccache-ccache-dpcpp-build-host_x86_64_linux ccache-ccache-dpcpp-build-host_aarch64_linux ccache-ccache-dpcpp-build-host_riscv64_linux"
+          cache_prefixes: "ccache-ccache-dpcpp-build-host_x86_64_linux ccache-ccache-dpcpp-build-host_aarch64_linux"

--- a/.github/workflows/planned_testing_caller_21.yml
+++ b/.github/workflows/planned_testing_caller_21.yml
@@ -57,4 +57,4 @@ jobs:
         uses: ./.github/actions/clean_cache
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          cache_prefixes: "ccache-ccache-dpcpp-build-host_x86_64_linux ccache-ccache-dpcpp-build-host_aarch64_linux ccache-ccache-dpcpp-build-host_riscv64_linux"
+          cache_prefixes: "ccache-ccache-dpcpp-build-host_x86_64_linux ccache-ccache-dpcpp-build-host_aarch64_linux"

--- a/.github/workflows/planned_testing_caller_main.yml
+++ b/.github/workflows/planned_testing_caller_main.yml
@@ -40,4 +40,4 @@ jobs:
         uses: ./.github/actions/clean_cache
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          cache_prefixes: "ccache-ccache-dpcpp-build-host_x86_64_linux ccache-ccache-dpcpp-build-host_aarch64_linux ccache-ccache-dpcpp-build-host_riscv64_linux"
+          cache_prefixes: "ccache-ccache-dpcpp-build-host_x86_64_linux ccache-ccache-dpcpp-build-host_aarch64_linux"


### PR DESCRIPTION
# Overview

[NFC] Remove leftover RISC-V SYCL bits.

# Reason for change

In !994, I removed RISC-V SYCL testing, but there were a few places that still had logic to handle it.

# Description of change

This commit cleans up those last bits.

# Anything else we should know?

*If there's any other relevant information we should know that may help us in
understanding and verifying your patch, please include it here.*

# Checklist

* Read and follow the project [Code of Conduct](https://github.com/uxlfoundation/oneapi-construction-kit/blob/main/CODE_OF_CONDUCT.md).
* Make sure the project builds successfully with your changes.
* Run relevant testing locally to avoid regressions.
* Run [clang-format-20](https://clang.llvm.org/docs/ClangFormat.html) on all modified code.
